### PR TITLE
Fix incorrect vertical spacing for bend effects

### DIFF
--- a/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGBeatImpl.java
+++ b/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGBeatImpl.java
@@ -52,6 +52,7 @@ public class TGBeatImpl extends TGBeat{
 	private boolean vibrato;
 	private boolean trill;
 	private boolean fadeIn;
+	private boolean bend;
 	
 	public TGBeatImpl(TGFactory factory){
 		super(factory);
@@ -195,6 +196,7 @@ public class TGBeatImpl extends TGBeat{
 		this.fadeIn = false;
 		this.vibrato = false;
 		this.trill = false;
+		this.bend = false;
 	}
 	
 	public void updateEffectsSpacing(TGLayout layout,TGNoteEffect effect){
@@ -231,6 +233,9 @@ public class TGBeatImpl extends TGBeat{
 		if(effect.isTrill()){
 			this.trill = true;
 		}
+		if(effect.isBend()) {
+			this.bend = true;
+		}
 	}
 	
 	public float getEffectsSpacing(TGLayout layout){
@@ -266,6 +271,9 @@ public class TGBeatImpl extends TGBeat{
 		}
 		if(this.trill){
 			this.bs.setSize(TGBeatSpacing.POSITION_TRILL_EFFEC,layout.getEffectSpacing());
+		}
+		if(this.bend){
+			this.bs.setSize(TGBeatSpacing.POSITION_BEND_VALUE,layout.getEffectSpacing());
 		}
 		return this.bs.getSize();
 	}

--- a/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGNoteImpl.java
@@ -678,7 +678,7 @@ public class TGNoteImpl extends TGNote {
 		float yLow = 0.0f;
 		float yMiddle = 0.0f;
 		float yHigh = 0.0f;
-		if (bs==null || ts==null) {
+		if (bs==null || ts==null || painter==null) {
 			// this case can occur when function is called not to paint, but just to compute spacing
 			canPaint = false;
 		} else {


### PR DESCRIPTION
Fix for issue #22 (sorry for that!)
Updated effect spacing in TGBeatImpl to consider bend effect, just as all other effects displayed above the tab. Absolutely necessary for Android.
Also added a check in TGNoteImpl to avoid an hypothetical null pointer exception (just a precaution)
Tested on Android, Linux SWT, Linux JFX