### PR TITLE
display doc in embedded browser

### DIFF
--- a/TuxGuitar-ui-toolkit-jfx/pom.xml
+++ b/TuxGuitar-ui-toolkit-jfx/pom.xml
@@ -45,6 +45,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-web</artifactId>
+			<version>${javafx.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-controls</artifactId>
 			<version>${javafx.version}</version>
 		</dependency>

--- a/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/JFXFactory.java
+++ b/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/JFXFactory.java
@@ -17,6 +17,7 @@ import org.herac.tuxguitar.ui.jfx.menu.JFXMenuBar;
 import org.herac.tuxguitar.ui.jfx.menu.JFXPopupMenu;
 import org.herac.tuxguitar.ui.jfx.resource.JFXResourceFactory;
 import org.herac.tuxguitar.ui.jfx.toolbar.JFXToolBar;
+import org.herac.tuxguitar.ui.jfx.widget.JFXBrowser;
 import org.herac.tuxguitar.ui.jfx.widget.JFXButton;
 import org.herac.tuxguitar.ui.jfx.widget.JFXCanvas;
 import org.herac.tuxguitar.ui.jfx.widget.JFXCheckBox;
@@ -58,6 +59,7 @@ import org.herac.tuxguitar.ui.resource.UIFontModel;
 import org.herac.tuxguitar.ui.resource.UIImage;
 import org.herac.tuxguitar.ui.resource.UIResourceFactory;
 import org.herac.tuxguitar.ui.toolbar.UIToolBar;
+import org.herac.tuxguitar.ui.widget.UIBrowser;
 import org.herac.tuxguitar.ui.widget.UIButton;
 import org.herac.tuxguitar.ui.widget.UICanvas;
 import org.herac.tuxguitar.ui.widget.UICheckBox;
@@ -314,5 +316,9 @@ public class JFXFactory implements UIFactory {
 
 	public UIImage createImage(InputStream inputStream) {
 		return this.resourceFactory.createImage(inputStream);
+	}
+
+	public UIBrowser createBrowser(UIWindow parent) {
+		return new JFXBrowser((JFXWindow) parent);
 	}
 }

--- a/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/widget/JFXBrowser.java
+++ b/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/widget/JFXBrowser.java
@@ -1,0 +1,61 @@
+package org.herac.tuxguitar.ui.jfx.widget;
+
+import java.net.URL;
+
+import org.herac.tuxguitar.ui.event.UIResizeListener;
+import org.herac.tuxguitar.ui.jfx.event.JFXResizeListenerManager;
+import org.herac.tuxguitar.ui.resource.UIRectangle;
+import org.herac.tuxguitar.ui.widget.UIBrowser;
+
+import javafx.scene.layout.Region;
+
+import javafx.scene.web.WebView;
+
+public class JFXBrowser extends JFXNode<WebView> implements UIBrowser {
+	
+	private UIRectangle bounds;
+	private JFXResizeListenerManager resizeListener;
+	
+	public JFXBrowser(JFXContainer<? extends Region> parent) {
+		super(new WebView(), parent);
+		this.resizeListener = new JFXResizeListenerManager(this);
+	}
+
+	public void loadUrl(URL url) {
+		this.getControl().getEngine().load(url.toString());
+	}
+
+	@Override
+	public UIRectangle getBounds() {
+		return this.bounds;
+	}
+
+	@Override
+	public void setBounds(UIRectangle bounds) {
+		this.bounds = bounds;
+		this.getControl().resize(bounds.getWidth(), bounds.getHeight());
+	}
+
+	@Override
+	public void redraw() {
+		this.getControl().getEngine().reload();
+	}
+
+	@Override
+	public void addResizeListener(UIResizeListener listener) {
+		if( this.resizeListener.isEmpty() ) {
+			this.getControl().widthProperty().addListener(this.resizeListener);
+			this.getControl().heightProperty().addListener(this.resizeListener);
+		}
+		this.resizeListener.addListener(listener);
+	}
+
+	@Override
+	public void removeResizeListener(UIResizeListener listener) {
+		this.resizeListener.removeListener(listener);
+		if( this.resizeListener.isEmpty() ) {
+			this.getControl().widthProperty().removeListener(this.resizeListener);
+			this.getControl().heightProperty().removeListener(this.resizeListener);
+		}
+	}
+}

--- a/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/SWTFactory.java
+++ b/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/SWTFactory.java
@@ -28,6 +28,7 @@ import org.herac.tuxguitar.ui.swt.menu.SWTMenuBar;
 import org.herac.tuxguitar.ui.swt.menu.SWTPopupMenu;
 import org.herac.tuxguitar.ui.swt.resource.SWTResourceFactory;
 import org.herac.tuxguitar.ui.swt.toolbar.SWTToolBar;
+import org.herac.tuxguitar.ui.swt.widget.SWTBrowser;
 import org.herac.tuxguitar.ui.swt.widget.SWTButton;
 import org.herac.tuxguitar.ui.swt.widget.SWTCanvas;
 import org.herac.tuxguitar.ui.swt.widget.SWTCheckBox;
@@ -66,6 +67,7 @@ import org.herac.tuxguitar.ui.swt.widget.SWTToggleButton;
 import org.herac.tuxguitar.ui.swt.widget.SWTWindow;
 import org.herac.tuxguitar.ui.swt.widget.SWTWrapLabel;
 import org.herac.tuxguitar.ui.toolbar.UIToolBar;
+import org.herac.tuxguitar.ui.widget.UIBrowser;
 import org.herac.tuxguitar.ui.widget.UIButton;
 import org.herac.tuxguitar.ui.widget.UICanvas;
 import org.herac.tuxguitar.ui.widget.UICheckBox;
@@ -375,5 +377,10 @@ public class SWTFactory implements UIFactory {
 
 	public UIImage createImage(InputStream inputStream) {
 		return this.resourceFactory.createImage(inputStream);
+	}
+
+	@SuppressWarnings("unchecked")
+	public UIBrowser createBrowser(UIWindow parent) {
+		return new SWTBrowser((SWTContainer<Composite>) parent);
 	}
 }

--- a/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/widget/SWTBrowser.java
+++ b/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/widget/SWTBrowser.java
@@ -1,0 +1,21 @@
+package org.herac.tuxguitar.ui.swt.widget;
+
+import java.net.URL;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.widgets.Composite;
+import org.herac.tuxguitar.ui.widget.UIBrowser;
+
+public class SWTBrowser extends SWTControl<Browser> implements UIBrowser {
+
+	public SWTBrowser(SWTContainer<? extends Composite> parent) {
+		super(new Browser(parent.getControl(), SWT.NONE), parent);
+	}
+
+	@Override
+	public void loadUrl(URL url) {
+		this.getControl().setUrl(url.toString());
+	}
+
+}

--- a/TuxGuitar-ui-toolkit/src/org/herac/tuxguitar/ui/UIFactory.java
+++ b/TuxGuitar-ui-toolkit/src/org/herac/tuxguitar/ui/UIFactory.java
@@ -10,6 +10,7 @@ import org.herac.tuxguitar.ui.menu.UIPopupMenu;
 import org.herac.tuxguitar.ui.resource.UIResourceFactory;
 import org.herac.tuxguitar.ui.toolbar.UIToolBar;
 import org.herac.tuxguitar.ui.widget.UIButton;
+import org.herac.tuxguitar.ui.widget.UIBrowser;
 import org.herac.tuxguitar.ui.widget.UICanvas;
 import org.herac.tuxguitar.ui.widget.UICheckBox;
 import org.herac.tuxguitar.ui.widget.UICheckTable;
@@ -138,4 +139,6 @@ public interface UIFactory extends UIResourceFactory {
 	UIDirectoryChooser createDirectoryChooser(UIWindow parent);
 	
 	UIPrinterChooser createPrinterChooser(UIWindow parent);
+	
+	UIBrowser createBrowser(UIWindow parent);
 }

--- a/TuxGuitar-ui-toolkit/src/org/herac/tuxguitar/ui/widget/UIBrowser.java
+++ b/TuxGuitar-ui-toolkit/src/org/herac/tuxguitar/ui/widget/UIBrowser.java
@@ -1,0 +1,9 @@
+package org.herac.tuxguitar.ui.widget;
+
+import java.net.URL;
+
+public interface UIBrowser extends UIControl {
+	
+	void loadUrl(URL url);
+	
+}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/documentation/TGDocumentationDialog.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/documentation/TGDocumentationDialog.java
@@ -6,10 +6,16 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 
+import org.herac.tuxguitar.app.TuxGuitar;
 import org.herac.tuxguitar.app.ui.TGApplication;
 import org.herac.tuxguitar.app.util.TGFileUtils;
 import org.herac.tuxguitar.app.view.controller.TGViewContext;
+import org.herac.tuxguitar.app.view.util.TGDialogUtil;
 import org.herac.tuxguitar.resource.TGResourceManager;
+import org.herac.tuxguitar.ui.UIFactory;
+import org.herac.tuxguitar.ui.layout.UITableLayout;
+import org.herac.tuxguitar.ui.widget.UIBrowser;
+import org.herac.tuxguitar.ui.widget.UIWindow;
 import org.herac.tuxguitar.util.TGException;
 
 public class TGDocumentationDialog {
@@ -24,14 +30,26 @@ public class TGDocumentationDialog {
 	}
 	
 	public void show() {
+		final UIFactory uiFactory = TGApplication.getInstance(context.getContext()).getFactory();
+		final UIWindow uiParent = context.getAttribute(TGViewContext.ATTRIBUTE_PARENT);
+		final UITableLayout dialogLayout = new UITableLayout();
+		final UIWindow dialog = uiFactory.createWindow(uiParent, false, true);
+		UIBrowser browser;
+		
+		dialog.setLayout(dialogLayout);
+		dialog.setText(TuxGuitar.getProperty("help.doc"));
+		
 		try {
 			URL url = getIndexUrl();
-			if( url != null ){
-				TGApplication.getInstance(this.context.getContext()).getApplication().openUrl(url);
-			}
+			browser = uiFactory.createBrowser(dialog);
+			browser.loadUrl(url);
 		} catch (Throwable throwable ) {
 			throw new TGException(throwable);
 		}
+		
+		dialogLayout.set(browser, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
+		
+		TGDialogUtil.openDialog(dialog,TGDialogUtil.OPEN_STYLE_CENTER | TGDialogUtil.OPEN_STYLE_LAYOUT);
 	}
 	
 	private URL getIndexUrl() throws Throwable{

--- a/build-scripts/tuxguitar-freebsd-jfx-x86_64/pom.xml
+++ b/build-scripts/tuxguitar-freebsd-jfx-x86_64/pom.xml
@@ -148,6 +148,22 @@
 									<version>${javafx.version}</version>
 								</artifactItem>
 								<artifactItem>
+									<groupId>org.openjfx</groupId>
+									<artifactId>javafx-web</artifactId>
+									<destFileName>javafx-web.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+									<classifier>${javafx.platform}</classifier>
+									<version>${javafx.version}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.openjfx</groupId>
+									<artifactId>javafx-media</artifactId>
+									<destFileName>javafx-media.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+									<classifier>${javafx.platform}</classifier>
+									<version>${javafx.version}</version>
+								</artifactItem>
+								<artifactItem>
 									<groupId>com.itextpdf</groupId>
 									<artifactId>itextpdf</artifactId>
 									<destFileName>itext-pdf.jar</destFileName>

--- a/build-scripts/tuxguitar-linux-jfx-x86_64/pom.xml
+++ b/build-scripts/tuxguitar-linux-jfx-x86_64/pom.xml
@@ -148,6 +148,22 @@
 									<version>${javafx.version}</version>
 								</artifactItem>
 								<artifactItem>
+									<groupId>org.openjfx</groupId>
+									<artifactId>javafx-web</artifactId>
+									<destFileName>javafx-web.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+									<classifier>${javafx.platform}</classifier>
+									<version>${javafx.version}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.openjfx</groupId>
+									<artifactId>javafx-media</artifactId>
+									<destFileName>javafx-media.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+									<classifier>${javafx.platform}</classifier>
+									<version>${javafx.version}</version>
+								</artifactItem>
+								<artifactItem>
 									<groupId>com.itextpdf</groupId>
 									<artifactId>itextpdf</artifactId>
 									<destFileName>itext-pdf.jar</destFileName>

--- a/build-scripts/tuxguitar-macosx-jfx-cocoa-x86_64/pom.xml
+++ b/build-scripts/tuxguitar-macosx-jfx-cocoa-x86_64/pom.xml
@@ -149,6 +149,22 @@
 									<version>${javafx.version}</version>
 								</artifactItem>
 								<artifactItem>
+									<groupId>org.openjfx</groupId>
+									<artifactId>javafx-web</artifactId>
+									<destFileName>javafx-web.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/Contents/MacOS/lib</outputDirectory>
+									<classifier>${javafx.platform}</classifier>
+									<version>${javafx.version}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.openjfx</groupId>
+									<artifactId>javafx-media</artifactId>
+									<destFileName>javafx-media.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/Contents/MacOS/lib</outputDirectory>
+									<classifier>${javafx.platform}</classifier>
+									<version>${javafx.version}</version>
+								</artifactItem>
+								<artifactItem>
 									<groupId>com.itextpdf</groupId>
 									<artifactId>itextpdf</artifactId>
 									<destFileName>itext-pdf.jar</destFileName>

--- a/build-scripts/tuxguitar-windows-jfx-x86_64/pom.xml
+++ b/build-scripts/tuxguitar-windows-jfx-x86_64/pom.xml
@@ -147,6 +147,22 @@
 									<version>${javafx.version}</version>
 								</artifactItem>
 								<artifactItem>
+									<groupId>org.openjfx</groupId>
+									<artifactId>javafx-web</artifactId>
+									<destFileName>javafx-web.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+									<classifier>${javafx.platform}</classifier>
+									<version>${javafx.version}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.openjfx</groupId>
+									<artifactId>javafx-media</artifactId>
+									<destFileName>javafx-media.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+									<classifier>${javafx.platform}</classifier>
+									<version>${javafx.version}</version>
+								</artifactItem>
+								<artifactItem>
 									<groupId>com.itextpdf</groupId>
 									<artifactId>itextpdf</artifactId>
 									<destFileName>itext-pdf.jar</destFileName>


### PR DESCRIPTION
to remove dependency to external web browser
Specific use case for Ubuntu, where distro's web browser cannot access local resources
see #153

Limitations:
- pom files updated for all configurations, but only tested with Linux/JFX, Linux/SWT, Win10/SWT
- no embedded controls for navigation (e.g. back, forward)

The method "openUrl" of application object is now unused, but I did not remove it: it can be used in future versions to link to an external website for online help