### PR TITLE
pause Player instead of stop

### DIFF
--- a/TuxGuitar/src/org/herac/tuxguitar/app/transport/TGTransport.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/transport/TGTransport.java
@@ -111,6 +111,7 @@ public class TGTransport {
 				TGErrorManager.getInstance(this.context).handleError(e);
 			}
 		}else{
+			gotoPlayerPosition();
 			player.pause();
 		}
 	}


### PR DESCRIPTION
Fix for issue (or feature request) https://sourceforge.net/p/tuxguitar/feature-requests/101/
When playing and "pause" is clicked, move caret to currently playing position else, "pause" behaves exactly as "stop" (resetting caret to initial play position)
before:

https://github.com/helge17/tuxguitar/assets/129443524/c57b2770-2150-4963-979f-17c88be311c8

after:

https://github.com/helge17/tuxguitar/assets/129443524/8e0c434d-fa20-4cf8-bf33-455af7e5522e


Note: this is consistent with Android app behavior
