### PR TITLE
fix annoying zoom issue with Ctrl+[2-fingers touchpad]

### DIFF
--- a/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/event/JFXZoomListenerManager.java
+++ b/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/event/JFXZoomListenerManager.java
@@ -17,7 +17,7 @@ public class JFXZoomListenerManager extends UIZoomListenerManager implements Eve
 	
 	public void handle(ScrollEvent event) {
 		if(!this.control.isIgnoreEvents()) {
-			if( event.isControlDown() ) {
+			if( event.isControlDown() && event.getDeltaY()!=0) {
 				this.onZoom(new UIZoomEvent(this.control, (event.getDeltaY() > 0 ? 1 : -1)));
 				
 				event.consume();

--- a/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/event/SWTZoomListenerManager.java
+++ b/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/event/SWTZoomListenerManager.java
@@ -19,7 +19,7 @@ public class SWTZoomListenerManager extends UIZoomListenerManager implements Lis
 	
 	public void handleEvent(Event event) {
 		if(!this.control.isIgnoreEvents()) {
-			if((event.stateMask & SWT.CONTROL) == SWT.CONTROL) {
+			if(((event.stateMask & SWT.CONTROL) == SWT.CONTROL) && (event.count!=0)) {
 				event.doit = false;
 				
 				this.onZoom(new UIZoomEvent(this.control, (event.count > 0 ? 1 : -1)));


### PR DESCRIPTION
Working on a compact laptop without mouse, the mouse wheel is emulated by 2-fingers movements on touchpad.
Basically the zoom in/out feature with Ctrl+touchpad was just unusable:
- start from 100% zoom level
- try to zoom-in slowly
- at some point it starts zooming-out so fast it finishes at 10%
Impossible to adjust precisely zoom level, except through many successive clicks in menu

Just understood why: keeping 2 fingers on the touchpad without moving generates mouse wheel events with value==0. It's a bit surprising, zero values make no sense: zero means no movement, so why trigger an event?
Logically, TuxGuitar was only expecting strictly positive or strictly negative values. And 0 was handled like -1
So, just stop moving or move too slowly, and it zooms-out continuously

Fix is trivial: just ignore events with zero values.

Tested on Linux JFX & SWT
Only tested absence of regression on Win10 (JFX & SWT) with a real mouse. My windows machine is too old and touchpad doesn't handle 2-fingers movements. Don't even know if the issue was present in this configuration.