### PR TITLE
update caret internal properties after shifting note 1 string

### DIFF
--- a/TuxGuitar-android/src/org/herac/tuxguitar/android/action/listener/cache/controller/TGUpdateShiftedNoteController.java
+++ b/TuxGuitar-android/src/org/herac/tuxguitar/android/action/listener/cache/controller/TGUpdateShiftedNoteController.java
@@ -29,6 +29,7 @@ public class TGUpdateShiftedNoteController extends TGUpdateItemsController {
 				public void run() {
 					TGCaret tgCaret = TGSongViewController.getInstance(context).getCaret();
 					tgCaret.setStringNumber(tgString.getNumber());
+					tgCaret.update();
 				}
 			});
 		}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateShiftedNoteController.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateShiftedNoteController.java
@@ -29,6 +29,7 @@ public class TGUpdateShiftedNoteController extends TGUpdateItemsController {
 				public void run() {
 					Caret caret = TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret();
 					caret.setStringNumber(tgString.getNumber());
+					caret.update();
 				}
 			});
 		}


### PR DESCRIPTION
bug fix (#70): after shifting 1 note up or down, menuItems and toolBar icons "enabled" properties were not updated
e.g., after shifting 1 note up or down 1 string it was impossible to associate an effect to this note, or to shift it 1 string again
Fix in both PC and Android environments