### PR TITLE
display "1" instead of "f" for full tone bend

### DIFF
--- a/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGNoteImpl.java
@@ -661,7 +661,7 @@ public class TGNoteImpl extends TGNote {
 		// fromX, fromY: top-left corner of drawing zone in current measure
 		float scale = layout.getScale();
 		float ARROW_WIDTH = 10.0f * scale;
-		String sAmplitude[] = { "", "1/4", "1/2", "3/4", "f", "1\u00BC", "1\u00BD", "1\u00BE", "2", "2\u00BC", "2\u00BD", "2\u00BE", "3" };
+		String sAmplitude[] = { "", "1/4", "1/2", "3/4", "1", "1\u00BC", "1\u00BD", "1\u00BE", "2", "2\u00BC", "2\u00BD", "2\u00BE", "3" };
 		boolean compactMode = getMeasureImpl().getCompactMode();
 		boolean canPaint = (painter != null);
 		


### PR DESCRIPTION
as requested in #61 
to avoid confusion with "forte"
