### PR TITLE
apply actions to selection: set note duration, clean beat

### DIFF
--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/duration/TGSetDurationAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/duration/TGSetDurationAction.java
@@ -3,12 +3,17 @@ package org.herac.tuxguitar.editor.action.duration;
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
+import org.herac.tuxguitar.song.factory.TGFactory;
+import org.herac.tuxguitar.song.managers.TGMeasureManager;
 import org.herac.tuxguitar.song.managers.TGSongManager;
 import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGDuration;
 import org.herac.tuxguitar.song.models.TGMeasure;
+import org.herac.tuxguitar.song.models.TGNote;
 import org.herac.tuxguitar.song.models.TGVoice;
+import org.herac.tuxguitar.util.TGBeatRange;
 import org.herac.tuxguitar.util.TGContext;
+import org.herac.tuxguitar.util.TGNoteRange;
 
 public class TGSetDurationAction extends TGActionBase {
 	
@@ -18,13 +23,33 @@ public class TGSetDurationAction extends TGActionBase {
 		super(context, NAME);
 	}
 	
-	protected void processAction(TGActionContext context){		
-		TGMeasure measure = ((TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE));
-		TGBeat beat = ((TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT));
-		TGVoice voice = ((TGVoice) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VOICE));
-		TGDuration duration = ((TGDuration) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_DURATION));
+	protected void processAction(TGActionContext context){
+		TGNoteRange noteRange = (TGNoteRange)context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
+		TGBeatRange beats = (TGBeatRange)context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
+		TGDuration duration = (TGDuration)context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_DURATION);
 		
-		TGSongManager tgSongManager = getSongManager(context);
-		tgSongManager.getMeasureManager().changeDuration(measure, beat, duration.clone(tgSongManager.getFactory()), voice.getIndex(), true);
+		TGSongManager songManager = getSongManager(context);
+		TGMeasureManager measureManager = songManager.getMeasureManager();
+		TGFactory factory = songManager.getFactory();
+		
+		if (noteRange!=null && !noteRange.isEmpty()) {
+			for (TGNote note : noteRange.getNotes()) {
+				TGVoice voice = note.getVoice();
+				TGBeat beat = voice.getBeat();
+				TGMeasure measure = beat.getMeasure();
+				measureManager.changeDuration(measure, beat, duration.clone(factory), voice.getIndex(), true);
+			}
+		} else if (beats!=null && !beats.isEmpty()){
+			TGVoice voice = (TGVoice)context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VOICE);
+			for (TGBeat beat : beats.getBeats()) {
+				TGMeasure measure = beat.getMeasure();
+				measureManager.changeDuration(measure, beat, duration.clone(factory), voice.getIndex(), true);
+			}
+		} else {
+			TGMeasure measure = (TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE);
+			TGBeat beat = (TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT);
+			TGVoice voice = (TGVoice) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VOICE);
+			songManager.getMeasureManager().changeDuration(measure, beat, duration.clone(songManager.getFactory()), voice.getIndex(), true);
+		}
 	}
 }

--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGCleanBeatAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGCleanBeatAction.java
@@ -4,6 +4,7 @@ import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
 import org.herac.tuxguitar.song.models.TGBeat;
+import org.herac.tuxguitar.util.TGBeatRange;
 import org.herac.tuxguitar.util.TGContext;
 
 public class TGCleanBeatAction extends TGActionBase {
@@ -15,9 +16,17 @@ public class TGCleanBeatAction extends TGActionBase {
 	}
 	
 	protected void processAction(TGActionContext context){
-		TGBeat beat = ((TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT));
-		if( beat != null ){
-			getSongManager(context).getMeasureManager().cleanBeat(beat);
+		TGBeatRange beats = (TGBeatRange) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
+		
+		if (beats!=null && !beats.isEmpty()){
+			for (TGBeat beat : beats.getBeats()) {
+				getSongManager(context).getMeasureManager().cleanBeat(beat);
+			}
+		} else {
+			TGBeat beat = (TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT);
+			if( beat != null ){
+				getSongManager(context).getMeasureManager().cleanBeat(beat);
+			}
 		}
 	}
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
@@ -483,7 +483,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		this.map(TGChangeVibratoNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 		
 		//duration actions
-		this.map(TGSetDurationAction.NAME, LOCKABLE | DISABLE_ON_PLAY, new TGUpdateModifiedDurationController(), UNDOABLE_MEASURE_GENERIC);
+		this.map(TGSetDurationAction.NAME, LOCKABLE | DISABLE_ON_PLAY, new TGUpdateModifiedDurationController(), UNDOABLE_BEAT_RANGE_GENERIC);
 		this.map(TGSetWholeDurationAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT);
 		this.map(TGSetHalfDurationAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT);
 		this.map(TGSetQuarterDurationAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateModifiedDurationController.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateModifiedDurationController.java
@@ -7,7 +7,7 @@ import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.song.models.TGMeasureHeader;
 import org.herac.tuxguitar.util.TGContext;
 
-public class TGUpdateModifiedDurationController extends TGUpdateItemsController {
+public class TGUpdateModifiedDurationController extends TGUpdateBeatRangeController {
 
 	public TGUpdateModifiedDurationController() {
 		super();


### PR DESCRIPTION
essentially backported from 2.0beta fork, but adapted to keep compatibility with Android version:
if the NOTE_RANGE and/or BEAT_RANGE attributes are not defined in action context or are empty,
then keep original implementation
Tested on Linux & Win10, JFX and SWT. This time I also tested the absence of regression in Android config (see #62)
