### PR TITLE
apply actions to selection: increment/decrement semitone

### DIFF
--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGDecrementNoteSemitoneAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGDecrementNoteSemitoneAction.java
@@ -1,32 +1,21 @@
 package org.herac.tuxguitar.editor.action.note;
 
-import org.herac.tuxguitar.action.TGActionContext;
-import org.herac.tuxguitar.document.TGDocumentContextAttributes;
-import org.herac.tuxguitar.editor.action.TGActionBase;
-import org.herac.tuxguitar.song.managers.TGSongManager;
+import org.herac.tuxguitar.song.managers.TGMeasureManager;
 import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGMeasure;
 import org.herac.tuxguitar.song.models.TGNote;
 import org.herac.tuxguitar.util.TGContext;
 
-public class TGDecrementNoteSemitoneAction extends TGActionBase {
-	
+public class TGDecrementNoteSemitoneAction extends TGTransposeNoteSemitoneAction {
 	public static final String NAME = "action.note.general.decrement-semitone";
-	
+
 	public TGDecrementNoteSemitoneAction(TGContext context) {
 		super(context, NAME);
 	}
-	
-	protected void processAction(TGActionContext context){
-		TGNote note = ((TGNote) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE));
-		if( note != null ){
-			TGBeat beat = ((TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT));
-			TGMeasure measure = ((TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE));
-			TGSongManager songManager = getSongManager(context);
-			
-			if( songManager.getMeasureManager().moveSemitoneDown(measure, beat.getStart(), note.getString()) ){
-				context.setAttribute(TGChangeNoteAction.ATTRIBUTE_SUCCESS, Boolean.TRUE);
-			}
-		}
+
+	@Override
+	protected boolean transposeSemiTone(TGMeasureManager measureManager, TGMeasure measure, TGBeat beat, TGNote note) {
+		return measureManager.moveSemitoneDown(measure, beat.getStart(), note.getString());
 	}
+	
 }

--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGIncrementNoteSemitoneAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGIncrementNoteSemitoneAction.java
@@ -1,32 +1,22 @@
 package org.herac.tuxguitar.editor.action.note;
 
-import org.herac.tuxguitar.action.TGActionContext;
-import org.herac.tuxguitar.document.TGDocumentContextAttributes;
-import org.herac.tuxguitar.editor.action.TGActionBase;
-import org.herac.tuxguitar.song.managers.TGSongManager;
+import org.herac.tuxguitar.song.managers.TGMeasureManager;
 import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGMeasure;
 import org.herac.tuxguitar.song.models.TGNote;
 import org.herac.tuxguitar.util.TGContext;
 
-public class TGIncrementNoteSemitoneAction extends TGActionBase {
+public class TGIncrementNoteSemitoneAction extends TGTransposeNoteSemitoneAction {
 	
 	public static final String NAME = "action.note.general.increment-semitone";
 	
 	public TGIncrementNoteSemitoneAction(TGContext context) {
 		super(context, NAME);
 	}
-	
-	protected void processAction(TGActionContext context){
-		TGNote note = ((TGNote) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE));		
-		if( note != null ){
-			TGBeat beat = ((TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT));
-			TGMeasure measure = ((TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE));
-			TGSongManager songManager = getSongManager(context);
-			
-			if( songManager.getMeasureManager().moveSemitoneUp(measure, beat.getStart(), note.getString())){
-				context.setAttribute(TGChangeNoteAction.ATTRIBUTE_SUCCESS, Boolean.TRUE);
-			}
-		}
+	@Override
+	protected boolean transposeSemiTone(TGMeasureManager measureManager, TGMeasure measure, TGBeat beat, TGNote note) {
+		return measureManager.moveSemitoneUp(measure, beat.getStart(), note.getString());
 	}
+
 }
+

--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGTransposeNoteSemitoneAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGTransposeNoteSemitoneAction.java
@@ -1,0 +1,60 @@
+package org.herac.tuxguitar.editor.action.note;
+
+import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
+import org.herac.tuxguitar.editor.action.TGActionBase;
+import org.herac.tuxguitar.song.managers.TGMeasureManager;
+import org.herac.tuxguitar.song.managers.TGSongManager;
+import org.herac.tuxguitar.song.models.TGBeat;
+import org.herac.tuxguitar.song.models.TGMeasure;
+import org.herac.tuxguitar.song.models.TGNote;
+import org.herac.tuxguitar.util.TGContext;
+import org.herac.tuxguitar.util.TGNoteRange;
+
+public abstract class TGTransposeNoteSemitoneAction extends TGActionBase {
+
+	public TGTransposeNoteSemitoneAction(TGContext context, String name) {
+		super(context, name);
+	}
+
+	protected abstract boolean transposeSemiTone(TGMeasureManager measureManager, TGMeasure measure, TGBeat beat, TGNote note);
+
+	protected void processAction(TGActionContext context){
+		boolean success = false;
+		TGNoteRange noteRange = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
+		if (noteRange!=null && !noteRange.isEmpty()) {
+			TGSongManager songManager = getSongManager(context);
+			// count number of beats: if 1 single beat, set TGChangeNoteAction.ATTRIBUTE_SUCCESS to True, to play sound
+			boolean moreThanOneBeat = false;
+			TGBeat refBeat = null;
+			for (TGNote note : noteRange.getNotes()) {
+				TGBeat beat = note.getVoice().getBeat();
+				TGMeasure measure = beat.getMeasure();
+				moreThanOneBeat |= (refBeat!=null && beat!=refBeat);
+				refBeat = beat;
+				success |= transposeSemiTone(songManager.getMeasureManager(), measure, beat, note);
+			}
+			if (success) {
+				context.setAttribute(ATTRIBUTE_SUCCESS, Boolean.TRUE);
+				if (moreThanOneBeat) {
+					context.setAttribute(TGChangeNoteAction.ATTRIBUTE_SUCCESS, Boolean.FALSE);
+				} else {
+					context.setAttribute(TGChangeNoteAction.ATTRIBUTE_SUCCESS, Boolean.TRUE);
+				}
+			}
+		}
+		else {
+			TGNote note = ((TGNote) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE));
+			if( note != null ){
+				TGBeat beat = ((TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT));
+				TGMeasure measure = ((TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE));
+				TGSongManager songManager = getSongManager(context);
+				
+				if (transposeSemiTone(songManager.getMeasureManager(), measure, beat, note)) {
+					context.setAttribute(TGChangeNoteAction.ATTRIBUTE_SUCCESS, Boolean.TRUE);
+				}
+			}
+		}
+	}
+
+}

--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/undo/impl/custom/TGUndoableNoteRangeController.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/undo/impl/custom/TGUndoableNoteRangeController.java
@@ -1,0 +1,38 @@
+package org.herac.tuxguitar.editor.undo.impl.custom;
+
+import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
+import org.herac.tuxguitar.editor.undo.TGUndoableActionController;
+import org.herac.tuxguitar.editor.undo.TGUndoableEdit;
+import org.herac.tuxguitar.editor.undo.impl.TGUndoableEditComposite;
+import org.herac.tuxguitar.editor.undo.impl.measure.TGUndoableMeasureGeneric;
+import org.herac.tuxguitar.song.models.TGMeasure;
+import org.herac.tuxguitar.util.TGContext;
+import org.herac.tuxguitar.util.TGNoteRange;
+
+/**
+ * Created by tubus on 25.01.17.
+ */
+public class TGUndoableNoteRangeController implements TGUndoableActionController {
+
+	public TGUndoableEdit startUndoable(TGContext context, TGActionContext actionContext) {
+		TGNoteRange noteRange = actionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
+		TGUndoableEditComposite editComposite = new TGUndoableEditComposite();
+		for (TGMeasure editedMeasure : noteRange.getMeasures()) {
+			editComposite.addEdit(TGUndoableMeasureGeneric.startUndo(context, editedMeasure));
+		}
+		return editComposite;
+	}
+
+	public TGUndoableEdit endUndoable(TGContext context, TGActionContext actionContext, TGUndoableEdit undoableEdit) {
+		TGNoteRange noteRange = actionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
+		TGUndoableEditComposite undoableEditComposite = (TGUndoableEditComposite) undoableEdit;
+		int i = 0;
+		for (TGMeasure editedMeasure : noteRange.getMeasures()) {
+			TGUndoableMeasureGeneric measureEdit = (TGUndoableMeasureGeneric) undoableEditComposite.getEdits().get(i);
+			measureEdit.endUndo(editedMeasure);
+			i++;
+		}
+		return undoableEdit;
+	}
+}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
@@ -148,6 +148,7 @@ import org.herac.tuxguitar.app.action.listener.cache.controller.TGUpdateModified
 import org.herac.tuxguitar.app.action.listener.cache.controller.TGUpdateModifiedMarkerController;
 import org.herac.tuxguitar.app.action.listener.cache.controller.TGUpdateModifiedNoteController;
 import org.herac.tuxguitar.app.action.listener.cache.controller.TGUpdateModifiedVelocityController;
+import org.herac.tuxguitar.app.action.listener.cache.controller.TGUpdateNoteRangeController;
 import org.herac.tuxguitar.app.action.listener.cache.controller.TGUpdatePlayerTracksController;
 import org.herac.tuxguitar.app.action.listener.cache.controller.TGUpdateRemovedMeasureController;
 import org.herac.tuxguitar.app.action.listener.cache.controller.TGUpdateRemovedTrackController;
@@ -276,6 +277,7 @@ import org.herac.tuxguitar.editor.undo.impl.custom.TGUndoableBeatRangeController
 import org.herac.tuxguitar.editor.undo.impl.custom.TGUndoableClefController;
 import org.herac.tuxguitar.editor.undo.impl.custom.TGUndoableCloseRepeatController;
 import org.herac.tuxguitar.editor.undo.impl.custom.TGUndoableKeySignatureController;
+import org.herac.tuxguitar.editor.undo.impl.custom.TGUndoableNoteRangeController;
 import org.herac.tuxguitar.editor.undo.impl.custom.TGUndoableOpenRepeatController;
 import org.herac.tuxguitar.editor.undo.impl.custom.TGUndoableSongInfoController;
 import org.herac.tuxguitar.editor.undo.impl.custom.TGUndoableTempoController;
@@ -311,12 +313,14 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 	private static final TGUpdateController UPDATE_SONG_LOADED_CTL = new TGUpdateLoadedSongController();
 	private static final TGUpdateController UPDATE_SONG_SAVED_CTL = new TGUpdateSavedSongController();
 	private static final TGUpdateController UPDATE_CHANNELS_CTL = new TGUpdateChannelsController();
+	private static final TGUpdateController UPDATE_NOTE_RANGE_CTL = new TGUpdateNoteRangeController();
 	private static final TGUpdateController UPDATE_BEAT_RANGE_CTL = new TGUpdateBeatRangeController();
 	
 	private static final TGUndoableActionController UNDOABLE_SONG_GENERIC = new TGUndoableSongGenericController();
 	private static final TGUndoableActionController UNDOABLE_MEASURE_GENERIC = new TGUndoableMeasureGenericController();
 	private static final TGUndoableActionController UNDOABLE_TRACK_GENERIC = new TGUndoableTrackGenericController();
 	private static final TGUndoableActionController UNDOABLE_CHANNEL_GENERIC = new TGUndoableChannelGenericController();
+	private static final TGUndoableActionController UNDOABLE_NOTE_RANGE = new TGUndoableNoteRangeController();
 	private static final TGUndoableActionController UNDOABLE_BEAT_RANGE_GENERIC = new TGUndoableBeatRangeController();
 	
 	public TGActionConfigMap() {
@@ -437,10 +441,10 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		this.map(TGChangeTiedNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 		this.map(TGChangeVelocityAction.NAME, LOCKABLE | DISABLE_ON_PLAY, new TGUpdateModifiedVelocityController(), UNDOABLE_MEASURE_GENERIC);
 		this.map(TGCleanBeatAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_BEAT_RANGE_CTL, UNDOABLE_BEAT_RANGE_GENERIC);
-		this.map(TGDecrementNoteSemitoneAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, new TGUpdateModifiedNoteController(), UNDOABLE_MEASURE_GENERIC);
+		this.map(TGDecrementNoteSemitoneAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_NOTE_RANGE_CTL, UNDOABLE_NOTE_RANGE);
 		this.map(TGDeleteNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 		this.map(TGDeleteNoteOrRestAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_BEAT_RANGE_CTL, UNDOABLE_BEAT_RANGE_GENERIC);
-		this.map(TGIncrementNoteSemitoneAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, new TGUpdateModifiedNoteController(), UNDOABLE_MEASURE_GENERIC);
+		this.map(TGIncrementNoteSemitoneAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_NOTE_RANGE_CTL, UNDOABLE_NOTE_RANGE);
 		this.map(TGInsertRestBeatAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 		this.map(TGMoveBeatsAction.NAME, LOCKABLE | DISABLE_ON_PLAY, UPDATE_SONG_CTL, UNDOABLE_TRACK_GENERIC);
 		this.map(TGMoveBeatsLeftAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateNoteRangeController.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateNoteRangeController.java
@@ -1,0 +1,31 @@
+package org.herac.tuxguitar.app.action.listener.cache.controller;
+
+import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.app.TuxGuitar;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
+import org.herac.tuxguitar.editor.action.note.TGChangeNoteAction;
+import org.herac.tuxguitar.song.models.TGBeat;
+import org.herac.tuxguitar.song.models.TGMeasure;
+import org.herac.tuxguitar.util.TGContext;
+import org.herac.tuxguitar.util.TGNoteRange;
+
+public class TGUpdateNoteRangeController extends TGUpdateItemsController {
+
+	@Override
+	public void update(TGContext context, TGActionContext actionContext) {
+		TGNoteRange noteRange = actionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
+		
+		if( Boolean.TRUE.equals( actionContext.getAttribute(TGChangeNoteAction.ATTRIBUTE_SUCCESS)) ) {
+			TGBeat beat = (TGBeat) actionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT);
+			TuxGuitar tuxguitar = TuxGuitar.getInstance();
+			tuxguitar.playBeat(beat);
+		}
+		if (noteRange!=null && !noteRange.isEmpty()) {
+			for (TGMeasure measure : noteRange.getMeasures()) {
+				this.findUpdateBuffer(context, actionContext).requestUpdateMeasure(measure.getNumber());
+			}
+		}
+		super.update(context, actionContext);
+	}
+	
+}


### PR DESCRIPTION
play sound if success and one single beat selected

tested on Linux & Win10, SWT & JFX:
- no click&drag selection: note under caret is transposed, beat is played
- after click&drag selection: everything selected is transposed, sound is played only if 1 single beat is selected

Also tested undo/redo
tested absence of regression on Android