### PR TITLE
bend and multitrack: better horizontal spacing

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGTimeSignature.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGTimeSignature.java
@@ -39,6 +39,10 @@ public abstract class TGTimeSignature {
 		this.denominator = denominator;
 	}
 	
+	public float getQuartersInSignature() {
+		return (float)this.numerator * TGDuration.QUARTER / (float)this.denominator.getValue();
+	}
+	
 	public TGTimeSignature clone(TGFactory factory){
 		TGTimeSignature tgTimeSignature = factory.newTimeSignature();
 		tgTimeSignature.copyFrom(this);


### PR DESCRIPTION
this is a trade-off
restoring vertical alignment of beats in multitrack mode when bends are present is complex. And this should lead to a significant waste of space So, this alignment is not strictly respected, especially when many wide bend movements are displayed in one track and none in the other(s). Max width of bend movements of all tracks is "distributed" linearly in each measure of each track.
At least, available horizontal space is used in a more optimal way.

see #242