### PR TITLE
fix selection in score edition mode

### DIFF
--- a/TuxGuitar-lib/src/org/herac/tuxguitar/document/TGDocumentContextAttributes.java
+++ b/TuxGuitar-lib/src/org/herac/tuxguitar/document/TGDocumentContextAttributes.java
@@ -43,4 +43,5 @@ public final class TGDocumentContextAttributes {
 	public static final String ATTRIBUTE_BEAT_RANGE = "beat-range";
 	public static final String ATTRIBUTE_NOTE_RANGE = "note-range";
 	public static final String ATTRIBUTE_KEEP_SELECTION = "keep-selection";
+	public static final String ATTRIBUTE_SELECTION_IS_ACTIVE = "selection-is-active";
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/TGActionContextFactoryImpl.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/TGActionContextFactoryImpl.java
@@ -34,6 +34,7 @@ public class TGActionContextFactoryImpl implements TGActionContextFactory{
 		tgActionContext.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_MARKER, caret.getMeasure().getHeader().getMarker());
 		tgActionContext.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE, tablature.getCurrentBeatRange());
 		tgActionContext.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE, tablature.getCurrentNoteRange());
+		tgActionContext.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE, (Boolean)tablature.getSelector().isActive());
 		
 		return tgActionContext;
 	}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGCopyAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGCopyAction.java
@@ -3,8 +3,6 @@ package org.herac.tuxguitar.app.action.impl.edit;
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.action.TGActionManager;
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureCopyDialogAction;
-import org.herac.tuxguitar.app.view.component.tab.Tablature;
-import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
 import org.herac.tuxguitar.editor.clipboard.TGClipboard;
@@ -21,8 +19,7 @@ public class TGCopyAction extends TGActionBase {
 	}
 	
 	protected void processAction(TGActionContext tgActionContext){
-	    Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature(); 
-		if (tablature.getSelector().isActive()) {
+		if (Boolean.TRUE.equals(tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE))) {
 			TGBeatRange beats = tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
 			TGClipboard.getInstance(this.getContext()).setData(new TGStoredBeatList(beats.getBeats(), getSongManager(tgActionContext).getFactory()));
 		}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGCutAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGCutAction.java
@@ -2,8 +2,7 @@ package org.herac.tuxguitar.app.action.impl.edit;
 
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.action.TGActionManager;
-import org.herac.tuxguitar.app.view.component.tab.Tablature;
-import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
 import org.herac.tuxguitar.editor.action.note.TGDeleteNoteOrRestAction;
 import org.herac.tuxguitar.util.TGContext;
@@ -17,8 +16,7 @@ public class TGCutAction extends TGActionBase{
 	}
 	
 	protected void processAction(TGActionContext context){
-	    Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature(); 
-		if (tablature.getSelector().isActive()) {
+		if (Boolean.TRUE.equals(context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE))) {
 			TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
 			tgActionManager.execute(TGCopyAction.NAME, context);
 			tgActionManager.execute(TGDeleteNoteOrRestAction.NAME, context);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGRepeatAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGRepeatAction.java
@@ -1,9 +1,10 @@
 package org.herac.tuxguitar.app.action.impl.edit;
 
+import java.util.List;
+
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.action.TGActionManager;
 import org.herac.tuxguitar.app.action.impl.caret.TGGoRightAction;
-import org.herac.tuxguitar.app.view.component.tab.Selector;
 import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
@@ -11,6 +12,7 @@ import org.herac.tuxguitar.graphics.control.TGMeasureImpl;
 import org.herac.tuxguitar.graphics.control.TGTrackImpl;
 import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGString;
+import org.herac.tuxguitar.util.TGBeatRange;
 import org.herac.tuxguitar.util.TGContext;
 
 public class TGRepeatAction extends TGActionBase {
@@ -22,13 +24,14 @@ public class TGRepeatAction extends TGActionBase {
 	}
 
 	protected void processAction(TGActionContext tgActionContext) {
-		Selector selector = TablatureEditor.getInstance(getContext()).getTablature().getSelector();
-		if (selector.isActive()) {
+		if (Boolean.TRUE.equals(tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE))) {
 			// copy
 			TGActionManager.getInstance(this.getContext()).execute(TGCopyAction.NAME, tgActionContext);
 			// move to last beat of selection
 			TGTrackImpl track = ((TGTrackImpl) tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK));
-			TGBeat lastBeat = selector.getEndBeat();
+			TGBeatRange beatRange = (TGBeatRange)tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
+			List<TGBeat> beatList = beatRange.getBeats();
+			TGBeat lastBeat = beatList.get(beatList.size()-1);
 			TGMeasureImpl measure = (TGMeasureImpl) lastBeat.getMeasure();
 			TGString string = ((TGString) tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING));
 			TablatureEditor.getInstance(getContext()).getTablature().getCaret().moveTo(track, measure, lastBeat, string.getNumber());

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/tablature/TGMouseClickAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/tablature/TGMouseClickAction.java
@@ -29,7 +29,8 @@ public class TGMouseClickAction extends TGActionBase{
 				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_KEEP_SELECTION, true);
 				actionManager.execute(TGMoveToAction.NAME, context);
 			}
-			if( editorKit.isMouseEditionAvailable() && editorKit.fillAddOrRemoveBeat(context) ) {
+			if( editorKit.isMouseEditionAvailable() && editorKit.fillAddOrRemoveBeat(context) &&
+					Boolean.FALSE==context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE)) {
 				
 				if( editorKit.fillRemoveNoteContext(context) ) {
 					


### PR DESCRIPTION
fix for #104
before the fix:
- activate score edition mode
- initiate selection with click&drag
- release mouse button in the score area if not on a note, it creates a note and clears selection (inconsistent) if on a note, it deletes note (inconsistent) and keeps selection

fixed: nothing is edited when selecting with click& drag in score edition mode

Also:
cleaner propagation of Selector.isActive through action context