### PR TITLE
apply "change velocity" action to selection

### DIFF
--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGChangeVelocityAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGChangeVelocityAction.java
@@ -3,9 +3,12 @@ package org.herac.tuxguitar.editor.action.note;
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
+import org.herac.tuxguitar.song.managers.TGMeasureManager;
 import org.herac.tuxguitar.song.models.TGMeasure;
+import org.herac.tuxguitar.song.models.TGNote;
 import org.herac.tuxguitar.song.models.TGString;
 import org.herac.tuxguitar.util.TGContext;
+import org.herac.tuxguitar.util.TGNoteRange;
 
 public class TGChangeVelocityAction extends TGActionBase {
 	
@@ -16,14 +19,27 @@ public class TGChangeVelocityAction extends TGActionBase {
 	}
 	
 	protected void processAction(TGActionContext context){
-		TGMeasure measure = (TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE);
-		TGString string = (TGString) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING);
-		Long position = (Long) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_POSITION);
 		Integer velocity = (Integer) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VELOCITY);
-		if( velocity != null && position != null && string != null && measure != null ){
-			getSongManager(context).getMeasureManager().changeVelocity(velocity, measure, position, string.getNumber());
+		
+		if (velocity != null) {
+			TGMeasureManager measureManager = getSongManager(context).getMeasureManager(); 
+			TGNoteRange noteRange = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
 			
-			context.setAttribute(ATTRIBUTE_SUCCESS, Boolean.TRUE);
+			if ((noteRange != null) && !noteRange.isEmpty()) {
+				for (TGNote note : noteRange.getNotes()) {
+					measureManager.changeVelocity(velocity, note);
+				}
+				context.setAttribute(ATTRIBUTE_SUCCESS, Boolean.TRUE);
+			}
+			else {
+				TGMeasure measure = (TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE);
+				TGString string = (TGString) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING);
+				Long position = (Long) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_POSITION);
+				if( velocity != null && position != null && string != null && measure != null ){
+					measureManager.changeVelocity(velocity, measure, position, string.getNumber());
+					context.setAttribute(ATTRIBUTE_SUCCESS, Boolean.TRUE);
+				}
+			}
 		}
 	}
 }

--- a/TuxGuitar-lib/src/org/herac/tuxguitar/song/managers/TGMeasureManager.java
+++ b/TuxGuitar-lib/src/org/herac/tuxguitar/song/managers/TGMeasureManager.java
@@ -1314,7 +1314,9 @@ public class TGMeasureManager {
 	 * Cambia el Velocity
 	 */
 	public void changeVelocity(int velocity,TGMeasure measure,long start,int string){
-		TGNote note = getNote(measure,start,string);
+		changeVelocity(velocity, getNote(measure,start,string));
+	}
+	public void changeVelocity(int velocity, TGNote note){
 		if(note != null){
 			note.setVelocity(velocity);
 		}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
@@ -439,7 +439,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		//beat actions
 		this.map(TGChangeNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY, new TGUpdateModifiedNoteController(), UNDOABLE_MEASURE_GENERIC);
 		this.map(TGChangeTiedNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
-		this.map(TGChangeVelocityAction.NAME, LOCKABLE | DISABLE_ON_PLAY, new TGUpdateModifiedVelocityController(), UNDOABLE_MEASURE_GENERIC);
+		this.map(TGChangeVelocityAction.NAME, LOCKABLE | DISABLE_ON_PLAY, new TGUpdateModifiedVelocityController(), UNDOABLE_NOTE_RANGE);
 		this.map(TGCleanBeatAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_BEAT_RANGE_CTL, UNDOABLE_BEAT_RANGE_GENERIC);
 		this.map(TGDecrementNoteSemitoneAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_NOTE_RANGE_CTL, UNDOABLE_NOTE_RANGE);
 		this.map(TGDeleteNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateModifiedVelocityController.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateModifiedVelocityController.java
@@ -8,7 +8,7 @@ import org.herac.tuxguitar.editor.action.note.TGChangeVelocityAction;
 import org.herac.tuxguitar.song.models.TGMeasureHeader;
 import org.herac.tuxguitar.util.TGContext;
 
-public class TGUpdateModifiedVelocityController extends TGUpdateItemsController {
+public class TGUpdateModifiedVelocityController extends TGUpdateNoteRangeController {
 
 	public TGUpdateModifiedVelocityController() {
 		super();
@@ -32,7 +32,6 @@ public class TGUpdateModifiedVelocityController extends TGUpdateItemsController 
 			});
 		}
 		
-		// Call super update.
 		super.update(context, actionContext);
 	}
 }


### PR DESCRIPTION
continuing to apply actions to whole selection, this one is simple.
Inspired by 2.0beta fork, with following improvements:
- maintain compatibility with Android
- undo also works properly if selection covers several measures