### PR TITLE
workaround for an external bug

### DIFF
--- a/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/widget/SWTCheckBox.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/widget/SWTCheckBox.java
@@ -60,4 +60,14 @@ public class SWTCheckBox extends SWTControl<Button> implements UICheckBox {
 			this.getControl().removeSelectionListener(this.selectionListener);
 		}
 	}
+
+	// 01/2024, workaround for an external bug visible in Linux SWT/KDE configuration
+	// to be deleted one day
+	// see https://github.com/helge17/tuxguitar/issues/52
+	@Override
+	public void computePackedSize(Float fixedWidth, Float fixedHeight) {
+		super.computePackedSize(fixedWidth, fixedHeight);
+		this.packedSize.setWidth(this.packedSize.getWidth() + 10.0f);
+	}
+
 }

--- a/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/widget/SWTControl.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/widget/SWTControl.java
@@ -58,7 +58,7 @@ public abstract class SWTControl<T extends Control> extends SWTEventReceiver<T> 
 	private SWTFocusListenerManager focusListener;
 	private SWTZoomListenerManager zoomListener;
 	
-	private UISize packedSize;
+	protected UISize packedSize;
 	private UIColor bgColor;
 	private UIColor fgColor;
 	private UIFont font;

--- a/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/widget/SWTRadioButton.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/widget/SWTRadioButton.java
@@ -60,4 +60,14 @@ public class SWTRadioButton extends SWTControl<Button> implements UIRadioButton 
 			this.getControl().removeSelectionListener(this.selectionListener);
 		}
 	}
+
+	// 01/2024, workaround for an external bug visible in Linux SWT/KDE configuration
+	// to be deleted one day
+	// see https://github.com/helge17/tuxguitar/issues/52
+	@Override
+	public void computePackedSize(Float fixedWidth, Float fixedHeight) {
+		super.computePackedSize(fixedWidth, fixedHeight);
+		this.packedSize.setWidth(this.packedSize.getWidth() + 10.0f);
+	}
+
 }


### PR DESCRIPTION
See #52
in SWT configuration, with some versions of Linux/KDE, estimated width of checkboxes and radio buttons by SWT is underestimated
This results in truncated strings shown to user

This is NOT a fix, just a workaround.
To be removed one day when external issue is fixed

Consequence: some controls may have an extra (useless) margin of 10px on other platforms (Windows, mac, freebsd).
I tried to add a parameter, so that the workaround would only apply to Linux version, but this would have required to add some dependencies between modules in pom files, I think it's not worth it.