### PR TITLE
fix midi import

### DIFF
--- a/common/TuxGuitar-midi/src/org/herac/tuxguitar/io/midi/MidiSongReader.java
+++ b/common/TuxGuitar-midi/src/org/herac/tuxguitar/io/midi/MidiSongReader.java
@@ -896,6 +896,7 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 			// try to find one string for each note in beat
 			List<TGNote> listNotes = beat.getVoice(0).getNotes();
 			Collections.sort(listNotes);
+			Collections.reverse(listNotes);
 			Iterator<TGNote> it = listNotes.iterator();
 			while(it.hasNext()){
 				TGNote note = (TGNote)it.next();


### PR DESCRIPTION
allocating notes on the lowest possible fret means on the highest possible string
so, notes should be allocated from highest to lowest to maximize chances to find a place for each note

see https://github.com/helge17/tuxguitar/issues/209#issuecomment-1902588352