### PR TITLE
fix sound mismatch in matrix editor

### DIFF
--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/matrix/TGMatrixEditor.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/matrix/TGMatrixEditor.java
@@ -638,6 +638,7 @@ public class TGMatrixEditor implements TGEventListener {
 						tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_POSITION, start);
 						tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_FRET, (value - string.getValue()));
 						tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING, string);
+						tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT, beat);
 						tgActionProcessor.process();
 						
 						this.moveTo(beat, string);


### PR DESCRIPTION
See discussion in #131 

Before the fix:
- click in cell 1 in matrix editor: correct sound is played
- click in cell 2 corresponding to another instrument: instrument of click 1 is played
- click in cell 3 corresponding to another instrument: instrument of click 2 is played etc.

one member of TGChangeNoteAction context was not updated