### PR TITLE
check trackTable is initialized before drawing markers

### DIFF
--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTable.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTable.java
@@ -56,6 +56,10 @@ public class TGTable {
 		this.createColumnLayout();
 	}
 	
+	public boolean rowsAreInitialized() {
+		return ((TGTableBodyLayout) this.rowControl.getLayout()).isInitialized();
+	}
+	
 	public UIPanel getControl(){
 		return this.table;
 	}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableBodyLayout.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableBodyLayout.java
@@ -9,6 +9,7 @@ import org.herac.tuxguitar.ui.widget.UILayoutContainer;
 public class TGTableBodyLayout extends UITableLayout {
 	
 	private float rowHeight;
+	private boolean initialized;
 	
 	public TGTableBodyLayout() {
 		super(0f);
@@ -22,6 +23,7 @@ public class TGTableBodyLayout extends UITableLayout {
 		List<UIControl> controls = container.getChildren();
 		for(UIControl control : controls) {
 			this.rowHeight = Math.max(this.rowHeight, control.getPackedSize().getHeight());
+			initialized = true;
 		}
 		
 		int row = 0;
@@ -36,5 +38,9 @@ public class TGTableBodyLayout extends UITableLayout {
 	
 	public float getRowHeight() {
 		return this.rowHeight;
+	}
+	
+	public boolean isInitialized() {
+		return initialized;
 	}
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableHeaderMeasures.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableHeaderMeasures.java
@@ -81,12 +81,18 @@ public class TGTableHeaderMeasures implements TGTableHeader, TGBufferedPainterHa
 	}
 
 	public void paintControl(UIPainter painter) {
+		// table might not be initialized yet
+		if (!this.table.rowsAreInitialized()) {
+			return;
+		}
+
 		int scrollX = this.table.getViewer().getHScrollSelection();
 		float cellSize = this.table.getRowHeight();
 		float width = this.canvas.getBounds().getWidth();
 		Tablature tablature = this.table.getViewer().getEditor().getTablature();
 		TGSong song = tablature.getSong();
-
+		float markerMargin = 1.0f;
+		float markerSize = cellSize - 2 * markerMargin;
 		TGTableColorModel colorModel = this.table.getViewer().getColorModel();
 		UIColor colorBackground = colorModel.createBackground(this.table.getViewer().getContext(), 0);
 		UIColor colorForeground = colorModel.createForeground(this.table.getViewer().getContext(), 0);
@@ -104,11 +110,10 @@ public class TGTableHeaderMeasures implements TGTableHeader, TGBufferedPainterHa
 		int j = (int) Math.floor(scrollX / cellSize);
 		for (float x = -scrollX + j * cellSize; j < count && x < width; j++, x += cellSize) {
 			TGMeasureHeader header = song.getMeasureHeader(j);
-
-			if (header.hasMarker() && this.imgMarker!=null) {
-				final float margin = 1.0f;
+			// additional check (markerSize): is there enough room to draw marker?
+			if (header.hasMarker() && this.imgMarker!=null && markerSize>10.0f) {
 				painter.drawImage(this.imgMarker, 0, 0, this.imgMarker.getWidth(), this.imgMarker.getHeight(),
-						x + margin, margin, cellSize - 2 * margin, cellSize - 2 * margin);
+						x + markerMargin, markerMargin, markerSize, markerSize);
 			}
 		}
 		colorBackground.dispose();


### PR DESCRIPTION
fixes one issue when opening TG by opening a file with markers in it (e.g. file passed as an argument in command line, or double-clicking a file in graphical interface) . This could lead to draw a marker in a non-initialized track table, with SWT throwing an exception and crashing app
see #99 (2 independent problems mentioned in this issue)

Implementation of markers in track table was inspired by 2.0beta, but it was not expected that this drawing of markers could be called even before table is fully initialized.
Especially I did not think it was possible that `cellSize` would equal 0.0f, just a few lines after `int j = (int) Math.floor(scrollX / cellSize);`
I just discovered that dividing by 0.0f returns `NaN` and raises no exception.