### PR TITLE
Rework of cursor position vs. player

### DIFF
--- a/TuxGuitar-jack/src/org/herac/tuxguitar/jack/sequencer/JackMidiPlayerStarter.java
+++ b/TuxGuitar-jack/src/org/herac/tuxguitar/jack/sequencer/JackMidiPlayerStarter.java
@@ -31,7 +31,7 @@ public class JackMidiPlayerStarter implements TGEventListener {
 	}
 	
 	public void start(){
-		TGTransport.getInstance(this.context).playPause();
+		TGTransport.getInstance(this.context).playPause(null, null);
 	}
 	
 	public void processCountDownStarted() {

--- a/TuxGuitar-test/src/org/herac/tuxguitar/test/TGTestPlayerPosition.java
+++ b/TuxGuitar-test/src/org/herac/tuxguitar/test/TGTestPlayerPosition.java
@@ -1,0 +1,488 @@
+package org.herac.tuxguitar.test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.herac.tuxguitar.app.action.impl.transport.TGTransportModeAction;
+import org.herac.tuxguitar.app.action.impl.transport.TGTransportPlayPauseAction;
+import org.herac.tuxguitar.app.action.impl.transport.TGTransportPlayStopAction;
+import org.herac.tuxguitar.app.action.impl.transport.TGTransportStopAction;
+import org.herac.tuxguitar.app.view.component.tab.Caret;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
+import org.herac.tuxguitar.app.TuxGuitar;
+import org.herac.tuxguitar.editor.action.TGActionProcessor;
+import org.herac.tuxguitar.editor.action.composition.TGChangeTempoAction;
+import org.herac.tuxguitar.player.base.MidiPlayer;
+import org.herac.tuxguitar.player.base.MidiPlayerMode;
+import org.herac.tuxguitar.song.factory.TGFactory;
+import org.herac.tuxguitar.song.models.TGDuration;
+import org.herac.tuxguitar.song.models.TGTempo;
+import org.herac.tuxguitar.song.models.TGTrack;
+
+public class TGTestPlayerPosition extends TGTest {
+		
+	private final int tempoValue = 240;	// to speed up tests
+	private final long tickOverflowTolerance = 50;	// empirical
+	private MidiPlayer player;
+	
+	/******** helper functions ************/
+	
+	protected long measureNumber(long tickPosition) {
+		return (tickPosition/TGDuration.QUARTER_TIME + 3)/4;	// empirical
+	}
+	protected long tickPosition(long measureNb) {
+		return (4*measureNb - 3) * TGDuration.QUARTER_TIME;	// empirical
+	}
+	
+	/******** user interactions, and acceptance criteria ************/
+	
+	protected void doSetSongTempoChecked(int value) {
+		TGTrack track = TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret().getTrack();
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGChangeTempoAction.NAME);
+		TGTempo tempo = new TGFactory().newTempo();
+		tempo.setValue(value);
+		tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_HEADER, track.getMeasure(0).getHeader());
+		tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_TEMPO, tempo);
+		log(String.format("setting tempo to %d...", value));
+		tgActionProcessor.process();
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			while (track.getMeasure(0).getHeader().getTempo().getValue() != value) {
+				doWait();
+			}
+		});
+		OK();
+	}
+	
+	protected void doPlayPause() {
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGTransportPlayPauseAction.NAME);
+		log("play/pause\n");
+		tgActionProcessor.process();
+	}
+	
+	protected void doPlayStop() {
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGTransportPlayStopAction.NAME);
+		log("play/stop\n");
+		tgActionProcessor.process();
+	}
+	
+	protected void doStop() {
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGTransportStopAction.NAME);
+		log("stop\n");
+		tgActionProcessor.process();
+	}
+	
+	// checks all measures in the interval are played
+	// if OK, returns as soon as player has started last specified measure
+	protected void checkPlaysInterval(int from, int to) {
+		int durationSec = (to-from)*240/tempoValue;
+
+		assertTrue(from>0, String.format("illegal arguments %d,%d\n",from,to));
+		assertTrue(to>from,  String.format("illegal arguments %d,%d\n",from,to));
+		
+		assertTimeoutPreemptively(Duration.ofSeconds(durationSec+1), () -> {
+			log("waiting for player to play...");
+			while (!player.isRunning()) {
+				doWait();
+			}
+			OK();
+			log(String.format("check: playing %d...", from));
+			long measure = measureNumber(player.getTickPosition());
+			assertTrue(measure == from, String.format("KO, played %d\n", measure));
+			OK();
+			// check sequence of played measures
+			for (int i=from+1; i<=to; i++) {
+				log(String.format("check: play %d...", i));
+				while (measureNumber(player.getTickPosition()) != i) {
+					assertTrue(player.isRunning());
+					doWait();
+				}
+				OK();
+			}
+		});		
+	}
+	
+	// checks measure1 then measure2 are played
+	// empirical: a small transient 'overflow' in measure1+1 can sometimes be observed
+	// and is tolerated
+	// if OK, returns as soon as player has started measure2
+	protected void checkPlaysMeasures(int measure1, int measure2) {
+		assertTimeoutPreemptively(Duration.ofSeconds(3), () -> {
+			log("waiting for player to play...");
+			while (!player.isRunning()) {
+				doWait();
+			}
+			OK();
+			log(String.format("check: playing %d...", measure1));
+			long measure = measureNumber(player.getTickPosition()); 
+			assertTrue(measure == measure1, String.format("KO, played %d\n", measure));
+			OK();
+			log(String.format("check: play %d...", measure2));
+			long position = player.getTickPosition();
+			while (player.isRunning() && measureNumber(position) == measure1) {
+				doWait();
+				position = player.getTickPosition();
+			}
+			assertTrue(player.isRunning(), "KO, unexpected stop");
+			// tolerance for a small overflow in measure1+1
+			long currentMeasureMin;
+			while (player.isRunning() && measureNumber(position) != measure2) {
+				currentMeasureMin = measureNumber(position-tickOverflowTolerance);
+				assertTrue(currentMeasureMin==measure1,
+						String.format("KO, played %d(%d)\n", measureNumber(position),position));
+				doWait();
+				position = player.getTickPosition();
+			}
+			OK();
+		});		
+	}
+	
+	// checks it starts playing from specified measure
+	// returns as soon as this measure is started
+	protected void checkPlaysFrom(int from) {
+		assertTrue(from>0, String.format("illegal parameters %d\n",from));
+		
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			log("waiting for player to play...");
+			while (!player.isRunning()) {
+				doWait();
+			}
+			OK();
+			log(String.format("check: play %d...", from));
+			long measure = measureNumber(player.getTickPosition());
+			assertTrue(measure == from, String.format("KO, played %d\n", measure));
+			OK();
+		});		
+	}
+	
+	// check it starts playing from specified tickPosition (with some margin)
+	// returns as soon as it is detected
+	protected void checkPlaysFromTick(long tick) {
+		assertTrue(tick>0, String.format("illegal parameter %d\n",tick));
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			log("waiting for player to play...");
+			while (!player.isRunning()) {
+				doWait();
+			}
+			long playedTick = player.getTickPosition();
+			OK();
+			log(String.format("check: play tick %d...", tick));
+			assertTrue((playedTick >= tick) && (playedTick - tick)<tickOverflowTolerance,
+				String.format("KO, played tick %d, expected %d\n", playedTick, tick));
+			OK();
+		});
+	}
+	
+	// check it plays until specified tickPosition
+	// WARNING: there is a timeout, call this function only when close to the theoretical stopping point
+	protected void checkPlaysUntilTick(long tick) {
+		assertTrue(tick>0, String.format("illegal parameter %d\n",tick));
+		assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+			log("waiting for player to stop...");
+			long playedTick = player.getTickPosition();
+			while (player.isRunning()) {
+				playedTick = player.getTickPosition();
+				assertTrue((playedTick <= tick),
+						String.format("KO, did not stop at tick %d, played %d\n", tick, playedTick));
+				doWait();
+			}
+			OK();
+			log(String.format("check: stopped at tick %d...", tick));
+			assertTrue((playedTick <= tick) && (tick - playedTick)<tickOverflowTolerance,
+					String.format("KO, stopped at tick %d, expected %d\n", playedTick, tick));
+			OK();
+		});
+	}
+	
+	// checks the last played measure, and the final position of caret after stop
+	// empirical: a small transient 'overflow' in [last played measure+1] can sometimes be observed
+	// (even if last played measure is the last measure of song)
+	// this is tolerated
+	// if OK, returns as soon as caret has been detected in the specified position
+	protected void checkStopsSetCaretAt(int singleMeasurePlayed, int finalCaretMeasure) {
+		Caret caret = TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret();
+
+		assertTrue(player.isRunning(), "player not running, can't check it stops");
+		assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+			log(String.format("waiting for player to stop at %d...",singleMeasurePlayed));
+			while (player.isRunning()) {
+				long position = player.getTickPosition();
+				long currentMeasureMax = measureNumber(position);
+				long currentMeasureMin = measureNumber(position-20);
+				assertTrue(currentMeasureMin == singleMeasurePlayed || currentMeasureMax == singleMeasurePlayed,
+						String.format("KO, played %d (%d)\n", currentMeasureMax, position));
+				doWait();				
+			}
+			while (caret.getMeasure().getNumber()!=finalCaretMeasure) {
+				doWait();
+			}
+			// TODO find another criterion to stop first loop: need to ensure that player is REALLY stopped
+			// when just waiting until !isRunning(), next call to 'play' may do nothing if done too soon
+			// (dirty) workaround: wait a bit after stop has been detected
+			Thread.sleep(500);
+		});
+		OK();
+	}
+	
+	// yet only "simple mode" (i.e. no training mode)
+	protected void setPlayerModeChecked(boolean isLooped, int from, int to) {
+		Integer type = MidiPlayerMode.TYPE_CUSTOM;
+		Boolean loop = isLooped;
+		Integer simplePercent = 100;
+		
+		TGActionProcessor tgActionProcessor = new TGActionProcessor(TuxGuitar.getInstance().getContext(),
+				TGTransportModeAction.NAME);
+		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_TYPE, type);
+		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_LOOP, loop);
+		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_SIMPLE_PERCENT, simplePercent);
+		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_CUSTOM_PERCENT_FROM, 100);
+		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_CUSTOM_PERCENT_TO, 100);
+		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_CUSTOM_PERCENT_INCREMENT, 0);
+		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_LOOP_S_HEADER, loop ? from : -1);
+		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_LOOP_E_HEADER, loop ? to : -1);
+		log(String.format("setting player mode(loop=%b, from=%d, to=%d)...", isLooped, from, to));
+		tgActionProcessor.process();
+		
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			MidiPlayerMode mode = player.getMode();
+			while ( mode.getType() != type
+					|| mode.isLoop()!= loop
+					|| mode.getSimplePercent() != simplePercent
+					|| (loop && (mode.getLoopSHeader()!=from || mode.getLoopEHeader()!=to))
+					) {
+				doWait();
+			}
+		});
+		OK();
+	}
+	
+	/******** the test scenarios ************/
+	
+	@BeforeEach
+	// same song structure for all tests: empty measures, fast tempo to speed up tests
+	void cleanSong() {
+		player =  MidiPlayer.getInstance(TuxGuitar.getInstance().getContext());
+		verbose=false;
+		doCloseAllSongsWithoutConfirmationChecked();
+		
+		doSetSongTempoChecked(tempoValue);
+		doInsertMeasuresChecked(2, 9);
+		verbose=true;
+	}
+	
+	@Test
+	void playUntilTheEnd() {
+		log("\n----playUntilTheEnd\n");
+		// click close to the end
+		doMouseClickChecked(9, 0, 1);
+		// play: shall stop at the end, then return caret where initially clicked
+		doPlayPause();
+		checkPlaysInterval(9,10);
+		checkStopsSetCaretAt(10,9);
+		// play shall restart from caret position
+		doPlayPause();
+		checkPlaysFrom(9);
+	}
+	
+	@Test
+	void playStop() {
+		log("\n----playStop\n");
+		// click anywhere
+		doMouseClickChecked(4, 0, 1);
+		// play, wait a bit then stop
+		doPlayStop();
+		checkPlaysInterval(4,6);
+		doPlayStop();
+		// shall stop, then return caret where initially clicked
+		checkStopsSetCaretAt(6,4);
+		doPlayStop();
+		checkPlaysFrom(4);
+	}
+	
+	@Test
+	void PlayPausePlayStop() {
+		log("\n----PlayPausePlayStop\n");
+		doMouseClickChecked(4, 0, 1);
+		doPlayPause();
+		checkPlaysInterval(4,6);
+		doPlayPause();
+		checkStopsSetCaretAt(6,6);
+		doPlayPause();
+		checkPlaysInterval(6, 8);
+		doPlayStop();
+		checkStopsSetCaretAt(8,6);
+	}
+	
+	@Test
+	void playSelection() {
+		// selecting left to right
+		log("\n----playSelection\n");
+		doSelectMeasuresChecked(4, 6);
+		doPlayPause();
+		checkPlaysInterval(4, 6);
+		checkStopsSetCaretAt(6, 4);
+	}
+	
+	@Test
+	void playSelectionReverse() {
+		// selecting right to left
+		log("\n----playSelectionReverse\n");
+		doSelectMeasuresChecked(6, 4);
+		doPlayPause();
+		checkPlaysInterval(4, 6);
+		checkStopsSetCaretAt(6, 4);
+	}
+	
+	@Test
+	void playSelectionPausePlayStop() {
+		log("\n----playSelectionPausePlayStop\n");
+		doSelectMeasuresChecked(4,8);
+		// play: shall start at selection start
+		doPlayPause();
+		checkPlaysInterval(4,6);
+		// pause: shall stop, caret in the middle of selection
+		doPlayPause();
+		checkStopsSetCaretAt(6,6);
+		// play again: shall restart from caret position
+		doPlayPause();
+		checkPlaysInterval(6, 7);
+		// stop: caret shall come back to selection start
+		doPlayStop();
+		checkStopsSetCaretAt(7,4);
+	}
+	
+	@Test
+	void playClickPlaying() {
+		log("\n----playClickPlaying\n");
+		doMouseClickChecked(4, 0, 1);
+		doPlayPause();
+		checkPlaysInterval(4, 6);
+		doMouseClick(2,0,1);
+		//can't use checkPlaysMeasures(6, 2) here, measure 6 may not be detected
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			while (measureNumber(player.getTickPosition()) == 6) {
+				doWait();
+			}
+			while (measureNumber(player.getTickPosition()) != 2) {
+				doWait();
+			}
+		});
+		checkPlaysMeasures(2,3);
+		doPlayStop();
+		checkStopsSetCaretAt(3, 2);
+	}
+	
+	
+	@Test
+	void playStopTwice() {
+		log("\n----playStopTwice\n");
+		doMouseClickChecked(4, 0, 1);
+		doPlayPause();
+		checkPlaysMeasures(4, 5);
+		doPlayStop();
+		checkStopsSetCaretAt(5, 4);
+		// second 'stop' action, shall do nothing
+		doStop();
+		// not trivial to detect absence of action, just wait a bit and check caret did not move
+		log("checking caret does not move...");
+		assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+			Caret caret = TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret();
+			Thread.sleep(200);
+			int measureNb = caret.getMeasure().getNumber();
+			assertTrue(measureNb == 4, String.format("unexpected move to %d", measureNb));
+		});
+		OK();
+	}
+	
+	@Test
+	void playSelectionPartial() {
+		// start and end measures of selection are only partially selected
+		// should only play selected beats
+		log("\n----playSelectionPartial\n");
+		doMouseClickChecked(4, 0, 1);
+		doSetDurationChecked(TGDuration.QUARTER);
+		doMouseClickChecked(6, 0, 1);
+		doSetDurationChecked(TGDuration.QUARTER);
+		doMouseClickChecked(4, 3, 1);
+		doMouseShiftClick(6, 2, 2);
+		doPlayPause();
+		checkPlaysFromTick(tickPosition(4)+3*TGDuration.QUARTER_TIME);
+		checkPlaysInterval(4, 6);
+		checkPlaysUntilTick(tickPosition(6)+2*TGDuration.QUARTER_TIME);
+	}
+	
+	@Test
+	void loopStop() {
+		log("\n----loopStop\n");
+		// define a loop
+		setPlayerModeChecked(true, 4, 6);
+		// click anywhere
+		doMouseClickChecked(2, 0, 1);
+		// play: shall loop
+		doPlayPause();
+		checkPlaysInterval(4, 6);
+		checkPlaysMeasures(6, 4);
+		checkPlaysInterval(4, 5);
+		// stop: shall move caret back to loop start
+		doPlayStop();
+		checkStopsSetCaretAt(5, 4);
+	}
+	
+	@Test
+	void loopPause() {
+		log("\n----loopPause\n");
+		// define a loop
+		setPlayerModeChecked(true, 4, 6);
+		// click anywhere, then play
+		doMouseClickChecked(2, 0, 1);
+		doPlayPause();
+		checkPlaysInterval(4, 5);
+		// pause within loop, caret shall be set where 'pause' was hit
+		doPlayPause();
+		checkStopsSetCaretAt(5, 5);
+		// play: shall restart from caret position
+		doPlayPause();
+		checkPlaysFrom(5);
+	}
+	
+	@Test
+	void loopPlaySelection() {
+		log("\n----loopPlaySelection\n");
+		// define a loop then click anywhere
+		setPlayerModeChecked(true, 6, 8);
+		doMouseClickChecked(2, 0, 1);
+		// select measures (out of loop), left to right
+		doSelectMeasuresChecked(4, 6);
+		// play: selection overrides loop
+		// shall play selection once then come back to selection start
+		doPlayPause();
+		checkPlaysInterval(4, 6);
+		checkStopsSetCaretAt(6,4);
+		doPlayPause();
+		checkPlaysFrom(4);
+	}
+	
+	@Test
+	void loopPlaySelectionReverse() {
+		log("\n----loopPlaySelectionReverse\n");
+		// define a loop then click anywhere
+		setPlayerModeChecked(true, 6, 8);
+		doMouseClickChecked(2, 0, 1);
+		// select measures (out of loop), right to left
+		doSelectMeasuresChecked(6, 4);
+		// play: selection overrides loop
+		// shall play selection once then come back to selection start
+		doPlayPause();
+		checkPlaysInterval(4, 6);
+		checkStopsSetCaretAt(6,4);
+		doPlayPause();
+		checkPlaysFrom(4);
+	}
+}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGGoFirstMeasureAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGGoFirstMeasureAction.java
@@ -1,9 +1,9 @@
 package org.herac.tuxguitar.app.action.impl.measure;
 
 import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.action.TGActionManager;
+import org.herac.tuxguitar.app.action.impl.caret.TGMoveToAction;
 import org.herac.tuxguitar.app.transport.TGTransport;
-import org.herac.tuxguitar.app.view.component.tab.Caret;
-import org.herac.tuxguitar.app.view.component.tab.Tablature;
 import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
@@ -25,15 +25,15 @@ public class TGGoFirstMeasureAction extends TGActionBase{
 			TGTransport.getInstance(getContext()).gotoFirst();
 		}
 		else{
-			Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature();
 			if (!Boolean.TRUE.equals(context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_KEEP_SELECTION))) {
-				tablature.getSelector().clearSelection();
+				TablatureEditor.getInstance(getContext()).getTablature().getSelector().clearSelection();
 			}
-			Caret caret = tablature.getCaret();
-			TGTrack track = caret.getTrack();
-			TGMeasure measure = getSongManager(context).getTrackManager().getFirstMeasure(track);
-			if( track != null && measure != null ){
-				caret.update(track.getNumber(), measure.getStart(), caret.getSelectedString().getNumber());
+			TGTrack track = (TGTrack) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
+			TGMeasure firstMeasure = getSongManager(context).getTrackManager().getFirstMeasure(track);
+			if( firstMeasure != null ){
+				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE, firstMeasure);
+				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT, firstMeasure.getBeat(0));
+				TGActionManager.getInstance(this.getContext()).execute(TGMoveToAction.NAME, context);
 			}
 		}
 	}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGGoLastMeasureAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGGoLastMeasureAction.java
@@ -1,9 +1,9 @@
 package org.herac.tuxguitar.app.action.impl.measure;
 
 import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.action.TGActionManager;
+import org.herac.tuxguitar.app.action.impl.caret.TGMoveToAction;
 import org.herac.tuxguitar.app.transport.TGTransport;
-import org.herac.tuxguitar.app.view.component.tab.Caret;
-import org.herac.tuxguitar.app.view.component.tab.Tablature;
 import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
@@ -25,15 +25,15 @@ public class TGGoLastMeasureAction extends TGActionBase{
 			TGTransport.getInstance(getContext()).gotoLast();
 		}
 		else{
-			Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature();
 			if (!Boolean.TRUE.equals(context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_KEEP_SELECTION))) {
-				tablature.getSelector().clearSelection();
+				TablatureEditor.getInstance(getContext()).getTablature().getSelector().clearSelection();
 			}
-			Caret caret = tablature.getCaret();
-			TGTrack track = caret.getTrack();
-			TGMeasure measure = getSongManager(context).getTrackManager().getLastMeasure(track);
-			if( track != null && measure != null ){
-				caret.update(track.getNumber(), measure.getStart(), caret.getSelectedString().getNumber());
+			TGTrack track = (TGTrack) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
+			TGMeasure lastMeasure = getSongManager(context).getTrackManager().getLastMeasure(track);
+			if( lastMeasure != null ){
+				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE, lastMeasure);
+				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT, lastMeasure.getBeat(0));
+				TGActionManager.getInstance(this.getContext()).execute(TGMoveToAction.NAME, context);
 			}
 		}
 	}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGGoNextMeasureAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGGoNextMeasureAction.java
@@ -1,15 +1,14 @@
 package org.herac.tuxguitar.app.action.impl.measure;
 
 import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.action.TGActionManager;
+import org.herac.tuxguitar.app.action.impl.caret.TGMoveToAction;
 import org.herac.tuxguitar.app.transport.TGTransport;
-import org.herac.tuxguitar.app.view.component.tab.Caret;
-import org.herac.tuxguitar.app.view.component.tab.Tablature;
 import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
 import org.herac.tuxguitar.player.base.MidiPlayer;
 import org.herac.tuxguitar.song.models.TGMeasure;
-import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.util.TGContext;
 
 public class TGGoNextMeasureAction extends TGActionBase{
@@ -25,15 +24,15 @@ public class TGGoNextMeasureAction extends TGActionBase{
 			TGTransport.getInstance(getContext()).gotoNext();
 		}
 		else{
-			Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature();
 			if (!Boolean.TRUE.equals(context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_KEEP_SELECTION))) {
-				tablature.getSelector().clearSelection();
+				TablatureEditor.getInstance(getContext()).getTablature().getSelector().clearSelection();
 			}
-			Caret caret = tablature.getCaret();
-			TGTrack track = caret.getTrack();
-			TGMeasure measure = getSongManager(context).getTrackManager().getNextMeasure(caret.getMeasure());
-			if( track != null && measure != null ){
-				caret.update(track.getNumber(), measure.getStart(), caret.getSelectedString().getNumber());
+			TGMeasure measureFrom = (TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE);
+			TGMeasure measureTo = getSongManager(context).getTrackManager().getNextMeasure(measureFrom);
+			if( measureTo != null ){
+				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE, measureTo);
+				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT, measureTo.getBeat(0));
+				TGActionManager.getInstance(this.getContext()).execute(TGMoveToAction.NAME, context);
 			}
 		}
 	}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGGoPreviousMeasureAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGGoPreviousMeasureAction.java
@@ -1,15 +1,14 @@
 package org.herac.tuxguitar.app.action.impl.measure;
 
 import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.action.TGActionManager;
+import org.herac.tuxguitar.app.action.impl.caret.TGMoveToAction;
 import org.herac.tuxguitar.app.transport.TGTransport;
-import org.herac.tuxguitar.app.view.component.tab.Caret;
-import org.herac.tuxguitar.app.view.component.tab.Tablature;
 import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
 import org.herac.tuxguitar.player.base.MidiPlayer;
 import org.herac.tuxguitar.song.models.TGMeasure;
-import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.util.TGContext;
 
 public class TGGoPreviousMeasureAction extends TGActionBase{
@@ -25,16 +24,15 @@ public class TGGoPreviousMeasureAction extends TGActionBase{
 			TGTransport.getInstance(getContext()).gotoPrevious();
 		}
 		else{
-			Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature();
 			if (!Boolean.TRUE.equals(context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_KEEP_SELECTION))) {
-				tablature.getSelector().clearSelection();
+				TablatureEditor.getInstance(getContext()).getTablature().getSelector().clearSelection();
 			}
-			Caret caret = tablature.getCaret();
-
-			TGTrack track = caret.getTrack();
-			TGMeasure measure = getSongManager(context).getTrackManager().getPrevMeasure(caret.getMeasure());
-			if( track != null && measure != null ){
-				caret.update(track.getNumber(), measure.getStart(), caret.getSelectedString().getNumber());
+			TGMeasure measureFrom = (TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE);
+			TGMeasure measureTo = getSongManager(context).getTrackManager().getPrevMeasure(measureFrom);
+			if( measureTo != null ){
+				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE, measureTo);
+				context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT, measureTo.getBeat(0));
+				TGActionManager.getInstance(this.getContext()).execute(TGMoveToAction.NAME, context);
 			}
 		}
 	}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/selector/TGExtendSelectionNextAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/selector/TGExtendSelectionNextAction.java
@@ -2,8 +2,6 @@ package org.herac.tuxguitar.app.action.impl.selector;
 
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.action.TGActionManager;
-import org.herac.tuxguitar.app.action.impl.caret.TGGoLeftAction;
-import org.herac.tuxguitar.app.action.impl.caret.TGGoRightAction;
 import org.herac.tuxguitar.app.action.impl.measure.TGGoNextMeasureAction;
 import org.herac.tuxguitar.app.view.component.tab.Caret;
 import org.herac.tuxguitar.app.view.component.tab.Selector;
@@ -30,7 +28,7 @@ public class TGExtendSelectionNextAction extends TGActionBase {
 		Selector selector = tablature.getSelector();
 		Caret caret = tablature.getCaret();
 		if (!selector.isActive()) {
-		    selector.initializeSelection(caret.getSelectedBeat());
+			selector.initializeSelection(caret.getSelectedBeat());
 		}
 		TGMeasure currentMeasure = caret.getMeasure();
 		TGMeasureManager measureManager = getSongManager(context).getMeasureManager();
@@ -55,7 +53,7 @@ public class TGExtendSelectionNextAction extends TGActionBase {
 
 	private void moveToMeasureEnd(TGActionContext context, Caret caret) {
 		TGMeasureImpl measure = caret.getMeasure();
-	    TGBeat lastBeat = getSongManager(context).getMeasureManager().getLastBeat(measure.getBeats());
+		TGBeat lastBeat = getSongManager(context).getMeasureManager().getLastBeat(measure.getBeats());
 		caret.moveTo(caret.getTrack(), measure, lastBeat, caret.getSelectedString().getNumber());
 	}
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/transport/TGTransportPlayPauseAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/transport/TGTransportPlayPauseAction.java
@@ -2,7 +2,9 @@ package org.herac.tuxguitar.app.action.impl.transport;
 
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.app.transport.TGTransport;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
+import org.herac.tuxguitar.util.TGBeatRange;
 import org.herac.tuxguitar.util.TGContext;
 
 public class TGTransportPlayPauseAction extends TGActionBase {
@@ -14,6 +16,11 @@ public class TGTransportPlayPauseAction extends TGActionBase {
 	}
 	
 	protected void processAction(TGActionContext context){
-		TGTransport.getInstance(getContext()).playPause();
+		TGBeatRange beatRange = (TGBeatRange)context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
+		boolean isSelectionActive = Boolean.TRUE.equals(context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE));
+
+		TGTransport.getInstance(getContext()).playPause(beatRange.getBeats().get(0), 
+				isSelectionActive ? beatRange.getBeats().get(beatRange.getBeats().size()-1) : null);
+
 	}
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/transport/TGTransportPlayStopAction.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/transport/TGTransportPlayStopAction.java
@@ -2,7 +2,9 @@ package org.herac.tuxguitar.app.action.impl.transport;
 
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.app.transport.TGTransport;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
+import org.herac.tuxguitar.util.TGBeatRange;
 import org.herac.tuxguitar.util.TGContext;
 
 public class TGTransportPlayStopAction extends TGActionBase {
@@ -14,6 +16,10 @@ public class TGTransportPlayStopAction extends TGActionBase {
 	}
 	
 	protected void processAction(TGActionContext context){
-		TGTransport.getInstance(getContext()).playStop();
+		TGBeatRange beatRange = (TGBeatRange)context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
+		boolean isSelectionActive = Boolean.TRUE.equals(context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE));
+
+		TGTransport.getInstance(getContext()).playStop(beatRange.getBeats().get(0), 
+				isSelectionActive ? beatRange.getBeats().get(beatRange.getBeats().size()-1) : null);
 	}
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/transport/TGTransport.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/transport/TGTransport.java
@@ -7,6 +7,7 @@ import org.herac.tuxguitar.document.TGDocumentManager;
 import org.herac.tuxguitar.player.base.MidiPlayer;
 import org.herac.tuxguitar.player.base.MidiPlayerException;
 import org.herac.tuxguitar.song.managers.TGSongManager;
+import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGMeasure;
 import org.herac.tuxguitar.song.models.TGMeasureHeader;
 import org.herac.tuxguitar.song.models.TGSong;
@@ -61,10 +62,6 @@ public class TGTransport {
 		}
 	}
 	
-	public void gotoMeasure(TGMeasureHeader header){
-		gotoMeasure(header, false);
-	}
-	
 	public void gotoCaretPosition() {
 		gotoMeasure(TablatureEditor.getInstance(this.context).getTablature().getCaret().getMeasure().getHeader(), false);
 	}
@@ -101,17 +98,23 @@ public class TGTransport {
 		TuxGuitar.getInstance().updateCache(true);
 	}
 	
-	public void playPause(){
+	public void playPause(TGBeat start, TGBeat end){
 		MidiPlayer player = MidiPlayer.getInstance(this.context);
 		if(!player.isRunning()){
+			if (start!=null) {
+				player.setSelection(start,end);
+			}
 			this.play();
 		}else{
 			this.pause();
 		}
 	}
-	public void playStop(){
+	public void playStop(TGBeat start, TGBeat end){
 		MidiPlayer player = MidiPlayer.getInstance(this.context);
 		if(!player.isRunning()){
+			if (start!=null) {
+				player.setSelection(start,end);
+			}
 			this.play();
 		}else{
 			this.stop();
@@ -120,6 +123,7 @@ public class TGTransport {
 	private void play() {
 		MidiPlayer player = MidiPlayer.getInstance(this.context);
 		try{
+			gotoCaretPosition();
 			player.getMode().reset();
 			player.play();
 		}catch(MidiPlayerException e){

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Caret.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Caret.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.herac.tuxguitar.app.TuxGuitar;
 import org.herac.tuxguitar.app.document.TGDocument;
 import org.herac.tuxguitar.app.document.TGDocumentListManager;
-import org.herac.tuxguitar.app.transport.TGTransport;
 import org.herac.tuxguitar.app.util.MidiTickUtil;
 import org.herac.tuxguitar.graphics.control.TGBeatImpl;
 import org.herac.tuxguitar.graphics.control.TGLayout;
@@ -106,7 +105,6 @@ public class Caret {
 		this.updateNote();
 		this.updateVoice();
 		this.updateBeat();
-		this.checkTransport();
 		this.setChanges(true);
 		this.saveState();
 	}
@@ -330,10 +328,6 @@ public class Caret {
 				this.selectedString = instrumentString;
 			}
 		}
-	}
-	
-	private void checkTransport(){
-		TGTransport.getInstance(this.tablature.getContext()).gotoMeasure(getMeasure().getHeader());
 	}
 	
 	public boolean hasChanges() {

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
@@ -25,6 +25,7 @@ import org.herac.tuxguitar.editor.util.TGSyncProcess;
 import org.herac.tuxguitar.editor.util.TGSyncProcessLocked;
 import org.herac.tuxguitar.event.TGEvent;
 import org.herac.tuxguitar.event.TGEventListener;
+import org.herac.tuxguitar.player.base.MidiPlayer;
 import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGChannel;
 import org.herac.tuxguitar.song.models.TGMeasure;
@@ -296,6 +297,9 @@ public class TGTableViewer implements TGEventListener {
 										TGBeat beat = TuxGuitar.getInstance().getSongManager().getMeasureManager().getFirstBeat(measure.getBeats());
 										if( beat != null ){
 											TGActionProcessor tgActionProcessor = new TGActionProcessor(TGTableViewer.this.context, TGMoveToAction.NAME);
+											if (MidiPlayer.getInstance(getContext()).isRunning()) {
+												tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_KEEP_SELECTION, true);
+											}
 											tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK, track);
 											tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE, measure);
 											tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT, beat);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/transport/TGTransportModeDialog.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/transport/TGTransportModeDialog.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.herac.tuxguitar.app.TuxGuitar;
+import org.herac.tuxguitar.app.action.impl.caret.TGMoveToAction;
 import org.herac.tuxguitar.app.action.impl.transport.TGTransportModeAction;
 import org.herac.tuxguitar.app.ui.TGApplication;
 import org.herac.tuxguitar.app.view.controller.TGViewContext;
@@ -12,8 +13,10 @@ import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionProcessor;
 import org.herac.tuxguitar.player.base.MidiPlayer;
 import org.herac.tuxguitar.player.base.MidiPlayerMode;
+import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGMeasureHeader;
 import org.herac.tuxguitar.song.models.TGSong;
+import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.ui.UIFactory;
 import org.herac.tuxguitar.ui.event.UISelectionEvent;
 import org.herac.tuxguitar.ui.event.UISelectionListener;
@@ -253,6 +256,15 @@ public class TGTransportModeDialog {
 		Integer simplePercent = this.simplePercent.getValue();
 		Integer loopSHeader = this.loopSHeader.getSelectedValue();
 		Integer loopEHeader = this.loopEHeader.getSelectedValue();
+		
+		// move caret to loop start if loop defined
+		if (loop && loopSHeader != null && loopSHeader>0) {
+			TGTrack track = (TGTrack) TGTransportModeDialog.this.context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
+			TGBeat beat = track.getMeasure(loopSHeader-1).getBeat(0);
+			TGActionProcessor tgActionProcessor = new TGActionProcessor(this.context.getContext(), TGMoveToAction.NAME);
+			tgActionProcessor.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT,beat);
+			tgActionProcessor.process();
+		}
 		
 		TGActionProcessor tgActionProcessor = new TGActionProcessor(this.context.getContext(), TGTransportModeAction.NAME);
 		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_TYPE, type);

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/toolbar/main/TGMainToolBarSectionTransport.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/toolbar/main/TGMainToolBarSectionTransport.java
@@ -1,11 +1,13 @@
 package org.herac.tuxguitar.app.view.toolbar.main;
 
+import org.herac.tuxguitar.app.action.TGActionProcessorListener;
+import org.herac.tuxguitar.app.action.impl.measure.TGGoFirstMeasureAction;
+import org.herac.tuxguitar.app.action.impl.measure.TGGoLastMeasureAction;
+import org.herac.tuxguitar.app.action.impl.measure.TGGoNextMeasureAction;
+import org.herac.tuxguitar.app.action.impl.measure.TGGoPreviousMeasureAction;
 import org.herac.tuxguitar.app.action.impl.transport.TGTransportPlayPauseAction;
 import org.herac.tuxguitar.app.action.impl.transport.TGTransportStopAction;
-import org.herac.tuxguitar.app.transport.TGTransport;
 import org.herac.tuxguitar.player.base.MidiPlayer;
-import org.herac.tuxguitar.ui.event.UISelectionEvent;
-import org.herac.tuxguitar.ui.event.UISelectionListener;
 import org.herac.tuxguitar.ui.toolbar.UIToolActionItem;
 
 public class TGMainToolBarSectionTransport extends TGMainToolBarSection {
@@ -28,18 +30,10 @@ public class TGMainToolBarSectionTransport extends TGMainToolBarSection {
 	
 	public void createSection() {
 		this.first = this.getToolBar().getControl().createActionItem();
-		this.first.addSelectionListener(new UISelectionListener() {
-			public void onSelect(UISelectionEvent event) {
-				TGTransport.getInstance(getToolBar().getContext()).gotoFirst();
-			}
-		});
+		this.first.addSelectionListener(new TGActionProcessorListener(this.getToolBar().getContext(), TGGoFirstMeasureAction.NAME));
 		
 		this.previous = this.getToolBar().getControl().createActionItem();
-		this.previous.addSelectionListener(new UISelectionListener() {
-			public void onSelect(UISelectionEvent event) {
-				TGTransport.getInstance(getToolBar().getContext()).gotoPrevious();
-			}
-		});
+		this.previous.addSelectionListener(new TGActionProcessorListener(this.getToolBar().getContext(), TGGoPreviousMeasureAction.NAME));
 		
 		this.play = this.getToolBar().getControl().createActionItem();
 		this.play.addSelectionListener(this.createActionProcessor(TGTransportPlayPauseAction.NAME));
@@ -48,18 +42,10 @@ public class TGMainToolBarSectionTransport extends TGMainToolBarSection {
 		this.stop.addSelectionListener(this.createActionProcessor(TGTransportStopAction.NAME));
 
 		this.next = this.getToolBar().getControl().createActionItem();
-		this.next.addSelectionListener(new UISelectionListener() {
-			public void onSelect(UISelectionEvent event) {
-				TGTransport.getInstance(getToolBar().getContext()).gotoNext();
-			}
-		});
+		this.next.addSelectionListener(new TGActionProcessorListener(this.getToolBar().getContext(), TGGoNextMeasureAction.NAME));
 		
 		this.last = this.getToolBar().getControl().createActionItem();
-		this.last.addSelectionListener(new UISelectionListener() {
-			public void onSelect(UISelectionEvent event) {
-				TGTransport.getInstance(getToolBar().getContext()).gotoLast();
-			}
-		});
+		this.last.addSelectionListener(new TGActionProcessorListener(this.getToolBar().getContext(), TGGoLastMeasureAction.NAME));
 		
 		this.status = STATUS_STOPPED;
 		this.loadIcons();


### PR DESCRIPTION
Evolution is quite complex, so I would appreciate some complementary tests if possible.
I tried to limit the risk by implementing automated tests, but I would not be surprised if a few bugs remain.
Note: I could not fully test with Jack plugin enabled.

# Description of the evolution
Where does the player start when hitting *play*? Where does the cursor go when hitting *pause* or *stop*?

Objective of this evolution is to rework how cursor and player interact, especially considering the "click & drag" feature introduced in 1.6.0. Examples of scenarios:
- select measures 4 to 6, type F9, click "play looped", click OK then *play*: it should loop from 4 to 6 (starts playing 6 before this evolution)
- after selecting something with click&drag, *play* should play once the selected area (plays from cursor to end of song before this evolution)

# User interface
From user point of view, the new behavior is the following:

- Priority to "click&drag" selection: after selecting something, *play* action plays this selection, just once and independently from player mode settings (F9). E.g. if a loop is defined in player mode it is ignored.
- Generally, hitting *play* starts playing where the cursor is. Exception: if something was just selected, it starts playing at beginning of selection, independently from cursor position
- When hitting *pause*, cursor is moved to the measure where *pause* was hit
- When hitting *stop* or when end of song is reached, in absence of selection cursor is moved to the measure where *play* was hit. With a selection active, cursor comes back to beginning of selection
- hitting *stop* while player is not playing does nothing.

# Implementation
From software point of view, there are 2 different indexes:

- the cursor (named `Caret` in the code), that user can move with keyboard, mouse, toolbar buttons, menu items...
- a `tickPosition`, internal to `MidiPlayer`, moving when song is played

I tried to de-correlate movements of `caret` and `tickPosition`:

- whatever user does when player is not playing, `tickPosition` is no more updated
- when player plays, `caret` position remains unchanged

The 2 indexes are aligned when player changes state:

- when player starts to play, `tickPosition` is updated considering selection state, `caret` position and player mode (e.g. loop configured)
- when player stops, `caret` is moved considering user action (*stop* or *pause*), current `tickPosition` and player starting point

# Limitations

With this evolution, player always plays **full** measures.
E.g. if selection covers last beat of measure 4 to first beat of measure 5, then *play* action plays full measures 4 & 5. Similarly, with one single beat selected a full measure is played.
This could be reworked in a second step (significant complexity, impacting several implementations of `MidiSequencerImpl` class).
A test corresponding to this use case has been added in `TGTestPlayerPosition`, it is the only failing test.

Automated tests may not be 100% reliable, there could be false positives (not too often hopefully). I did not succeed to implement an automated test for the case where a "Close Repeat" is present in the selected area. This case was only tested manually.