### PR TITLE
first automated tests

### DIFF
--- a/TuxGuitar-test/pom.xml
+++ b/TuxGuitar-test/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>tuxguitar-pom</artifactId>
+		<groupId>org.herac.tuxguitar</groupId>
+		<version>SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>tuxguitar-test</artifactId>
+	<packaging>jar</packaging>
+	<name>${project.artifactId}</name>
+
+	<build>
+		<sourceDirectory>src</sourceDirectory>
+	</build>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>5.10.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar-lib</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar-editor-utils</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar-ui-toolkit</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar-ui-toolkit-swt</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${org.eclipse.swt.groupId}</groupId>
+			<artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
+			<version>4.13</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/TuxGuitar-test/src/org/herac/tuxguitar/test/TGTest.java
+++ b/TuxGuitar-test/src/org/herac/tuxguitar/test/TGTest.java
@@ -1,0 +1,262 @@
+package org.herac.tuxguitar.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.action.TGActionManager;
+import org.herac.tuxguitar.app.TuxGuitar;
+import org.herac.tuxguitar.app.action.impl.caret.TGMoveToAction;
+import org.herac.tuxguitar.app.action.impl.file.TGCloseAllDocumentsAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGExtendSelectionNextAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGExtendSelectionPreviousAction;
+import org.herac.tuxguitar.app.action.listener.save.TGUnsavedDocumentInterceptor;
+import org.herac.tuxguitar.app.document.TGDocument;
+import org.herac.tuxguitar.app.document.TGDocumentListManager;
+import org.herac.tuxguitar.app.view.component.tab.Caret;
+import org.herac.tuxguitar.app.view.component.tab.Selector;
+import org.herac.tuxguitar.app.view.component.tab.Tablature;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
+import org.herac.tuxguitar.editor.action.TGActionProcessor;
+import org.herac.tuxguitar.editor.action.duration.TGSetDurationAction;
+import org.herac.tuxguitar.editor.action.file.TGNewSongAction;
+import org.herac.tuxguitar.editor.action.measure.TGAddMeasureListAction;
+import org.herac.tuxguitar.player.base.MidiPlayer;
+import org.herac.tuxguitar.song.models.TGBeat;
+import org.herac.tuxguitar.song.models.TGDuration;
+import org.herac.tuxguitar.song.models.TGTrack;
+import org.herac.tuxguitar.util.TGContext;
+
+public abstract class TGTest {
+	// note:
+	// methods triggering actions are prefixed with "do"
+	//    results of "do" methods with suffix "Checked" ARE checked (i.e. action was effective or test fails)
+	//    with no suffix, action is launched but nothing is checked
+	// methods prefixed with "check" do not trigger any action, but check something
+	
+	// these need to be initialized by tests scenarios
+	protected boolean verbose;
+	
+	@BeforeAll
+	static void startTG() {
+		TuxGuitar tg = TuxGuitar.getInstance();
+		assertNotNull(tg);
+		
+		new Thread() {
+			public void run() {
+				tg.createApplication(null);
+			}
+		}.start();
+		assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+			while (!tg.isInitialized()) {
+				Thread.sleep(500);
+			}
+		});
+	}
+	
+	// VERY basic logging to console, TODO: improve!
+	protected void log(String s) {
+		if (verbose) System.out.printf("%s",s);
+	}
+	protected void OK() {
+		log("OK\n");
+	}
+	
+	protected void doWait() throws InterruptedException {
+		Thread.sleep(10);
+	}
+	
+	protected void doInsertMeasuresChecked(int from, int nb) {
+		TGTrack track = TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret().getTrack();
+		
+		int nbMeasuresInit = track.countMeasures();
+		
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGAddMeasureListAction.NAME);
+		tgActionProcessor.setAttribute(TGAddMeasureListAction.ATTRIBUTE_MEASURE_COUNT, nb);
+		tgActionProcessor.setAttribute(TGAddMeasureListAction.ATTRIBUTE_MEASURE_NUMBER, from);
+		log(String.format("inserting %d measures... ",nb));
+		tgActionProcessor.process();
+		
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			while (track.countMeasures() != (nbMeasuresInit+nb)) {
+				doWait();
+			}
+		});
+		OK();
+	}
+
+	// measures and strings are numbered from 1
+	// beats are numbered from 0
+	// not fully representative in all cases:
+	// not all conditions of onMouseUp (TGMouseClickAction) are emulated here
+	protected void doMouseClick(int measureNb, int beatNb, int stringNb) {
+		TGActionManager tgActionManager = TGActionManager.getInstance(TuxGuitar.getInstance().getContext());
+		Tablature tablature = TuxGuitar.getInstance().getTablatureEditor().getTablature();
+		TGTrack track = tablature.getCaret().getTrack();
+
+		log(String.format("clicking in measure %d, beat %d, string %d\n", measureNb, beatNb, stringNb));
+		// see MouseKit.onMouseDown and TGStartDragSelectionAction.processAction
+		TGActionContext context = tgActionManager.createActionContext();
+		context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK, track);
+		context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE, track.getMeasure(measureNb-1));
+		context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT, track.getMeasure(measureNb-1).getBeat(beatNb));
+		context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING, track.getString(stringNb));
+
+		tgActionManager.execute(TGMoveToAction.NAME, context);
+		TGBeat beat = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT);
+		Selector selector = tablature.getSelector();
+		selector.initializeSelection(beat);
+
+		// onMouseUp (not all conditions)
+		if (MidiPlayer.getInstance(TuxGuitar.getInstance().getContext()).isRunning()) {
+			log("mouse up, midi player running\n");
+			context = tgActionManager.createActionContext();
+			context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_KEEP_SELECTION, true);
+			TGActionManager.getInstance(TuxGuitar.getInstance().getContext()).execute(TGMoveToAction.NAME, context);
+		}
+	}
+	
+	protected void checkCaretPosition(int measureNb, int beatNb, int stringNb) {
+		Caret caret = TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret();
+		log("checking caret position...");
+
+		assertTrue(caret.getMeasure().getNumber() == measureNb ,
+				String.format("measure %d, expected %d\n", caret.getMeasure().getNumber(), measureNb));
+		assertTrue((TGBeat)caret.getSelectedBeat() == caret.getMeasure().getBeat(beatNb),
+				"unexpected beat\n");
+		assertTrue(caret.getStringNumber() == stringNb,
+				String.format("string %d, expected %d\n", caret.getStringNumber(), stringNb));
+		OK();
+	}
+
+	protected void doMouseClickChecked(int measureNb, int beatNb, int stringNb) {
+		doMouseClick(measureNb, beatNb, stringNb);
+		checkCaretPosition(measureNb, beatNb, stringNb);
+	}
+	
+	protected void checkCaretReachesMeasure(int measureNb) {
+		Caret caret = TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret();
+		log(String.format("checking caret is in measure %d...",measureNb));
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			while (caret.getMeasure().getNumber() != measureNb) {
+				doWait();
+			}
+		});
+		OK();
+	}
+	
+	protected void doSelectMeasuresChecked(int from, int to) {
+		TGActionProcessor tgActionProcessor;
+		Tablature tablature = TuxGuitar.getInstance().getTablatureEditor().getTablature();
+
+		assertTrue(from>0 && to>0 && to!=from, String.format("illegal parameters, should be different and positive: %d,%d\n",from,to));
+
+		int nb;
+		if (to>from) {
+			tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+					TGExtendSelectionNextAction.NAME);
+			nb = to-from;
+		} else {
+			tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+					TGExtendSelectionPreviousAction.NAME);
+			nb = from-to;
+		}
+		doMouseClickChecked(from, 0, 1);
+		for (int i=1; i<nb+1; i++) {
+			log("extending selection...");
+			tgActionProcessor.process();
+			final int iteration = i;
+			assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+				boolean ok = false;
+				Selector selector = tablature.getSelector();
+				while (!ok) {
+					int start = to > from ? from : from-iteration;
+					int end = to > from ? from + iteration : from;
+					ok  = (selector.getStartBeat() == null ? false : selector.getStartBeat().getMeasure().getNumber() == start);
+					ok &= (selector.getEndBeat() == null ? false : selector.getEndBeat().getMeasure().getNumber() == end);
+					doWait();
+				}
+			});
+		}
+		OK();
+	}
+
+	protected void doNewSongChecked() {
+		TGContext context = TuxGuitar.getInstance().getContext();
+		TGDocumentListManager docManager = TGDocumentListManager.getInstance(context);
+		List<TGDocument> documents = new ArrayList<TGDocument>(docManager.getDocuments());
+		int documentsNb = documents.size();
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGNewSongAction.NAME);
+		log("creating new song...");
+		tgActionProcessor.process();
+		assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+			// TODO remove this sleep (yet needed to stabilize tests), find a better criterion
+			Thread.sleep(200);
+			while (docManager.getDocuments().size() != documentsNb+1) {
+				doWait();
+			}
+		});
+		OK();
+	}
+	
+	protected void doCloseAllSongsWithoutConfirmationChecked() {
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGCloseAllDocumentsAction.NAME);
+		tgActionProcessor.setAttribute(TGUnsavedDocumentInterceptor.UNSAVED_INTERCEPTOR_BY_PASS, Boolean.TRUE);
+		log("closing all songs...");
+		tgActionProcessor.process();
+		
+		// wait until closed
+		assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+			boolean allClosed = false;
+			while (!allClosed) {
+				TGContext context = TuxGuitar.getInstance().getContext();
+				List<TGDocument> documents = new ArrayList<TGDocument>(TGDocumentListManager.getInstance(context).getDocuments());
+				// TODO improvement required, this is not a clean criterion
+				allClosed = (documents.size() == 1);
+				Thread.sleep(500);
+			}
+		});
+		OK();
+	}
+	
+	protected void checkCaretDuration(int value) {
+		// TODO: difficult to find a clean criterion to detect end of setDuration...
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			boolean ok = false;
+			while (!ok) {
+				Thread.sleep(100);
+				ok = (value == TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret().getDuration().getValue());				
+			}
+		});
+		OK();
+	}
+	
+	protected void doSetDuration(int value) {
+		Tablature tablature = TuxGuitar.getInstance().getTablatureEditor().getTablature();
+		TGDuration duration = tablature.getCaret().getDuration();
+		duration.setValue(value);
+		duration.setDotted(false);
+		duration.setDoubleDotted(false);
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGSetDurationAction.NAME);
+		tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE, tablature.getCurrentNoteRange());
+		tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE, tablature.getCurrentBeatRange());
+		tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_DURATION, duration);
+		log(String.format("setting duration to %d", value));
+		tgActionProcessor.process();
+	}
+	protected void doSetDurationChecked(int value) {
+		doSetDuration(value);
+		log("...");
+		checkCaretDuration(value);
+	}
+}

--- a/TuxGuitar-test/src/org/herac/tuxguitar/test/TGTestSwitchTab.java
+++ b/TuxGuitar-test/src/org/herac/tuxguitar/test/TGTestSwitchTab.java
@@ -1,0 +1,141 @@
+package org.herac.tuxguitar.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import org.herac.tuxguitar.app.TuxGuitar;
+import org.herac.tuxguitar.app.document.TGDocument;
+import org.herac.tuxguitar.app.document.TGDocumentListAttributes;
+import org.herac.tuxguitar.app.document.TGDocumentListManager;
+import org.herac.tuxguitar.app.view.component.tab.Selector;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
+import org.herac.tuxguitar.editor.action.TGActionProcessor;
+import org.herac.tuxguitar.editor.action.file.TGLoadSongAction;
+import org.herac.tuxguitar.song.models.TGDuration;
+
+
+public class TGTestSwitchTab extends TGTest {
+
+	private TGDocumentListManager documentManager;
+	private TGDocument doc1;
+	private TGDocument doc2;
+	
+	private void doSwitchDocumentChecked(TGDocument doc) {
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGLoadSongAction.NAME);
+		tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_SONG, doc.getSong());
+		tgActionProcessor.setAttribute(TGDocumentListAttributes.ATTRIBUTE_UNWANTED, doc.isUnwanted());
+		log("Switching to doc ...");
+		tgActionProcessor.process();
+		// TODO: difficult to find a clean criterion to detect everything has been refreshed after switching doc...
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			boolean ok = false;
+			while (!ok) {
+				Thread.sleep(100);
+				ok = (doc == documentManager.findCurrentDocument());
+			}
+		});
+		OK();
+	}
+	
+	@BeforeEach
+	void setupTest() {
+		documentManager = TGDocumentListManager.getInstance(TuxGuitar.getInstance().getContext());
+		
+		verbose=false;
+		doCloseAllSongsWithoutConfirmationChecked();
+		doc1 = documentManager.findCurrentDocument();
+		doInsertMeasuresChecked(2, 5);
+		doMouseClickChecked(1, 0, 1);
+		
+		doNewSongChecked();
+		doc2 = documentManager.findCurrentDocument();
+		doInsertMeasuresChecked(2, 9);
+		doMouseClickChecked(1, 0, 1);
+		verbose=true;
+	}
+
+	// did reproduce known issue from 1.6.0beta3, and validate its correction
+	// https://github.com/helge17/tuxguitar/issues/101
+	@Test
+	@DisplayName("issue #101")
+	void testIssue101() {
+		log("\n-- testIssue101\n");
+		doMouseClickChecked(3, 0, 1);
+		doSwitchDocumentChecked(doc1);
+		doSwitchDocumentChecked(doc2);
+		log("Checking selection is inactive...");
+		assertFalse(TuxGuitar.getInstance().getTablatureEditor().getTablature().getSelector().isActive());
+		OK();
+	}
+
+	// introduced after 1.6.0
+	// see https://github.com/helge17/tuxguitar/discussions/81
+	@Test
+	@DisplayName("Caret position is memorized")
+	void switchTabsKeepsCaret() {
+		log("\n-- switchTabsKeepsCaret\n");
+		doMouseClickChecked(3, 0, 4);
+		doSetDurationChecked(TGDuration.QUARTER);
+		doMouseClickChecked(3, 2, 4);
+		doSwitchDocumentChecked(doc1);
+		checkCaretPosition(1, 0, 1);
+		doMouseClickChecked(2, 0, 2);
+		doSwitchDocumentChecked(doc2);
+		checkCaretPosition(3, 2, 4);
+		doSwitchDocumentChecked(doc1);
+		checkCaretPosition(2, 0, 2);
+		doNewSongChecked();
+		checkCaretPosition(1, 0, 1);
+	}
+
+	@Test
+	@DisplayName("Selection is memorized")
+	void switchTabsKeepsSelection() {
+		log("\n-- switchTabsKeepsSelection()\n");
+		doSelectMeasuresChecked(2, 4);
+		doSwitchDocumentChecked(doc1);
+		Selector selector = TuxGuitar.getInstance().getTablatureEditor().getTablature().getSelector();
+		log("checking selection is inactive...");
+		assertFalse(selector.isActive());
+		OK();
+		doSelectMeasuresChecked(1, 3);
+		doSwitchDocumentChecked(doc2);
+		log("checking selection is active...");
+		assertTrue(selector.isActive());
+		OK();
+		log("checking selection starts from 2...");
+		assertNotNull(selector.getStartBeat());
+		assertTrue(selector.getStartBeat().getMeasure().getNumber() == 2);
+		OK();
+		log("checking selection ends at 4...");
+		assertNotNull(selector.getEndBeat());
+		assertTrue(selector.getEndBeat().getMeasure().getNumber() == 4);
+		OK();
+		doSwitchDocumentChecked(doc1);
+		log("checking selection is active...");
+		assertTrue(selector.isActive());
+		OK();
+		log("checking selection starts from 1...");
+		assertNotNull(selector.getStartBeat());
+		assertTrue(selector.getStartBeat().getMeasure().getNumber() == 1);
+		OK();
+		log("checking selection ends at 3...");
+		assertNotNull(selector.getEndBeat());
+		assertTrue(selector.getEndBeat().getMeasure().getNumber() == 3);
+		OK();
+		doMouseClickChecked(2, 0, 3);
+		doSwitchDocumentChecked(doc2);
+		doSwitchDocumentChecked(doc1);
+		log("checking selection is inactive...");
+		assertFalse(selector.isActive());
+		OK();
+	}
+}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/save/TGUnsavedDocumentInterceptor.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/save/TGUnsavedDocumentInterceptor.java
@@ -29,7 +29,7 @@ public class TGUnsavedDocumentInterceptor implements TGActionInterceptor, TGEven
 	
 	private static final String UNSAVED_INTERCEPTOR_DOCUMENTS = "unsavedInterceptor_documents";
 	private static final String UNSAVED_INTERCEPTOR_ACTION_ID = "unsavedInterceptor_actionId";
-	private static final String UNSAVED_INTERCEPTOR_BY_PASS = "unsavedInterceptor_byPass";
+	public static final String UNSAVED_INTERCEPTOR_BY_PASS = "unsavedInterceptor_byPass";
 	
 	private TGContext context;
 	private List<String> actionIds;


### PR DESCRIPTION
# Objective
Objective of this pull request is to introduce the possibility to define test scenarios and run them automatically, to ease the development of new features and limit the risk of future regression.

# Dependencies
Test module adds new external dependencies to Junit. However, **only the tests are dependent from this lib**, not the application itself. If for some reason this dependency becomes difficult to maintain some day, only the tests will be impacted.

Only a *very minor* modification has been implemented in the app source code: one string in `TGUnsavedDocumentInterceptor` class has been changed from `private` to `public`. This enables the test scenarios to bypass the confirmation popup when closing unsaved documents. This should be completely harmless, and have zero impact on the application or the build process.

# Maturity
This is far from perfect, and still *work in progress*, and there are a significant number of *TODO* in the code.

Especially, it is quite difficult to handle the parallelism of user actions processing: when a scenario triggers an action, when to check that the result is OK? Some scenarios still include calls to `Thread.sleep` instructions: *I know this is bad practice* and this shall definitely be improved.

However, imho it is still **much** better than manual and opportunistic testing.

# How to create & run tests
A few tests scenarios are implemented, and they can be used as a template to design new tests in the future.

These test scenarios can be executed automatically from Eclipse. I have not yet searched how to run them independently (from command line for example), but this should be possible.

Note: one test scenario is currently failing, it's normal. Scenario checks the correct implementation of "save/restore cursor position" feature (see #81). This feature is being implemented in another branch, and test should become OK once both branches are merged.

Here is what scenarios execution looks like, with one test failing because cursor is not at the expected position (`checkCaretPosition` assertion fails)

https://github.com/helge17/tuxguitar/assets/129443524/7d3cdb05-5316-45a5-8efc-40ea15cd2e0f

