### PR TITLE
rework of tracks table colors

### DIFF
--- a/TuxGuitar/share/skins/Breeze-dark/skin.prop
+++ b/TuxGuitar/share/skins/Breeze-dark/skin.prop
@@ -1,12 +1,11 @@
-#table.background.0=${uiWidgetLightBackground}
-#table.background.1=${uiWidgetHighlightBackground}
-#table.background.2=${uiWidgetSelectedBackground}
-#table.background.3=${uiWidgetSelectedBackground}
-#
-#table.foreground.0=${uiWidgetLightForeground}
-#table.foreground.1=${uiWidgetHighlightForeground}
-#table.foreground.2=${uiWidgetSelectedForeground}
-#table.foreground.3=${uiWidgetSelectedForeground}
+# tracks table configurable colors: R,G,B
+#table.caret=
+#table.even-line.background=
+#table.even-line.foreground=
+#table.odd-line.background=
+#table.odd-line.foreground=
+#table.cell.background=
+#table.cell.rest-measure=
 #
 #widget.chordEditor.backgroundColor=${uiInputBackground}
 #widget.chordEditor.foregroundColor=${uiInputForeground}

--- a/TuxGuitar/share/skins/Breeze/skin.prop
+++ b/TuxGuitar/share/skins/Breeze/skin.prop
@@ -1,12 +1,11 @@
-#table.background.0=${uiWidgetLightBackground}
-#table.background.1=${uiWidgetHighlightBackground}
-#table.background.2=${uiWidgetSelectedBackground}
-#table.background.3=${uiWidgetSelectedBackground}
-#
-#table.foreground.0=${uiWidgetLightForeground}
-#table.foreground.1=${uiWidgetHighlightForeground}
-#table.foreground.2=${uiWidgetSelectedForeground}
-#table.foreground.3=${uiWidgetSelectedForeground}
+# tracks table configurable colors: R,G,B
+#table.caret=
+#table.even-line.background=
+#table.even-line.foreground=
+#table.odd-line.background=
+#table.odd-line.foreground=
+#table.cell.background=
+#table.cell.rest-measure=
 #
 #widget.chordEditor.backgroundColor=${uiInputBackground}
 #widget.chordEditor.foregroundColor=${uiInputForeground}

--- a/TuxGuitar/share/skins/Oxygen/skin.prop
+++ b/TuxGuitar/share/skins/Oxygen/skin.prop
@@ -1,12 +1,11 @@
-#table.background.0=${uiWidgetLightBackground}
-#table.background.1=${uiWidgetHighlightBackground}
-#table.background.2=${uiWidgetSelectedBackground}
-#table.background.3=${uiWidgetSelectedBackground}
-#
-#table.foreground.0=${uiWidgetLightForeground}
-#table.foreground.1=${uiWidgetHighlightForeground}
-#table.foreground.2=${uiWidgetSelectedForeground}
-#table.foreground.3=${uiWidgetSelectedForeground}
+# tracks table configurable colors: R,G,B
+#table.caret=
+#table.even-line.background=
+#table.even-line.foreground=
+#table.odd-line.background=
+#table.odd-line.foreground=
+#table.cell.background=
+#table.cell.rest-measure=
 #
 #widget.chordEditor.backgroundColor=${uiInputBackground}
 #widget.chordEditor.foregroundColor=${uiInputForeground}

--- a/TuxGuitar/share/skins/Symbolic-dark/skin.prop
+++ b/TuxGuitar/share/skins/Symbolic-dark/skin.prop
@@ -1,12 +1,11 @@
-#table.background.0=${uiWidgetLightBackground}
-#table.background.1=${uiWidgetHighlightBackground}
-#table.background.2=${uiWidgetSelectedBackground}
-#table.background.3=${uiWidgetSelectedBackground}
-#
-#table.foreground.0=${uiWidgetLightForeground}
-#table.foreground.1=${uiWidgetHighlightForeground}
-#table.foreground.2=${uiWidgetSelectedForeground}
-#table.foreground.3=${uiWidgetSelectedForeground}
+# tracks table configurable colors: R,G,B
+#table.caret=
+#table.even-line.background=
+#table.even-line.foreground=
+#table.odd-line.background=
+#table.odd-line.foreground=
+#table.cell.background=
+#table.cell.rest-measure=
 #
 #widget.chordEditor.backgroundColor=${uiInputBackground}
 #widget.chordEditor.foregroundColor=${uiInputForeground}

--- a/TuxGuitar/share/skins/Symbolic/skin.prop
+++ b/TuxGuitar/share/skins/Symbolic/skin.prop
@@ -1,12 +1,11 @@
-#table.background.0=${uiWidgetLightBackground}
-#table.background.1=${uiWidgetHighlightBackground}
-#table.background.2=${uiWidgetSelectedBackground}
-#table.background.3=${uiWidgetSelectedBackground}
-#
-#table.foreground.0=${uiWidgetLightForeground}
-#table.foreground.1=${uiWidgetHighlightForeground}
-#table.foreground.2=${uiWidgetSelectedForeground}
-#table.foreground.3=${uiWidgetSelectedForeground}
+# tracks table configurable colors: R,G,B
+#table.caret=
+#table.even-line.background=
+#table.even-line.foreground=
+#table.odd-line.background=
+#table.odd-line.foreground=
+#table.cell.background=
+#table.cell.rest-measure=
 #
 #widget.chordEditor.backgroundColor=${uiInputBackground}
 #widget.chordEditor.foregroundColor=${uiInputForeground}

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableCanvasPainter.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableCanvasPainter.java
@@ -5,13 +5,10 @@ import org.herac.tuxguitar.graphics.control.TGLayout;
 import org.herac.tuxguitar.graphics.control.TGMeasureImpl;
 import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.ui.resource.UIColor;
-import org.herac.tuxguitar.ui.resource.UIColorModel;
 import org.herac.tuxguitar.ui.resource.UIPainter;
 import org.herac.tuxguitar.util.TGBeatRange;
 
 public class TGTableCanvasPainter {
-	
-	private static final UIColorModel COLOR_BLACK = new UIColorModel(0x00, 0x00, 0x00);
 	
 	private TGTableViewer viewer;
 	private TGTrack track;
@@ -29,8 +26,7 @@ public class TGTableCanvasPainter {
 		float width = row.getPainter().getBounds().getWidth();
 		boolean playing = TuxGuitar.getInstance().getPlayer().isRunning();
 		
-		UIColor colorBlack = this.viewer.getUIFactory().createColor(COLOR_BLACK);
-		UIColor colorBackground = this.viewer.getColorModel().createBackground(this.viewer.getContext(), 3);
+		UIColor colorBackground = this.viewer.getColorModel().getColor(TGTableColorModel.CELL_BACKGROUND);
 		
 		painter.setLineWidth(UIPainter.THINNEST_LINE_WIDTH);
 		painter.setBackground(colorBackground);
@@ -40,8 +36,6 @@ public class TGTableCanvasPainter {
 		painter.closePath();
 		
 		UIColor trackColor = this.viewer.getUIFactory().createColor(this.track.getColor().getR(), this.track.getColor().getG(), this.track.getColor().getB());
-		painter.setBackground(trackColor);
-		painter.setForeground(trackColor);
 
 		TGLayout layout = viewer.getEditor().getTablature().getViewLayout();
 		TGBeatRange beatRange = viewer.getEditor().getTablature().getSelector().getBeatRange();
@@ -51,19 +45,20 @@ public class TGTableCanvasPainter {
 		for(int j = 0;j < count;j++){
 			TGMeasureImpl measure = (TGMeasureImpl) this.track.getMeasure(j);
 			if(isRestMeasure(measure)){
-				painter.initPath(UIPainter.PATH_DRAW);
-				painter.setAntialias(false);
-				painter.addRectangle(x, y, size - 2, size - 1);
-				painter.closePath();
+				painter.setBackground(viewer.getColorModel().getColor(TGTableColorModel.CELL_REST_MEASURE));
+				painter.setForeground(viewer.getColorModel().getColor(TGTableColorModel.CELL_REST_MEASURE));
 			}else{
-				painter.initPath(UIPainter.PATH_FILL);
-				painter.setAntialias(false);
-				painter.addRectangle(x,y,size - 1,size );
-				painter.closePath();
+				painter.setBackground(trackColor);
+				painter.setForeground(trackColor);
 			}
+			painter.initPath(UIPainter.PATH_FILL);
+			painter.setAntialias(false);
+			painter.addRectangle(x,y,size - 1,size );
+			painter.closePath();
+			
 			boolean hasCaret = TuxGuitar.getInstance().getTablatureEditor().getTablature().getCaret().getMeasure().equals(measure);
 			if((playing && measure.isPlaying(this.viewer.getEditor().getTablature().getViewLayout())) || (!playing && hasCaret)){
-				painter.setBackground(colorBlack);
+				painter.setBackground(viewer.getColorModel().getColor(TGTableColorModel.CARET));
 				painter.initPath(UIPainter.PATH_FILL);
 				painter.setAntialias(false);
 				painter.addRectangle(x + 4, y + 4, size - 9, size - 8);
@@ -85,8 +80,6 @@ public class TGTableCanvasPainter {
 		}
 		
 		trackColor.dispose();
-		colorBackground.dispose();
-		colorBlack.dispose();
 	}
 	
 	private boolean isRestMeasure(TGMeasureImpl measure){

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableColorModel.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableColorModel.java
@@ -1,8 +1,11 @@
 package org.herac.tuxguitar.app.view.component.table;
 
+import java.util.HashMap;
+
 import org.herac.tuxguitar.app.system.icons.TGSkinManager;
 import org.herac.tuxguitar.app.system.properties.TGPropertiesUIUtil;
 import org.herac.tuxguitar.app.ui.TGApplication;
+import org.herac.tuxguitar.ui.UIFactory;
 import org.herac.tuxguitar.ui.appearance.UIAppearance;
 import org.herac.tuxguitar.ui.appearance.UIColorAppearance;
 import org.herac.tuxguitar.ui.resource.UIColor;
@@ -12,8 +15,19 @@ import org.herac.tuxguitar.util.properties.TGProperties;
 
 public class TGTableColorModel {
 	
-	private UIColorModel[] backgrounds;
-	private UIColorModel[] foregrounds;
+	public static final int DEFAULT = 0;
+	public static final int CARET = 1;
+	public static final int HEADER = 2;
+	public static final int EVEN_LINE_BACKGROUND = 3;
+	public static final int EVEN_LINE_FOREGROUND = 4;
+	public static final int ODD_LINE_BACKGROUND = 5;
+	public static final int ODD_LINE_FOREGROUND = 6;
+	public static final int SELECTED_LINE_BACKGROUND = 7;
+	public static final int SELECTED_LINE_FOREGROUND = 8;
+	public static final int CELL_BACKGROUND = 9;
+	public static final int CELL_REST_MEASURE = 10;
+	
+	private UIColor[] colors;
 	
 	public TGTableColorModel() {
 		super();
@@ -22,53 +36,52 @@ public class TGTableColorModel {
 	public void resetColors(TGContext context) {
 		UIAppearance appearance = TGApplication.getInstance(context).getAppearance();;
 		TGProperties properties = TGSkinManager.getInstance(context).getCurrentSkinProperties();
+		UIFactory factory = TGApplication.getInstance(context).getFactory();
+		UIColorModel[] colorModels = new UIColorModel[11];
+
+		// names of properties which are configurable by skin
+		HashMap<Integer, String> colorProperties = new HashMap<Integer, String>();
+		colorProperties.put(CARET, "table.caret");
+		colorProperties.put(EVEN_LINE_BACKGROUND, "table.even-line.background");
+		colorProperties.put(EVEN_LINE_FOREGROUND, "table.even-line.foreground");
+		colorProperties.put(ODD_LINE_BACKGROUND, "table.odd-line.background");
+		colorProperties.put(ODD_LINE_FOREGROUND, "table.odd-line.foreground");
+		colorProperties.put(CELL_BACKGROUND, "table.cell.background");
+		colorProperties.put(CELL_REST_MEASURE, "table.cell.rest-measure");
 		
-		UIColorModel[] defaultForegrounds = new UIColorModel[] {
-			appearance.getColorModel(UIColorAppearance.WidgetLightForeground),
-			appearance.getColorModel(UIColorAppearance.WidgetHighlightForeground),
-			appearance.getColorModel(UIColorAppearance.WidgetSelectedForeground),
-			appearance.getColorModel(UIColorAppearance.WidgetSelectedForeground),
-		};
+		// defaults
+		colorModels[DEFAULT] = new UIColorModel(0x00, 0x00, 0x00);	// BLACK
+		colorModels[CARET] = new UIColorModel(0x00, 0x00, 0x00);	// BLACK
+		colorModels[HEADER] = appearance.getColorModel(UIColorAppearance.WidgetBackground);
+		colorModels[EVEN_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetHighlightBackground);
+		colorModels[EVEN_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetHighlightForeground);
+		colorModels[ODD_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightBackground);
+		colorModels[ODD_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightForeground);
+		colorModels[SELECTED_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetSelectedBackground);
+		colorModels[SELECTED_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetSelectedForeground);
+		colorModels[CELL_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightBackground);
+		colorModels[CELL_REST_MEASURE] = appearance.getColorModel(UIColorAppearance.WidgetSelectedBackground);
 		
-		UIColorModel[] defaultBackgrounds = new UIColorModel[] {
-			appearance.getColorModel(UIColorAppearance.WidgetLightBackground),
-			appearance.getColorModel(UIColorAppearance.WidgetHighlightBackground),
-			appearance.getColorModel(UIColorAppearance.WidgetSelectedBackground),
-			appearance.getColorModel(UIColorAppearance.WidgetSelectedBackground),
-		};
-		
-		this.foregrounds = new UIColorModel[defaultForegrounds.length];
-		for(int i = 0 ; i < this.foregrounds.length; i ++) {
-			this.foregrounds[i] = TGPropertiesUIUtil.getColorModelValue(context, properties, ("table.foreground." + i), defaultForegrounds[i]);
+		// (re)define colors (override defaults by user parameter if relevant)
+		if (this.colors!=null) {
+			for (int i=0; i<this.colors.length; i++) {
+				if (this.colors[i]!=null) {
+					this.colors[i].dispose();
+				}
+			}
 		}
-		
-		this.backgrounds = new UIColorModel[defaultBackgrounds.length];
-		for(int i = 0 ; i < this.backgrounds.length; i ++) {
-			this.backgrounds[i] = TGPropertiesUIUtil.getColorModelValue(context, properties, ("table.background." + i), defaultBackgrounds[i]);
+		this.colors = new UIColor[colorModels.length];
+		for (int i=0; i<colorModels.length; i++) {
+			if (colorProperties.get(i)==null) {
+				this.colors[i] = factory.createColor(colorModels[i]);
+			} else {
+				this.colors[i] = factory.createColor(TGPropertiesUIUtil.getColorModelValue(context, properties, colorProperties.get(i), colorModels[i]));
+			}
 		}
 	}
 	
-	public UIColor createForeground(TGContext context, int index) {
-		return TGApplication.getInstance(context).getFactory().createColor(this.foregrounds[index]);
-	}
-	
-	public UIColor createBackground(TGContext context, int index) {
-		return TGApplication.getInstance(context).getFactory().createColor(this.backgrounds[index]);
-	}
-	
-	public UIColor[] createForegrounds(TGContext context) {
-		UIColor[] colors = new UIColor[this.foregrounds.length];
-		for(int i = 0 ; i < this.foregrounds.length; i ++) {
-			colors[i] = this.createForeground(context, i);
-		}
-		return colors;
-	}
-	
-	public UIColor[] createBackgrounds(TGContext context) {
-		UIColor[] colors = new UIColor[this.backgrounds.length];
-		for(int i = 0 ; i < this.backgrounds.length; i ++) {
-			colors[i] = this.createBackground(context, i);
-		}
-		return colors;
+	public UIColor getColor(int colorIndex) {
+		if (colorIndex < 0 || colorIndex >= this.colors.length) return (this.colors[DEFAULT]);
+		return(this.colors[colorIndex]);
 	}
 }

--- a/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableHeaderMeasures.java
+++ b/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableHeaderMeasures.java
@@ -93,10 +93,8 @@ public class TGTableHeaderMeasures implements TGTableHeader, TGBufferedPainterHa
 		TGSong song = tablature.getSong();
 		float markerMargin = 1.0f;
 		float markerSize = cellSize - 2 * markerMargin;
-		TGTableColorModel colorModel = this.table.getViewer().getColorModel();
-		UIColor colorBackground = colorModel.createBackground(this.table.getViewer().getContext(), 0);
-		UIColor colorForeground = colorModel.createForeground(this.table.getViewer().getContext(), 0);
-
+		UIColor colorBackground = this.table.getViewer().getColorModel().getColor(TGTableColorModel.HEADER);
+		
 		painter.setLineWidth(UIPainter.THINNEST_LINE_WIDTH);
 		painter.setBackground(colorBackground);
 		painter.initPath(UIPainter.PATH_FILL);
@@ -116,8 +114,6 @@ public class TGTableHeaderMeasures implements TGTableHeader, TGBufferedPainterHa
 						x + markerMargin, markerMargin, markerSize, markerSize);
 			}
 		}
-		colorBackground.dispose();
-		colorForeground.dispose();
 	}
 
 	public UICanvas getPaintableControl() {


### PR DESCRIPTION
Objective: less aggressive for the eye
(graphically inspired by 2.0beta fork)

before:
![before](https://github.com/helge17/tuxguitar/assets/129443524/d8d42b34-2186-4115-83fe-465d74b92aca)

after:
![after](https://github.com/helge17/tuxguitar/assets/129443524/c7b7586b-4134-4878-a6b3-c81949307c26)

Implementation: a complete rework of color model (hopefully simplified). Colors are now indexed with named variables instead of integers. At least it clarifies which color goes where.
Configuration per skin is kept (more clear now), even if currently unused