### PR TITLE
smooth horizontal scrolling of tracks table when playing

### DIFF
--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
@@ -442,7 +442,7 @@ public class TGTableViewer implements TGEventListener {
 				this.resetTexts = false;
 			}
 			if( this.followScroll ){
-				this.followHorizontalScroll(getEditor().getTablature().getCaret().getMeasure().getNumber());
+				this.followHorizontalScroll(getEditor().getTablature().getCaret().getMeasure().getNumber(), 0);
 				this.followScroll = false;
 			}
 			getControl().redraw();
@@ -458,7 +458,7 @@ public class TGTableViewer implements TGEventListener {
 				int selectedMeasure = measure.getNumber();
 				if(this.selectedTrack != selectedTrack || this.selectedMeasure != selectedMeasure){
 					this.redrawRows(selectedTrack);
-					this.followHorizontalScroll(selectedMeasure);
+					this.followHorizontalScroll(selectedMeasure, 3);
 				}
 				this.selectedTrack = selectedTrack;
 				this.selectedMeasure = selectedMeasure;
@@ -466,18 +466,23 @@ public class TGTableViewer implements TGEventListener {
 		}
 	}
 	
-	private void followHorizontalScroll(int selectedMeasure){
+	private void followHorizontalScroll(int selectedMeasure, int nbMeasuresMargin){
 		int hScrollSelection = this.hScroll.getValue();
 		int hScrollThumb = this.hScroll.getThumb();
 		
 		float measureSize = this.table.getRowHeight();
 		float measurePosition = ((selectedMeasure * measureSize) - measureSize);
 		
+		// reduce margin is window is very small to avoid left <-> right oscillations
+		while (hScrollThumb < 4 * nbMeasuresMargin* measureSize)  {
+			nbMeasuresMargin--;
+		}
+		
 		if((measurePosition - hScrollSelection) < 0 ){
 			this.hScroll.setValue(Math.max(Math.round(measurePosition), 0));
 		}
-		else if((measurePosition + measureSize - hScrollSelection ) > hScrollThumb){
-			this.hScroll.setValue(Math.max(Math.round(measurePosition + measureSize - hScrollThumb), 0));
+		else if((measurePosition + (1+nbMeasuresMargin)*measureSize - hScrollSelection ) > hScrollThumb){
+			this.hScroll.setValue(Math.max(Math.round(measurePosition - nbMeasuresMargin*measureSize), 0));
 		}
 	}
 	


### PR DESCRIPTION
This is a proposal for an evolution of tracks table horizontal scrolling, with the objective to address issue #28 

The idea is:
- when playing, to anticipate horizontal scroll of tracks table by a few measures for a better anticipation
- when scrolling, leave a few measures "behind" for continuity

On a wide screen it will leave 3 measures margin left and right. This margin is reduced if the window is so small there is not enough space for that.
This margin is only applied when playing: when *not* playing, moving with arrows or mouse should have the same behavior as before (scroll measures 1 by 1)