### PR TITLE
workaround to avoid crash when pasting to track with less strings

### DIFF
--- a/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/measure/TGPasteMeasureAction.java
+++ b/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/measure/TGPasteMeasureAction.java
@@ -61,6 +61,12 @@ public class TGPasteMeasureAction extends TGActionBase{
 						int fromNumber = measure.getNumber();
 						long theMove = (measure.getStart() - first.getStart());
 
+						// TODO, BUG here: source and destination tracks may not have the same tuning
+						// even not the same number of strings
+						// yet, measures are pasted: measure contains beats, beat contains voices, voice contains notes, note contains (string number + fret number)
+						// if not the same tuning, notes can change
+						// also possible to create a note on the 5th string of a 4 string instrument
+						
 						segment = segment.clone(songManager.getFactory());
 						helper.insertMeasures(song, segment, fromNumber, theMove, toTrack);
 					}

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGNote.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGNote.java
@@ -14,7 +14,7 @@ import org.herac.tuxguitar.song.factory.TGFactory;
  * TODO To change the template for this generated type comment go to Window - Preferences - Java - Code Style - Code Templates
  */
 public abstract class TGNote implements Comparable<TGNote>{
-	private int value;
+	private int value;		// fret number
 	private int velocity;
 	private int string;
 	private boolean tiedNote;
@@ -87,6 +87,7 @@ public abstract class TGNote implements Comparable<TGNote>{
 		return note;
 	}
 	
+	// sort by "value": sort by fret number, useful to sort notes on the same string only
 	public int compareTo(TGNote note) {
 		return Integer.valueOf(this.value).compareTo(Integer.valueOf(note.getValue()));
 	}


### PR DESCRIPTION
See #218

this is NOT a fix
just a workaround, to avoid creating notes on non-existing strings when copy-pasting between different tracks

bug remains: what is finally pasted is a list of (string number, fret number)
so, if source and destination tracks don't have the same tuning, notes pitch change

Before this workaround:
- create a note on lowest string of a standard tuned guitar
- select beat, copy
- in a standard tuned bass track, paste: permanent error message

With this workaround, notes can be lost but app should no more crash

still some significant job TODO (see added comments)

no impact on android app
(only comments added in modules common to desktop/android)