### PR TITLE
fix display of an erroneous selection when switching tabs

### DIFF
--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Selector.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Selector.java
@@ -107,14 +107,23 @@ public class Selector {
 	private void saveState() {
 		TGDocumentListManager documents = TGDocumentListManager.getInstance(this.tablature.getContext());
 		TGDocument document = this.initial == null ? documents.findCurrentDocument() : documents.findDocument(this.initial.getMeasure().getTrack().getSong());
-		document.setSelectionStart(this.getStartBeat());
-		document.setSelectionEnd(this.getEndBeat());
+		if (isActive()) {
+			document.setSelectionStart(this.getStartBeat());
+			document.setSelectionEnd(this.getEndBeat());
+		} else {
+			document.setSelectionStart(null);
+			document.setSelectionEnd(null);
+		}
 	}
 
 	public void restoreStateFrom(TGDocument document) {
 		TGBeat start = document.getSelectionStart();
 		TGBeat end = document.getSelectionEnd();
-		this.initializeSelection(start);
-		this.updateSelection(end);
+		if ((start!=null) && (end!=null)) {
+			this.initializeSelection(start);
+			this.updateSelection(end);
+		} else {
+			this.clearSelection();
+		}
 	}
 }


### PR DESCRIPTION
Fix for #101
scenario (before the fix):
- open 2 songs
- in song 1, click in measure 4, without click&drag : no selection
- switch to song 2
- switch back to song 1 a selection appears in measure 4 where the cursor was

Explanation: introduced in 0d728c2ab26b2256e5ac00d7124182912bd3370f when fixing one bug backported from 2.0beta.
In 2.0beta, when user switches song, a selection is initialized where the cursor was.
BUT, since a selection of a single beat does not work, nothing happens
After the possibility to select 1 single beat selection was reintroduced, the consequences became visible

fix: when switching song, save/restore selection only if it's not empty