### PR TITLE
copy-paste: adapation to different tuning presets

### DIFF
--- a/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/measure/TGPasteMeasureAction.java
+++ b/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/measure/TGPasteMeasureAction.java
@@ -60,13 +60,6 @@ public class TGPasteMeasureAction extends TGActionBase{
 					} else if( pasteMode.equals(TRANSFER_TYPE_INSERT)) {
 						int fromNumber = measure.getNumber();
 						long theMove = (measure.getStart() - first.getStart());
-
-						// TODO, BUG here: source and destination tracks may not have the same tuning
-						// even not the same number of strings
-						// yet, measures are pasted: measure contains beats, beat contains voices, voice contains notes, note contains (string number + fret number)
-						// if not the same tuning, notes can change
-						// also possible to create a note on the 5th string of a 4 string instrument
-						
 						segment = segment.clone(songManager.getFactory());
 						helper.insertMeasures(song, segment, fromNumber, theMove, toTrack);
 					}

--- a/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/clipboard/TGClipboard.java
+++ b/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/clipboard/TGClipboard.java
@@ -8,9 +8,8 @@ import org.herac.tuxguitar.util.singleton.TGSingletonUtil;
 
 public class TGClipboard {
 	
-	private TGSongSegment segment;
-
-	private TGStoredBeatList beats;
+	private TGSongSegment segment;		// if measures are copied
+	private TGStoredBeatList beats;		// if selection is copied
 	
 	private TGClipboard() {
 		super();
@@ -23,7 +22,7 @@ public class TGClipboard {
 	public TGStoredBeatList getBeats() {
 		return beats;
 	}
-
+	
 	public boolean hasContents() {
 		return this.segment != null || this.beats != null;
 	}

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGSongSegment.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGSongSegment.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.herac.tuxguitar.song.factory.TGFactory;
 import org.herac.tuxguitar.song.models.TGMeasure;
 import org.herac.tuxguitar.song.models.TGMeasureHeader;
+import org.herac.tuxguitar.song.models.TGString;
 
 public class TGSongSegment {
 	
@@ -25,8 +26,12 @@ public class TGSongSegment {
 		return this.tracks;
 	}
 	
-	public void addTrack(int track, List<TGMeasure> measures){
-		this.tracks.add(new TGTrackSegment(track, measures));
+	public void addTrack(int track, List<TGMeasure> measures, List<TGString> strings, boolean isPercussionTrack){
+		List<Integer> trackStringsValues = new ArrayList<Integer>();
+		for (TGString string : strings) {
+			trackStringsValues.add(string.getValue());
+		}
+		this.tracks.add(new TGTrackSegment(track, measures, trackStringsValues, isPercussionTrack));
 	}
 	
 	public boolean isEmpty(){

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGStoredBeatList.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGStoredBeatList.java
@@ -2,33 +2,57 @@ package org.herac.tuxguitar.song.helpers;
 
 import org.herac.tuxguitar.song.factory.TGFactory;
 import org.herac.tuxguitar.song.models.TGBeat;
+import org.herac.tuxguitar.song.models.TGString;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class TGStoredBeatList {
-    private List<TGBeat> beats;
-    private long length = 0;
-
-    public TGStoredBeatList(List<TGBeat> range, TGFactory factory) {
-        this.beats = new ArrayList<>();
-        long first = -1;
-        for (TGBeat beat : range) {
-            if (first == -1) {
-                first = beat.getStart();
-            }
-            beat = beat.clone(factory);
-            beat.setStart(beat.getStart() - first);
-            beat.setMeasure(null);
-            this.length += beat.getVoice(0).getDuration().getTime();
-            this.beats.add(beat);
-        }
-    }
-
-    public List<TGBeat> getBeats() {
-        return beats;
-    }
-
-    public long getLength() {
-        return length;
-    }
+	private List<TGBeat> beats;
+	private long length = 0;
+	private List<Integer> stringValues;
+	private boolean isPercussionTrack;
+	
+	public TGStoredBeatList(List<TGBeat> range, List<TGString> strings, boolean isPercussionTrack, TGFactory factory) {
+		this.beats = new ArrayList<>();
+		long first = -1;
+		for (TGBeat beat : range) {
+			if (first == -1) {
+				first = beat.getStart();
+			}
+			beat = beat.clone(factory);
+			beat.setStart(beat.getStart() - first);
+			beat.setMeasure(null);
+			this.length += beat.getVoice(0).getDuration().getTime();
+			this.beats.add(beat);
+		}
+		this.stringValues = new ArrayList<Integer>();
+		if (strings!=null) {
+			for (TGString string : strings) {
+				this.stringValues.add(string.getValue());
+			}
+		}
+		this.isPercussionTrack = isPercussionTrack;
+	}
+	
+	public List<TGBeat> getBeats() {
+		return beats;
+	}
+	public long getLength() {
+		return length;
+	}
+	
+	public List<Integer> getStringValues() {
+		return stringValues;
+	}
+	
+	public boolean isPercussionTrack() {
+		return isPercussionTrack;
+	}
+	
+	public TGStoredBeatList clone(TGFactory factory) {
+		TGStoredBeatList clone = new TGStoredBeatList(this.beats, null, this.isPercussionTrack, factory);
+		clone.stringValues = new ArrayList<Integer>(this.stringValues);
+		return clone;
+	}
 }

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGTrackSegment.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGTrackSegment.java
@@ -10,10 +10,14 @@ import org.herac.tuxguitar.song.models.TGMeasureHeader;
 public class TGTrackSegment {
 	private int track;
 	private List<TGMeasure> measures;
+	private List<Integer> stringValues;
+	private boolean isPercussionTrack;
 	
-	public TGTrackSegment(int track, List<TGMeasure> measures){
+	public TGTrackSegment(int track, List<TGMeasure> measures, List<Integer> stringValues, boolean isPercussionTrack){
 		this.track = track;
 		this.measures = measures;
+		this.stringValues = new ArrayList<Integer>(stringValues);
+		this.isPercussionTrack = isPercussionTrack;
 	}
 	
 	public List<TGMeasure> getMeasures() {
@@ -24,12 +28,20 @@ public class TGTrackSegment {
 		return this.track;
 	}
 	
+	public List<Integer> getStringValues() {
+		return this.stringValues;
+	}
+	
+	public boolean isPercussionTrack() {
+		return this.isPercussionTrack;
+	}
+	
 	public Object clone(TGFactory factory,List<TGMeasureHeader> headers){
 		List<TGMeasure> measures = new ArrayList<TGMeasure>();
 		for(int i = 0;i < getMeasures().size();i++){
 			TGMeasure measure = getMeasures().get(i);
 			measures.add(measure.clone(factory, headers.get(i)));
 		}
-		return new TGTrackSegment(getTrack(),measures);
+		return new TGTrackSegment(getTrack(), measures, getStringValues(), isPercussionTrack());
 	}
 }

--- a/desktop/TuxGuitar-test/src/org/herac/tuxguitar/test/TGTestAllocateNotesToStrings.java
+++ b/desktop/TuxGuitar-test/src/org/herac/tuxguitar/test/TGTestAllocateNotesToStrings.java
@@ -1,0 +1,259 @@
+package org.herac.tuxguitar.test;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.herac.tuxguitar.song.factory.TGFactory;
+import org.herac.tuxguitar.song.managers.TGSongManager;
+import org.herac.tuxguitar.song.managers.TGTrackManager;
+import org.herac.tuxguitar.song.models.TGBeat;
+import org.herac.tuxguitar.song.models.TGNote;
+import org.herac.tuxguitar.song.models.TGString;
+import org.herac.tuxguitar.song.models.TGVoice;
+
+public class TGTestAllocateNotesToStrings {
+	
+	private static TGString stringE2;
+	private static TGString stringA2;
+	private static TGString stringD3;
+	private static TGString stringG3;
+	private static TGString stringB3;
+	private static TGString stringE4;
+	private static TGFactory factory;
+	
+	@BeforeAll
+	static void init() {
+		factory = new TGFactory();
+		stringE2 = factory.newString();
+		stringE2.setValue(40);
+		stringA2 = factory.newString();
+		stringA2.setValue(45);
+		stringD3 = factory.newString();
+		stringD3.setValue(50);
+		stringG3 = factory.newString();
+		stringG3.setValue(55);
+		stringB3 = factory.newString();
+		stringB3.setValue(59);
+		stringE4 = factory.newString();
+		stringE4.setValue(64);
+		
+	}
+	
+	@Test
+	public void move1note() {
+		TGTrackManager trackManager = new TGTrackManager(new TGSongManager());
+		
+		List<Integer> fromStrings = new ArrayList<Integer>();
+		fromStrings.add(stringA2.getValue());
+		
+		TGBeat beat = factory.newBeat();
+		TGNote noteA2 = factory.newNote();
+		noteA2.setString(1);
+		noteA2.setValue(0);
+		beat.getVoice(0).addNote(noteA2);
+		List<TGBeat> beats = new ArrayList<TGBeat>();
+		beats.add(beat);
+		
+		stringE2.setNumber(1);
+		List<TGString> toStrings = new ArrayList<TGString>();
+		toStrings.add(stringE2);
+		
+		trackManager.allocateNotesToStrings(fromStrings, beats, toStrings);
+		
+		assertEquals(1, beats.get(0).getVoice(0).countNotes());
+		assertEquals(1, beats.get(0).getVoice(0).getNote(0).getString());
+		assertEquals(5, beats.get(0).getVoice(0).getNote(0).getValue());
+	}
+
+	@Test
+	public void move1chord() {
+		TGTrackManager trackManager = new TGTrackManager(new TGSongManager());
+
+		List<Integer> fromStrings = new ArrayList<Integer>();
+		fromStrings.add(stringG3.getValue());
+		fromStrings.add(stringD3.getValue());
+		
+		TGBeat beat = factory.newBeat();
+		TGNote noteG3 = factory.newNote();
+		noteG3.setString(1);
+		noteG3.setValue(0);
+		beat.getVoice(0).addNote(noteG3);
+		TGNote noteE3 = factory.newNote();
+		noteE3.setString(2);
+		noteE3.setValue(2);
+		beat.getVoice(0).addNote(noteE3);
+
+		List<TGBeat> beats = new ArrayList<TGBeat>();
+		beats.add(beat);
+		
+		stringA2.setNumber(1);
+		stringE2.setNumber(2);
+		List<TGString> toStrings = new ArrayList<TGString>();
+		toStrings.add(stringA2);
+		toStrings.add(stringE2);
+		
+		trackManager.allocateNotesToStrings(fromStrings, beats, toStrings);
+		
+		TGVoice voice = beats.get(0).getVoice(0);
+		assertEquals(2, voice.countNotes());
+		assertTrue(beatContainsNote(beats.get(0), 1, 10));
+		assertTrue(beatContainsNote(beats.get(0), 2, 12));
+		
+		// same test, but different order of notes in original chord
+		while (voice.countNotes() > 0) {
+			voice.removeNote(voice.getNote(0));
+		}
+		beat.getVoice(0).addNote(noteE3);
+		beat.getVoice(0).addNote(noteG3);
+		beats.clear();
+		beats.add(beat);
+
+		trackManager.allocateNotesToStrings(fromStrings, beats, toStrings);
+		
+		voice = beats.get(0).getVoice(0);
+		assertEquals(2, voice.countNotes());
+		assertTrue(beatContainsNote(beats.get(0), 1, 10));
+		assertTrue(beatContainsNote(beats.get(0), 2, 12));
+		
+	}
+	
+	@Test
+	public void distributeNotes() {
+		TGTrackManager trackManager = new TGTrackManager(new TGSongManager());
+
+		List<Integer> fromStrings = new ArrayList<Integer>();
+		fromStrings.add(0);
+
+		// all notes of a major A chord on 5th fret, allocated to string with value zero
+		TGBeat beat = factory.newBeat();
+		TGNote noteA4 = factory.newNote();
+		noteA4.setString(1);
+		noteA4.setValue(69);
+		beat.getVoice(0).addNote(noteA4);
+		TGNote noteE4 = factory.newNote();
+		noteE4.setString(1);
+		noteE4.setValue(64);
+		beat.getVoice(0).addNote(noteE4);
+		TGNote noteC3sharp = factory.newNote();
+		noteC3sharp.setString(1);
+		noteC3sharp.setValue(61);
+		beat.getVoice(0).addNote(noteC3sharp);
+		TGNote noteA3 = factory.newNote();
+		noteA3.setString(1);
+		noteA3.setValue(57);
+		beat.getVoice(0).addNote(noteA3);
+		TGNote noteE3 = factory.newNote();
+		noteE3.setString(1);
+		noteE3.setValue(52);
+		beat.getVoice(0).addNote(noteE3);
+		TGNote noteA2 = factory.newNote();
+		noteA2.setString(1);
+		noteA2.setValue(45);
+		beat.getVoice(0).addNote(noteA2);
+		
+		List<TGBeat> beats = new ArrayList<TGBeat>();
+		beats.add(beat);
+
+		stringE4.setNumber(1);
+		stringB3.setNumber(2);
+		stringG3.setNumber(3);
+		stringD3.setNumber(4);
+		stringA2.setNumber(5);
+		stringE2.setNumber(6);
+		List<TGString> toStrings = new ArrayList<TGString>();
+		toStrings.add(stringE4);
+		toStrings.add(stringB3);
+		toStrings.add(stringG3);
+		toStrings.add(stringD3);
+		toStrings.add(stringA2);
+		toStrings.add(stringE2);
+
+		trackManager.allocateNotesToStrings(fromStrings, beats, toStrings);
+		
+		TGVoice voice = beats.get(0).getVoice(0);
+		assertEquals(6, voice.countNotes());
+		assertTrue(beatContainsNote(beats.get(0), 1, 5));
+		assertTrue(beatContainsNote(beats.get(0), 2, 5));
+		assertTrue(beatContainsNote(beats.get(0), 3, 6));
+		assertTrue(beatContainsNote(beats.get(0), 4, 7));
+		assertTrue(beatContainsNote(beats.get(0), 5, 7));
+		assertTrue(beatContainsNote(beats.get(0), 6, 5));
+	}
+	
+	@Test
+	public void noTuningChange() {
+		TGTrackManager trackManager = new TGTrackManager(new TGSongManager());
+
+		List<Integer> fromStrings = new ArrayList<Integer>();
+		fromStrings.add(stringG3.getValue());
+		fromStrings.add(stringD3.getValue());
+		
+		TGBeat beat = factory.newBeat();
+		TGNote note = factory.newNote();
+		note.setString(2);
+		note.setValue(16);
+		beat.getVoice(0).addNote(note);
+
+		List<TGBeat> beats = new ArrayList<TGBeat>();
+		beats.add(beat);
+		
+		stringG3.setNumber(1);
+		stringD3.setNumber(2);
+		List<TGString> toStrings = new ArrayList<TGString>();
+		toStrings.add(stringG3);
+		toStrings.add(stringD3);
+		
+		trackManager.allocateNotesToStrings(fromStrings, beats, toStrings);
+		
+		TGVoice voice = beats.get(0).getVoice(0);
+		assertEquals(1, voice.countNotes());
+		assertTrue(beatContainsNote(beats.get(0), 2, 16));
+	}
+	
+	@Test
+	public void toTrackWithLessStrings() {
+		TGTrackManager trackManager = new TGTrackManager(new TGSongManager());
+
+		List<Integer> fromStrings = new ArrayList<Integer>();
+		fromStrings.add(stringG3.getValue());
+		fromStrings.add(stringD3.getValue());
+		
+		TGBeat beat = factory.newBeat();
+		TGNote noteG3 = factory.newNote();
+		noteG3.setString(1);
+		noteG3.setValue(0);
+		beat.getVoice(0).addNote(noteG3);
+		TGNote noteE3 = factory.newNote();
+		noteE3.setString(2);
+		noteE3.setValue(2);
+		beat.getVoice(0).addNote(noteE3);
+
+		List<TGBeat> beats = new ArrayList<TGBeat>();
+		beats.add(beat);
+		
+		stringA2.setNumber(1);
+		List<TGString> toStrings = new ArrayList<TGString>();
+		toStrings.add(stringA2);
+		
+		trackManager.allocateNotesToStrings(fromStrings, beats, toStrings);
+		
+		TGVoice voice = beats.get(0).getVoice(0);
+		assertEquals(1, voice.countNotes());
+		assertTrue(beatContainsNote(beats.get(0), 1, 10) || beatContainsNote(beats.get(0), 1, 7));
+	}
+	
+	private boolean beatContainsNote(TGBeat beat, int string, int value) {
+		for (int i=0; i<beat.countVoices(); i++) {
+			for (TGNote note : beat.getVoice(i).getNotes()) {
+				if (string==note.getString() && value==note.getValue()) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGCopyAction.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGCopyAction.java
@@ -7,6 +7,8 @@ import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
 import org.herac.tuxguitar.editor.clipboard.TGClipboard;
 import org.herac.tuxguitar.song.helpers.TGStoredBeatList;
+import org.herac.tuxguitar.song.managers.TGSongManager;
+import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.util.TGBeatRange;
 import org.herac.tuxguitar.util.TGContext;
 
@@ -21,7 +23,10 @@ public class TGCopyAction extends TGActionBase {
 	protected void processAction(TGActionContext tgActionContext){
 		if (Boolean.TRUE.equals(tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SELECTION_IS_ACTIVE))) {
 			TGBeatRange beats = tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT_RANGE);
-			TGClipboard.getInstance(this.getContext()).setData(new TGStoredBeatList(beats.getBeats(), getSongManager(tgActionContext).getFactory()));
+			TGTrack track = tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
+			TGSongManager songManager = getSongManager(tgActionContext);
+			TGClipboard.getInstance(this.getContext()).setData(
+				new TGStoredBeatList(beats.getBeats(), track.getStrings(), songManager.isPercussionChannel(track.getSong(), track.getChannelId()), songManager.getFactory()));
 		}
 		else {
 			TGActionManager.getInstance(this.getContext()).execute(TGOpenMeasureCopyDialogAction.NAME, tgActionContext);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGPasteAction.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGPasteAction.java
@@ -1,6 +1,5 @@
 package org.herac.tuxguitar.app.action.impl.edit;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.herac.tuxguitar.action.TGActionContext;
@@ -17,9 +16,7 @@ import org.herac.tuxguitar.song.helpers.TGStoredBeatList;
 import org.herac.tuxguitar.song.managers.TGSongManager;
 import org.herac.tuxguitar.song.managers.TGTrackManager;
 import org.herac.tuxguitar.song.models.TGBeat;
-import org.herac.tuxguitar.song.models.TGNote;
 import org.herac.tuxguitar.song.models.TGTrack;
-import org.herac.tuxguitar.song.models.TGVoice;
 import org.herac.tuxguitar.util.TGContext;
 
 public class TGPasteAction extends TGActionBase {
@@ -36,53 +33,33 @@ public class TGPasteAction extends TGActionBase {
 		if (clipboard.getSegment() != null) {
 			TGActionManager.getInstance(this.getContext()).execute(TGOpenMeasurePasteDialogAction.NAME, tgActionContext);
 		} else if (beatList != null && beatList.getLength() > 0) {
+			TGFactory factory = getSongManager(tgActionContext).getFactory();
 			TGSongManager songManager = this.getSongManager(tgActionContext);
 			TGTrackManager trackManager = songManager.getTrackManager();
 			TGBeat start = tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT);
 			TGTrack destTrack = tgActionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
-
-			TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
-			tgActionContext.setAttribute(TGMoveBeatsAction.ATTRIBUTE_MOVE, -beatList.getLength());
-			tgActionManager.execute(TGMoveBeatsAction.NAME, tgActionContext);
 			
-			// TODO, BUG here: source and destination tracks may not have the same tuning
-			// even not the same number of strings
-			// yet, "beats" are pasted: beat contains voices, voice contains notes, note contains (string number + fret number)
-			// if not the same tuning, notes can change
-			// also possible to create a note on the 5th string of a 4 string instrument
-			
-			// yet a simplistic workaround: remove notes on non-existing strings
-			TGFactory factory = getSongManager(tgActionContext).getFactory();
-			int maxString = destTrack.getStrings().size();	// max string number (included), strings are numbered 1 to n
-			List <TGBeat> beatsToPaste = new ArrayList<TGBeat>();
-			for (TGBeat beat : beatList.getBeats()) {
-				TGBeat newBeat = beat.clone(factory);
-				for (int i=0; i<2; i++) {
-					TGVoice voice = newBeat.getVoice(i);
-					if (voice !=null) {
-						List<TGNote>notesToDelete = new ArrayList<TGNote>();
-						for (TGNote note : voice.getNotes()) {
-							if (note.getString() > maxString) {
-								notesToDelete.add(note);
-							}
-						}
-						for (TGNote note : notesToDelete) {
-							voice.removeNote(note);
-						}
-					}
+			// don't copy paste between percussion/non-percussion tracks
+			if (beatList.isPercussionTrack() == songManager.isPercussionChannel(destTrack.getSong(), destTrack.getChannelId())) {
+				TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
+				tgActionContext.setAttribute(TGMoveBeatsAction.ATTRIBUTE_MOVE, -beatList.getLength());
+				tgActionManager.execute(TGMoveBeatsAction.NAME, tgActionContext);
+				
+				// clone clipboard content before modifying it, so it can be re-pasted later
+				TGStoredBeatList beatsListToPaste = beatList.clone(factory);
+				// then adapt notes to destination track (tuning might differ from source track)
+				trackManager.allocateNotesToStrings(beatsListToPaste.getStringValues(), beatsListToPaste.getBeats(), destTrack.getStrings());
+				
+				// paste
+				List<TGBeat> newBeats = trackManager.addBeats(destTrack, beatsListToPaste, start.getStart());
+				trackManager.moveOutOfBoundsBeatsToNewMeasure(destTrack, start.getStart());
+				
+				// re-select new beats
+				if (newBeats.size()>0)  {	// test is theoretically useless, just a precaution
+					Selector selector = TablatureEditor.getInstance(getContext()).getTablature().getSelector();
+					selector.initializeSelection(newBeats.get(0));
+					selector.updateSelection(newBeats.get(newBeats.size()-1));
 				}
-				beatsToPaste.add(newBeat);
-			}
-			TGStoredBeatList beatsListToPaste = new TGStoredBeatList(beatsToPaste, factory);
-			
-			List<TGBeat> newBeats = trackManager.addBeats(destTrack, beatsListToPaste, start.getStart());
-			trackManager.moveOutOfBoundsBeatsToNewMeasure(destTrack, start.getStart());
-			
-			// re-select new beats
-			if (newBeats.size()>0)  {	// test is theoretically useless, just a precaution
-				Selector selector = TablatureEditor.getInstance(getContext()).getTablature().getSelector();
-				selector.initializeSelection(newBeats.get(0));
-				selector.updateSelection(newBeats.get(newBeats.size()-1));
 			}
 		}
 	}


### PR DESCRIPTION
Complete rework of copy-paste feature, with the objective to keep *notes* unchanged when source and destination tracks don't have the same tuning. Previous implementation pasted *fret numbers*, this broke the global harmony.

Also: forbid copy/paste from percussion track(s) to non-percussion track(s) and vice-versa. Previously this led to weird results.

See #218 

Allocation is done beat per beat.
Strategy:

1. When source and destination tracks have the same tuning, keep notes and fingering unchanged, just as before

else:

2. try to move all notes to the closest string in destination tuning. "Closest" in terms of string pitch, not string number (number of strings may change)
example of use cases:
- copy from one standard tuned guitar to a guitar with F tuning: keep "fingering patterns" unchanged, as far as possible
- copy from one standard tuned guitar to a dropped-d guitar: keep all frets unchanged on the 5 unchanged strings
- copy to a 5-string bass to a 4-string bass: keep all frets unchanged on the 4 strings common to source and destination tracks

If all notes find a new place, apply this strategy and stop here.
else:

3. reallocate all notes to strings arbitrarily, targeting lowest possible fret number for each note.
Process notes from highest to lowest, to maximize probability to find a place for each note.
Discard all notes which could not fit.


Implementation:
One day a better algorithm could be implemented, considering for example previous and next beats (to minimize hands movements). So there is absolutely no reason to process the beats measure per measure. This explains why allocation of notes to strings is done in TGTrackManager, and not in TGMeasureManager as many other note manipulation functions.

Allocation of notes to strings is also performed in another use case: when importing a midi file.
The same allocation function is used.
Since there is no such thing as "source track tuning" in midi file, it falls back to strategy 3
So, behavior is unchanged compared to previous implementation.

Max number of frets is hard-coded, as in several other places in the code already. This needs to be rationalized