### PR TITLE
restore FreeBSD/JFX build

### DIFF
--- a/misc/build_tuxguitar_from_source.sh
+++ b/misc/build_tuxguitar_from_source.sh
@@ -199,10 +199,11 @@ else
     SWT_JARF=/usr/local/share/java/classes/swt.jar
 
     # Ugly hack to also install JFX on FreeBSD
+    # pre-requisite, run as root: pkg install openjfx14
     JFX_VER=14.0.2.1
     JFX_DIR=$SW_DIR/OpenJFX
     mkdir -p $JFX_DIR
-    for JFX_PKG in javafx-base javafx-controls javafx-graphics; do
+    for JFX_PKG in javafx-base javafx-controls javafx-graphics javafx-web javafx-media; do
       if [ ! -e $JFX_DIR/$JFX_PKG-$JFX_VER.pom ]; then
         wget -P $JFX_DIR https://repo.maven.apache.org/maven2/org/openjfx/$JFX_PKG/$JFX_VER/$JFX_PKG-$JFX_VER.pom
         sed -i '.orig' -e 's/${javafx.platform}/freebsd/' $JFX_DIR/$JFX_PKG-$JFX_VER.pom


### PR DESCRIPTION
see #159 (especially [freebsd/jfx issue](https://github.com/helge17/tuxguitar/pull/159#issuecomment-1826788310)), and #153

I could not run this exact build script in my environment, but I performed the same steps manually. Then, build of FreeBSD/JavaFX version succeeded.
So, I recommend to check before merging.

note: I could not either test if the produced app works correctly (I just configured build environment in freebsd, but no x server yet)
