### PR TITLE
enable a single-beat selection

### DIFF
--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Selector.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Selector.java
@@ -42,9 +42,7 @@ public class Selector {
 	    if (initial == null || beat == null) {
 	    	initializeSelection(beat);
 		} else {
-	    	if (beat != initial) {
-	    		active = true;
-			}
+    		active = true;
 			if (initial.getMeasure().getNumber() < beat.getMeasure().getNumber() || initialIsEarlierInTheSameMeasure(beat)) {
 				start = initial;
 				end = beat;


### PR DESCRIPTION
Fix for issue #39

before that, to select 1 single beat with the mouse user needs to select 2 first, then come back to keep only one
consequences:
- re-select after pasting 1 single beat doesn't work
- repeat 1 single beat only works once

note: bug is present in original implementation of "click&drag select" in 2.0beta fork