### PR TITLE
avoid a crash when deleting track with an active selection

### DIFF
--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateRemovedTrackController.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateRemovedTrackController.java
@@ -3,6 +3,7 @@ package org.herac.tuxguitar.app.action.listener.cache.controller;
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.app.TuxGuitar;
 import org.herac.tuxguitar.app.view.component.tab.Caret;
+import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.track.TGRemoveTrackAction;
 import org.herac.tuxguitar.song.models.TGTrack;
@@ -18,6 +19,9 @@ public class TGUpdateRemovedTrackController extends TGUpdateSongController {
 	public void update(final TGContext context, TGActionContext actionContext) {
 		if( Boolean.TRUE.equals( actionContext.getAttribute(TGRemoveTrackAction.ATTRIBUTE_SUCCESS)) ) {			
 			final TGTrack tgTrack = (TGTrack) actionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
+			
+			// clear selection (corresponding track may have been deleted)
+			TablatureEditor.getInstance(context).getTablature().getSelector().clearSelection();
 			
 			// Update caret position to previous track
 			this.findUpdateBuffer(context, actionContext).doPostUpdate(new Runnable() {


### PR DESCRIPTION
fix #227
clear selection *after* removing track, in update controller, so before updating display (where the crash occurred)

It would have been cleaner to clear selection *before* removing track, ideally only if selection was active on the track to be removed

but TGRemoveTrackAction is in tuxguitar-editor-utils, where it cannot access Selector (in tuxguitar module), and cannot call Selector.clearSelection()
So this would require to reallocate all classes related to click&drag feature to different modules

(note: bug was back-ported from 2.0beta fork, together with click&drag feature)