### PR TITLE
fix play loop in alt repeat

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/player/base/MidiRepeatController.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/player/base/MidiRepeatController.java
@@ -45,6 +45,7 @@ public class MidiRepeatController {
 		if( (this.sHeader != -1 && header.getNumber() < this.sHeader) || ( this.eHeader != -1 && header.getNumber() > this.eHeader ) ){
 			this.shouldPlay = false;
 			this.index ++;
+			this.repeatNumber += header.getRepeatClose();
 			return;
 		}
 		


### PR DESCRIPTION
fix #234
scenario: define loop over an interval corresponding to an alternative repeat >1, hit play
before this fix, player never starts