### PR TITLE
remove links to external web pages from help, authors updated

### DIFF
--- a/TuxGuitar/share/help/about.html
+++ b/TuxGuitar/share/help/about.html
@@ -88,9 +88,9 @@
         <h2>Description</h2>
         <p>TuxGuitar is a multitrack tablature editor and player written in Java using SWT Graphic libraries. It is a multi-platform application available for Linux, Windows, MacOS, FreeBSD and other operating systems. TuxGuitar is open-source software, released under the GNU Lesser General Public License.</p>
         <h2>Website</h2>
-        <p>You should check TuxGuitar project website on <b><a href="https://github.com/helge17/tuxguitar">https://github.com/helge17/tuxguitar</a></b>.</p>
+        <p>You should check TuxGuitar project website on <b>https://github.com/helge17/tuxguitar</b>.</p>
         <h2>Source repository</h2>
-        <p>TuxGuitar source repository can be browsed on <b><a href="https://github.com/helge17/tuxguitar">https://github.com/helge17/tuxguitar</a></b>.</p>
+        <p>TuxGuitar source repository can be browsed on <b>https://github.com/helge17/tuxguitar</b>.</p>
         <h2>Contribution</h2>
         <p>If you have sufficient skills and some ideas, you are free to join the project.</p>
         <h2>Authors</h2><br />
@@ -104,6 +104,11 @@
         <ul>
           <li>Developer</li>
           <li>Web Page:&nbsp;<b>https://www.herac.com.ar/</b></li>
+        </ul>
+        <h4>Guiv42</h4>
+        <ul>
+          <li>Developer</li>
+          <li>Web Page:&nbsp;<b>https://github.com/guiv42</b></li>
         </ul>
         <h4>Nahuel Portilla</h4>
         <ul>
@@ -133,6 +138,12 @@
         <h4>Sascha Riemer</h4>
         <ul>
           <li>Lavender Icon Theme</li>
+        </ul>
+        <h4>Helge17</h4>
+        <ul>
+          <li>Binary builds</li>
+          <li>Breeze Theme</li>
+          <li>Web Page:&nbsp;<b>https://github.com/helge17</b></li>
         </ul>
         <h4>Auria</h4>
         <ul>
@@ -262,6 +273,11 @@
         <ul>
           <li>Bulgarian translation</li>
           <li>Web Page:&nbsp;<b>https://learnfree.eu/</b></li>
+        </ul>
+        <h4>Alejandro6626</h4>
+        <ul>
+          <li>Spanish translation</li>
+          <li>Web Page:&nbsp;<b>https://github.com/alejandro6626</b></li>
         </ul><br />
         <br />
       </td>

--- a/TuxGuitar/share/help/detail_measure_beat.html
+++ b/TuxGuitar/share/help/detail_measure_beat.html
@@ -108,8 +108,8 @@
         <p>The next three menu entries will change the note’s values to dotted, double-dotted, and a wide variety of "division type" values.</p>
         <p>If you do not understand the difference between the various note durations, you may want to research it a bit before you begin editing tabs, as you may find yourself quickly getting lost. Any basic music theory guide should cover these topics. A good starting place (as always) is the Wikipedia’s pages on music theory and music notation:</p>
         <ul>
-          <li><a href="https://en.wikipedia.org/wiki/Music_theory">https://en.wikipedia.org/wiki/Music_theory</a></li>
-          <li><a href="https://en.wikipedia.org/wiki/List_of_musical_symbols">https://en.wikipedia.org/wiki/List_of_musical_symbols</a></li>
+          <li><b>https://en.wikipedia.org/wiki/Music_theory</b></li>
+          <li><b>https://en.wikipedia.org/wiki/List_of_musical_symbols</b></li>
         </ul>
         <p>Clicking on the menu entriy <strong>Beat → Tied Note</strong> or the last icon in the Duration toolbar will "tie" the currently selected note to the one before it. This feature basically takes the value of two notes and combines them into one. The most common use for this feature is when you have a note that begins in one measure and ends in the next. Tying notes is really just a way of keeping the score clean and organized. If you need more information, you may want to research musical notation via the links above.</p>
         <h3 id="note_dynamics">Note dynamic</h3>


### PR DESCRIPTION
keeping the URLs as text, but removing  `<a>` tag

trade-off for security, now that doc is opened by embedded browser. A click on such a link and the embedded browser is in the wild, connected to Internet. If a vulnerability is discovered for embedded browser, it could have a severe impact on TuxGuitar's users, and most probably it would take a very long time before an eventual patch reaches all users of a TuxGuitar release. Since there is no control to enter a URL, this limits de facto the browser to the delivered files in local file-system, reducing the attack surface.

authors updated: that's for self-satisfaction ;)