### PR TITLE
prepare for future deletion of skins

### DIFF
--- a/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -14,6 +14,7 @@ public class TGConfigDefaults{
 	public static final String RESOURCE = "config-defaults";
 	public static final String MODULE = "tuxguitar";
 	
+	public static final String DEFAULT_SKIN = "Oxygen";
 	private static final String DEFAULT_FONT_NAME = UIFontModel.DEFAULT_NAME;
 	
 	public static TGProperties createDefaults(){
@@ -26,7 +27,7 @@ public class TGConfigDefaults{
 	}
 	
 	public static void loadProperties(TGProperties properties){
-		loadProperty(properties, TGConfigKeys.SKIN, "Oxygen");
+		loadProperty(properties, TGConfigKeys.SKIN, DEFAULT_SKIN);
 		loadProperty(properties, TGConfigKeys.WINDOW_TITLE, "${appname} - ${filename}");
 		loadProperty(properties, TGConfigKeys.SHOW_SPLASH, true);
 		loadProperty(properties, TGConfigKeys.MAXIMIZED, false);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/system/icons/TGSkinManager.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/system/icons/TGSkinManager.java
@@ -1,5 +1,6 @@
 package org.herac.tuxguitar.app.system.icons;
 
+import org.herac.tuxguitar.app.system.config.TGConfigDefaults;
 import org.herac.tuxguitar.app.system.config.TGConfigKeys;
 import org.herac.tuxguitar.app.system.config.TGConfigManager;
 import org.herac.tuxguitar.event.TGEventListener;
@@ -50,7 +51,17 @@ public class TGSkinManager {
 	}
 	
 	public String getCurrentSkin() {
-		return TGConfigManager.getInstance(this.context).getStringValue(TGConfigKeys.SKIN);
+		String configuredSkin = TGConfigManager.getInstance(this.context).getStringValue(TGConfigKeys.SKIN);
+		// does skin exist?
+		TGProperties skinInfo = getSkinInfo(configuredSkin);
+		if (skinInfo.getValue("name") != null) {
+			return configuredSkin;
+		} else {
+			// Use case: user has upgraded TuxGuitar, and configured skin was deleted in the new version
+			// overwrite configured skin: replace by default
+			TGConfigManager.getInstance(this.context).setValue(TGConfigKeys.SKIN, TGConfigDefaults.DEFAULT_SKIN);
+			return TGConfigDefaults.DEFAULT_SKIN;
+		}
 	}
 	
 	public TGProperties getCurrentSkinInfo() {


### PR DESCRIPTION
see discussion in #119

user config file is kept when user upgrades TuxGuitar (starting from 1.6.0) If, in the newly installed version, user configured skin was deleted, then replace the configured value by (hardcoded) default.

Test done:
- start TuxGuitar and close it, to make sure config file exist
- edit config file (~/.config/tuxguitar/config/tuxguitar.cfg): replace value of parameter "skin" by an arbitrary value
- start TuxGuitar: user interface is displayed with Oxygen skin
- open "Tools/Settings/Skins" dialog: Oxygen is selected
- close TuxGuitar
- open config file: parameter "skin" is now set to "Oxygen"