### PR TITLE
Fix bug when opening transport mode dialog

### DIFF
--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/transport/TGTransportModeDialog.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/transport/TGTransportModeDialog.java
@@ -60,6 +60,7 @@ public class TGTransportModeDialog {
 		final UITableLayout dialogLayout = new UITableLayout();
 		final UIWindow dialog = uiFactory.createWindow(uiParent, true, false);
 		final TGBeatRange beats = this.context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
+		boolean isSelectionActive = Boolean.TRUE.equals(this.context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE));
 		
 		dialog.setLayout(dialogLayout);
 		dialog.setText(TuxGuitar.getProperty("transport.mode"));
@@ -202,7 +203,7 @@ public class TGTransportModeDialog {
 		rangeLayout.set(this.loopEHeader, 2, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
 		mHeaderRangeStatus.addControl(this.loopEHeader);
 		
-		if (beats!= null && !beats.isEmpty()) {
+		if (isSelectionActive && beats!= null && !beats.isEmpty()) {
 			mode.setLoopSHeader(beats.firstMeasure().getNumber());
 			mode.setLoopEHeader(beats.lastMeasure().getNumber());
 		}


### PR DESCRIPTION
When something is selected with click & drag, loop range in transport mode dialog (F9) is correctly initialized with selection.
However, even when nothing was selected the values of loop range were updated

Scenario to reproduce bug:
- select measures 4 to 8 with click & drag
- type F9, loop range is initialized from 4 to 8 (OK)
- click 'training mode' then 'OK'
- click somewhere in measure 5 (empty selection)
- type F9: loop range is set from 5 to 5, even before clicking "OK" -> BUG

bug was introduced with 531495044d70a7e93afb29049527325cfbb7d8c4 (sorry for that!)