### PR TITLE
translation of plugins-related strings (shortcuts settings dialog)

### DIFF
--- a/TuxGuitar-converter/src/org/herac/tuxguitar/app/tools/custom/converter/TGConverterPlugin.java
+++ b/TuxGuitar-converter/src/org/herac/tuxguitar/app/tools/custom/converter/TGConverterPlugin.java
@@ -1,6 +1,5 @@
 package org.herac.tuxguitar.app.tools.custom.converter;
 
-import org.herac.tuxguitar.app.TuxGuitar;
 import org.herac.tuxguitar.util.TGContext;
 
 
@@ -13,10 +12,6 @@ public class TGConverterPlugin extends org.herac.tuxguitar.app.tools.custom.TGTo
 	}
 	
 	protected String getItemName() {
-		return "File format batch converter";
-	}
-	
-	protected String getItemLabel() {
 		return "batch.converter";
 	}
 	

--- a/TuxGuitar-jack-ui/src/org/herac/tuxguitar/jack/console/JackConsolePlugin.java
+++ b/TuxGuitar-jack-ui/src/org/herac/tuxguitar/jack/console/JackConsolePlugin.java
@@ -13,13 +13,8 @@ public class JackConsolePlugin extends org.herac.tuxguitar.app.tools.custom.TGTo
 	private JackConsoleDialog jackConsoleDialog;
 	
 	protected String getItemName() {
-		return "Jack Console";
-	}
-	
-	protected String getItemLabel() {
 		return "jack.console.title";
 	}
-
 	
 	protected void doAction(TGContext context) {
 		if( this.jackConsoleDialog == null ){

--- a/TuxGuitar-tuner/src/org/herac/tuxguitar/app/tools/custom/tuner/TGTunerPlugin.java
+++ b/TuxGuitar-tuner/src/org/herac/tuxguitar/app/tools/custom/tuner/TGTunerPlugin.java
@@ -35,10 +35,6 @@ public class TGTunerPlugin extends org.herac.tuxguitar.app.tools.custom.TGToolIt
 	}
 
 	protected String getItemName() {
-		return "Guitar Tuner";
-	}
-	
-	protected String getItemLabel() {
 		return "tuner.tuner";
 	}
 

--- a/TuxGuitar/src/org/herac/tuxguitar/app/tools/custom/TGCustomTool.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/tools/custom/TGCustomTool.java
@@ -3,13 +3,11 @@ package org.herac.tuxguitar.app.tools.custom;
 public class TGCustomTool {
 	
 	private String name;
-	private String label;
 	private String action;
 	
-	public TGCustomTool(String name, String action, String label) {
+	public TGCustomTool(String name, String action) {
 		this.name = name;
 		this.action = action;
-		this.label = label;
 	}
 	
 	public String getName() {
@@ -20,8 +18,4 @@ public class TGCustomTool {
 		return this.action;
 	}
 	
-	public String getLabel() {
-		return this.label;
-	}
-
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/tools/custom/TGToolItemPlugin.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/tools/custom/TGToolItemPlugin.java
@@ -14,17 +14,14 @@ public abstract class TGToolItemPlugin implements TGPlugin{
 	private TGCustomToolAction toolAction;
 	
 	protected abstract void doAction(TGContext context);
-	
 	protected abstract String getItemName() throws TGPluginException ;
-	protected abstract String getItemLabel() throws TGPluginException ;
 	
 	public void connect(TGContext context) throws TGPluginException {
 		try {
 			if( this.tool == null && this.toolAction == null ) {
 				String name = getItemName();
-				String label = getItemLabel();
 				
-				this.tool = new TGCustomTool(name, name, label);
+				this.tool = new TGCustomTool(name, name);
 				this.toolAction = new TGCustomToolAction(context, this.tool.getName());
 				
 				TuxGuitar.getInstance().getActionManager().mapAction(this.tool.getAction(), this.toolAction);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/ToolMenuItem.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/ToolMenuItem.java
@@ -47,7 +47,7 @@ public class ToolMenuItem extends TGMenuItem {
 		while(it.hasNext()){
 			TGCustomTool tool = (TGCustomTool)it.next();
 			UIMenuActionItem uiMenuItem = this.settingsMenuItem.getMenu().createActionItem();
-			pluginsMap.put(uiMenuItem, tool.getLabel());
+			pluginsMap.put(uiMenuItem, tool.getName());
 			uiMenuItem.addSelectionListener(this.createActionProcessor(tool.getAction()));
 		}
 		


### PR DESCRIPTION
This modification enables the translation of plugins-related items in Tools/Shortcuts dialog (see the last items in list)

following translation of "Tools" menu item, an additional "label" property was created in class TGCustomTool to avoid interfering with "name" property

But... finally, just changing the value of "name" property was enough This value was already used to populate the shortcuts settings dialog

