### PR TITLE
Fix midi import with transposition

### DIFF
--- a/TuxGuitar-midi/src/org/herac/tuxguitar/io/midi/MidiSongReader.java
+++ b/TuxGuitar-midi/src/org/herac/tuxguitar/io/midi/MidiSongReader.java
@@ -208,7 +208,7 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 		}else if(value > 0){
 			createTempNotesBefore(tick,track);
 			getTempChannel(channel).addTrack(track);
-			getTrackTuningHelper(track).checkValue(value);
+			getTrackTuningHelper(track).checkValue(value + this.settings.getTranspose());
 			this.tempNotes.add(new TempNote(track,channel,value,tick));
 		}
 	}


### PR DESCRIPTION
Value entered by user for transposition when importing a midi file was not considered to choose an appropriate tuning.
This could lead to negative fret numbers displayed in the tablature.
See #150