### PR TITLE
attempt to solve shortcut issue with non-EN keyboard

### DIFF
--- a/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/event/SWTKeyListenerManager.java
+++ b/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/event/SWTKeyListenerManager.java
@@ -46,13 +46,13 @@ public class SWTKeyListenerManager implements KeyListener {
 
 	public void keyPressed(KeyEvent e) {
 		if(!this.control.isIgnoreEvents()) {
-			this.keyPressedListener.onKeyPressed(new UIKeyEvent(this.control, this.key.getCombination(e.keyCode, e.stateMask)));
+			this.keyPressedListener.onKeyPressed(new UIKeyEvent(this.control, this.key.getCombination(e.keyCode, e.stateMask, e.character)));
 		}
 	}
 
 	public void keyReleased(KeyEvent e) {
 		if(!this.control.isIgnoreEvents()) {
-			this.keyReleasedListener.onKeyReleased(new UIKeyEvent(this.control, this.key.getCombination(e.keyCode, e.stateMask)));
+			this.keyReleasedListener.onKeyReleased(new UIKeyEvent(this.control, this.key.getCombination(e.keyCode, e.stateMask, e.character)));
 		}
 	}
 }


### PR DESCRIPTION
Description of the issue
------
Some users have problems using keyboard shortcuts to insert new notes in the tab. The problem is present with keyboards:
- with no numpad (typ. compact laptop)
- at least AZERTY layout, possibly others

See https://sourceforge.net/p/tuxguitar/discussion/522985/thread/84fa6888dc

On these keyboards, digits are only reachable with a combination of keys, e.g. "shift + &" = "1".
It's still possible to redefine the keyboard shortcuts through dedicated setting dialog manually, but this is not very intuitive. When displayed shortcut is "1", user expects to trigger this shortcut when typing "1", whatever the keys combination used. Especially when only one such combination exists!
Furthermore, non-en keys are not correctly displayed in this dialog. E.g. "shift + à" corresponds to "0", but is displayed "shift + undefined" in JFX variant. So, this shortcut settings dialog is not considered an acceptable solution.

Workaround
----
I tried a fix with a generic behavior for all types of keys, but it's impossible to anticipate all combinations for all keyboards, some of them even leading to non-printable characters.

So the proposed modification is more a *workaround* than a *fix*, anyway it is minor and very localized, so it should be harmless. Basically, when one keyboardReleased event is detected, if the entered text is a digit, then this digit overrides the combination of keys used to enter it, and "shift" modifier is ignored.
Only SWT and JFX variants are handled, not yet Qt (because of issue #20). Anyway the same behavior should be easily implementable in Qt variant, where the additional required event attribute is also available.

Test
-----
I only tested it in my AZERTY configuration, and only in Linux SWT and JFX configurations.
A short regression test on a more "conventional" keyboard layout (qwerty, or any layout where first line enables direct access to digits without "shift" modifier) would be useful I think before eventually merging this pull request

regards,
guiv