### PR TITLE
invert Decrement/Increment Duration Actions

### DIFF
--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/duration/TGDecrementDurationAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/duration/TGDecrementDurationAction.java
@@ -18,8 +18,8 @@ public class TGDecrementDurationAction extends TGActionBase {
 	protected void processAction(TGActionContext context) {
 		TGDuration duration = ((TGDuration) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_DURATION));
 		
-		if( duration.getValue() > TGDuration.WHOLE ){
-			duration.setValue(duration.getValue() / 2);
+		if( duration.getValue() < TGDuration.SIXTY_FOURTH ){
+			duration.setValue(duration.getValue() * 2);
 			duration.setDotted(false);
 			duration.setDoubleDotted(false);
 			

--- a/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/duration/TGIncrementDurationAction.java
+++ b/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/duration/TGIncrementDurationAction.java
@@ -18,8 +18,8 @@ public class TGIncrementDurationAction extends TGActionBase {
 	protected void processAction(TGActionContext context) {
 		TGDuration duration = ((TGDuration) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_DURATION));
 		
-		if( duration.getValue() < TGDuration.SIXTY_FOURTH ){
-			duration.setValue(duration.getValue() * 2);
+		if( duration.getValue() > TGDuration.WHOLE ){
+			duration.setValue(duration.getValue() / 2);
 			duration.setDotted(false);
 			duration.setDoubleDotted(false);
 			

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/fretboard/TGFretBoard.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/fretboard/TGFretBoard.java
@@ -134,16 +134,16 @@ public class TGFretBoard {
 		this.createToolSeparator(uiFactory, ++column);
 		
 		// duration
-		this.decrement = uiFactory.createButton(this.toolComposite);
-		this.decrement.addSelectionListener(new TGActionProcessorListener(this.context, TGDecrementDurationAction.NAME));
-		this.createToolItemLayout(decrement, ++column);
+		this.increment = uiFactory.createButton(this.toolComposite);
+		this.increment.addSelectionListener(new TGActionProcessorListener(this.context, TGIncrementDurationAction.NAME));
+		this.createToolItemLayout(increment, ++column);
 		
 		this.durationLabel = uiFactory.createImageView(this.toolComposite);
 		this.createToolItemLayout(this.durationLabel, ++column);
 		
-		this.increment = uiFactory.createButton(this.toolComposite);
-		this.increment.addSelectionListener(new TGActionProcessorListener(this.context, TGIncrementDurationAction.NAME));
-		this.createToolItemLayout(increment, ++column);
+		this.decrement = uiFactory.createButton(this.toolComposite);
+		this.decrement.addSelectionListener(new TGActionProcessorListener(this.context, TGDecrementDurationAction.NAME));
+		this.createToolItemLayout(decrement, ++column);
 		
 		// separator
 		this.createToolSeparator(uiFactory, ++column);
@@ -665,8 +665,8 @@ public class TGFretBoard {
 	public void loadIcons(){
 		this.goLeft.setImage(TuxGuitar.getInstance().getIconManager().getArrowLeft());
 		this.goRight.setImage(TuxGuitar.getInstance().getIconManager().getArrowRight());
-		this.decrement.setImage(TuxGuitar.getInstance().getIconManager().getArrowUp());
-		this.increment.setImage(TuxGuitar.getInstance().getIconManager().getArrowDown());
+		this.decrement.setImage(TuxGuitar.getInstance().getIconManager().getArrowDown());
+		this.increment.setImage(TuxGuitar.getInstance().getIconManager().getArrowUp());
 		this.settings.setImage(TuxGuitar.getInstance().getIconManager().getSettings());
 		this.loadDurationImage(true);
 		this.control.layout();

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/matrix/TGMatrixEditor.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/matrix/TGMatrixEditor.java
@@ -193,16 +193,16 @@ public class TGMatrixEditor implements TGEventListener {
 		this.createToolSeparator(uiFactory, ++column);
 		
 		// duration
-		this.decrement = uiFactory.createButton(this.toolbar);
-		this.decrement.addSelectionListener(new TGActionProcessorListener(this.context, TGDecrementDurationAction.NAME));
-		this.createToolItemLayout(this.decrement, ++column);
+		this.increment = uiFactory.createButton(this.toolbar);
+		this.increment.addSelectionListener(new TGActionProcessorListener(this.context, TGIncrementDurationAction.NAME));
+		this.createToolItemLayout(this.increment, ++column);
 		
 		this.durationLabel = uiFactory.createImageView(this.toolbar);
 		this.createToolItemLayout(this.durationLabel, ++column);
 		
-		this.increment = uiFactory.createButton(this.toolbar);
-		this.increment.addSelectionListener(new TGActionProcessorListener(this.context, TGIncrementDurationAction.NAME));
-		this.createToolItemLayout(this.increment, ++column);
+		this.decrement = uiFactory.createButton(this.toolbar);
+		this.decrement.addSelectionListener(new TGActionProcessorListener(this.context, TGDecrementDurationAction.NAME));
+		this.createToolItemLayout(this.decrement, ++column);
 		
 		// separator
 		this.createToolSeparator(uiFactory, ++column);
@@ -755,8 +755,8 @@ public class TGMatrixEditor implements TGEventListener {
 			this.dialog.setImage(TuxGuitar.getInstance().getIconManager().getAppIcon());
 			this.goLeft.setImage(TuxGuitar.getInstance().getIconManager().getArrowLeft());
 			this.goRight.setImage(TuxGuitar.getInstance().getIconManager().getArrowRight());
-			this.decrement.setImage(TuxGuitar.getInstance().getIconManager().getArrowUp());
-			this.increment.setImage(TuxGuitar.getInstance().getIconManager().getArrowDown());
+			this.decrement.setImage(TuxGuitar.getInstance().getIconManager().getArrowDown());
+			this.increment.setImage(TuxGuitar.getInstance().getIconManager().getArrowUp());
 			this.settings.setImage(TuxGuitar.getInstance().getIconManager().getSettings());
 			this.loadDurationImage(true);
 			this.layout();

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/piano/TGPiano.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/piano/TGPiano.java
@@ -122,16 +122,16 @@ public class TGPiano {
 		this.createToolSeparator(uiFactory, ++column);
 		
 		// duration
-		this.decrement = uiFactory.createButton(this.toolComposite);
-		this.decrement.addSelectionListener(new TGActionProcessorListener(this.context, TGDecrementDurationAction.NAME));
-		this.createToolItemLayout(this.decrement, ++column);
+		this.increment = uiFactory.createButton(this.toolComposite);
+		this.increment.addSelectionListener(new TGActionProcessorListener(this.context, TGIncrementDurationAction.NAME));
+		this.createToolItemLayout(this.increment, ++column);
 		
 		this.durationLabel = uiFactory.createImageView(this.toolComposite);
 		this.createToolItemLayout(this.durationLabel, ++column);
 		
-		this.increment = uiFactory.createButton(this.toolComposite);
-		this.increment.addSelectionListener(new TGActionProcessorListener(this.context, TGIncrementDurationAction.NAME));
-		this.createToolItemLayout(this.increment, ++column);
+		this.decrement = uiFactory.createButton(this.toolComposite);
+		this.decrement.addSelectionListener(new TGActionProcessorListener(this.context, TGDecrementDurationAction.NAME));
+		this.createToolItemLayout(this.decrement, ++column);
 		
 		// separator
 		this.createToolSeparator(uiFactory, ++column);
@@ -560,8 +560,8 @@ public class TGPiano {
 	public void loadIcons(){
 		this.goLeft.setImage(TuxGuitar.getInstance().getIconManager().getArrowLeft());
 		this.goRight.setImage(TuxGuitar.getInstance().getIconManager().getArrowRight());
-		this.decrement.setImage(TuxGuitar.getInstance().getIconManager().getArrowUp());
-		this.increment.setImage(TuxGuitar.getInstance().getIconManager().getArrowDown());
+		this.decrement.setImage(TuxGuitar.getInstance().getIconManager().getArrowDown());
+		this.increment.setImage(TuxGuitar.getInstance().getIconManager().getArrowUp());
 		this.settings.setImage(TuxGuitar.getInstance().getIconManager().getSettings());
 		this.loadDurationImage(true);
 		this.control.layout();


### PR DESCRIPTION
see #73 

to be consistent with "+" and "-" default shortcuts: "increment duration" shall increment the duration from the user's point of view: less notes within 1 single measure

with this modification, Androip app behavior becomes consistent: arrow up increases note duration

also invert icons in FretBoard, MatrixEditor and Piano to keep actual behavior: arrow up increases note duration