### PR TITLE
ignore android studio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build-scripts/native-modules/tuxguitar-synth-vst-*/include/
 .classpath
 .settings/
 .project
+build-scripts/tuxguitar-android/local.properties
+build-scripts/tuxguitar-android/.idea/


### PR DESCRIPTION
From what I read on the Internet it seems there is no consensus about which android studio files shall or shall not be in configuration.
I do not actively work on the Android version of TuxGuitar, just build and run it from time to time to check absence of regression. And each time Android Studio recreates these files that I delete manually after the test. Since none is actually present in configuration, it seems to me more logical to ignore them.
