### PR TITLE
invert orientation of "tied note" symbol in score

### DIFF
--- a/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGNoteImpl.java
@@ -303,6 +303,7 @@ public class TGNoteImpl extends TGNote {
 			//----------ligadura---------------------------------------
 			if (isTiedNote()) {
 				TGNoteImpl noteForTie = getNoteForTie();
+				float yDirection = ((direction == TGBeatGroup.DIRECTION_UP ? 1.0f : -1.0f));
 				float tX = x - (20.0f * layoutScale);
 				float tY = (y1 + (layout.getScoreLineSpacing() / 2f));
 				if (noteForTie != null) {
@@ -318,8 +319,8 @@ public class TGNoteImpl extends TGNote {
 				layout.setTiedStyle(painter, playing);
 				painter.initPath(UIPainter.PATH_FILL);
 				painter.moveTo(tX, tY);
-				painter.cubicTo(tX, tY - tHeight1, tX + tWidth, tY - tHeight1, tX + tWidth, tY);
-				painter.cubicTo(tX + tWidth, tY - tHeight2, tX, tY - tHeight2, tX, tY);
+				painter.cubicTo(tX, tY + yDirection*tHeight1, tX + tWidth, tY + yDirection*tHeight1, tX + tWidth, tY);
+				painter.cubicTo(tX + tWidth, tY + yDirection*tHeight2, tX, tY + yDirection*tHeight2, tX, tY);
 				painter.closePath();
 			}
 			


### PR DESCRIPTION
when tied symbol is under the note
see #42 
![after](https://github.com/helge17/tuxguitar/assets/129443524/81254afd-8e3d-47cb-98f9-f79d4e70b238)
