### PR TITLE
Fix for Android issue when deleting note

### DIFF
--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGDeleteNoteOrRestAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGDeleteNoteOrRestAction.java
@@ -23,20 +23,27 @@ public class TGDeleteNoteOrRestAction extends TGActionBase {
 	
 	protected void processAction(TGActionContext context){
 		TGNoteRange noteRange = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
-		if (noteRange.isEmpty()) {
-			TGBeatRange beats = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
-			TGVoice voice = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VOICE);
-			TGString string = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING);
-			for (TGBeat beat : beats.getBeats()) {
-				removeNote(context, beat.getMeasure(), beat, voice, string.getNumber());
-			}
-		} else {
+		TGBeatRange beats = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
+		if (noteRange!=null && !noteRange.isEmpty()) {
 			for (TGNote note : noteRange.getNotes()) {
 				TGVoice voice = note.getVoice();
 				TGBeat beat = voice.getBeat();
 				TGMeasure measure = beat.getMeasure();
 				removeNote(context, measure, beat, voice, note.getString());
 			}
+		}
+		else if (beats!=null && !beats.isEmpty()) {
+			TGVoice voice = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VOICE);
+			TGString string = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING);
+			for (TGBeat beat : beats.getBeats()) {
+				removeNote(context, beat.getMeasure(), beat, voice, string.getNumber());
+			}
+		} else {
+			TGBeat beat = ((TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT));
+			TGVoice voice = ((TGVoice) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VOICE));
+			TGMeasure measure = ((TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE));
+			TGString string = ((TGString) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING));
+			removeNote(context, measure, beat, voice, string.getNumber());
 		}
 	}
 	private void removeNote(TGActionContext context, TGMeasure measure, TGBeat beat, TGVoice voice, int string) {


### PR DESCRIPTION
Fix for issue #62
bug introduced when back-porting from 2.0beta fork the application of TGDeleteNoteOrRestAction action to current selection instead of current beat. This relies on 2 context attributes not defined in Android context (ATTRIBUTE_NOTE_RANGE, ATTRIBUTE_BEAT_RANGE)
Fix: if attributes do not exist or are empty, fallback to original implementation

To tests all branches of the successive if/else if/ conditions, trigger action:
- with nothing selected (to test on PC + Android)
- with a selection containing only notes for 1 voice
- with a selection containing notes for 2 voices