### PR TITLE
first step towards customizable lineFeed (WIP)

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayoutVertical.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayoutVertical.java
@@ -172,19 +172,21 @@ public class TGLayoutVertical extends TGLayout{
 		}
 		
 		int measureCount = track.countMeasures();
+		boolean lineFeed = false;
 		for (int measureIdx = fromIndex; measureIdx < measureCount; measureIdx++) {
 			TGMeasureImpl measure = (TGMeasureImpl)track.getMeasure(measureIdx);
 			
 			//verifico si tengo que bajar de linea
-			if((line.tempWith + measure.getWidth(this)) >= this.maximumWidth ){
+			line.fullLine = (line.tempWith + measure.getWidth(this)) >= this.maximumWidth;
+			if(line.fullLine || lineFeed){
 				if( line.measures.isEmpty() ) {
 					this.addToTempLine(line, ts, measure, measureIdx);
 				}
-				line.fullLine = true;
 				return line;
 			}
 			
 			this.addToTempLine(line, ts, measure, measureIdx);
+			if (measureIdx+1<measureCount) lineFeed = ((TGMeasureImpl)track.getMeasure(measureIdx+1)).isLineFeed();
 		}
 		
 		return line;

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGMeasureImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGMeasureImpl.java
@@ -1576,4 +1576,8 @@ public class TGMeasureImpl extends TGMeasure{
 		}
 		return getPosY();
 	}
+	
+	public boolean isLineFeed() {
+		return getHeaderImpl().isLineFeed();
+	}
 }

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
@@ -248,20 +248,22 @@ public class TGPrintLayout extends TGLayout {
 	private TempLine getTempLines(TGTrack track,int fromIndex,TGTrackSpacing ts) {
 		TempLine line = new TempLine();
 		int measureCount = track.countMeasures();
+		boolean lineFeed = false;
 		for (int measureIdx = fromIndex; measureIdx < measureCount; measureIdx++) {
 			TGMeasureImpl measure= (TGMeasureImpl) track.getMeasure(measureIdx);
 			if( measure.getNumber() >= this.settings.getFromMeasure() && measure.getNumber() <= this.settings.getToMeasure()){
 				
 				//verifico si tengo que bajar de linea
-				if((line.tempWith + measure.getWidth(this)) >= getMaxWidth() ){
+				line.fullLine = (line.tempWith + measure.getWidth(this)) >= getMaxWidth();
+				if (line.fullLine || lineFeed){
 					if( line.measures.isEmpty() ) {
 						this.addToTempLine(line, ts, measure, measureIdx);
 					}
-					line.fullLine = true;
 					return line;
 				}
 				
 				this.addToTempLine(line, ts, measure, measureIdx);
+				if (measureIdx+1<measureCount) lineFeed = ((TGMeasureImpl)track.getMeasure(measureIdx+1)).isLineFeed();
 			}
 		}
 		

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGMeasureHeader.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGMeasureHeader.java
@@ -29,6 +29,7 @@ public abstract class TGMeasureHeader {
 	private int repeatClose;
 	private int tripletFeel;
 	private TGSong song;
+	private boolean lineFeed;
 	
 	public TGMeasureHeader(TGFactory factory){
 		this.number = 0;
@@ -142,6 +143,19 @@ public abstract class TGMeasureHeader {
 		this.song = song;
 	}
 	
+	public void toggleLineFeed() {
+		this.lineFeed = !this.lineFeed;
+	}
+	
+	public boolean isLineFeed() {
+		return this.lineFeed;
+	}
+	
+	public void setLineFeed(boolean lineFeed) {
+		this.lineFeed = lineFeed;
+	}
+	
+	
 	public void copyFrom(TGFactory factory, TGMeasureHeader header){
 		this.setNumber(header.getNumber());
 		this.setStart(header.getStart());
@@ -153,6 +167,8 @@ public abstract class TGMeasureHeader {
 		this.getTempo().copyFrom(header.getTempo());
 		this.setMarker(header.hasMarker() ? header.getMarker().clone(factory) : null);
 		this.checkMarker();
+		this.setLineFeed(header.isLineFeed());
+		
 	}
 	
 	public TGMeasureHeader clone(TGFactory factory){
@@ -160,4 +176,5 @@ public abstract class TGMeasureHeader {
 		tgMeasureHeader.copyFrom(factory, this);
 		return tgMeasureHeader;
 	}
+
 }

--- a/desktop/TuxGuitar/share/lang/messages.properties
+++ b/desktop/TuxGuitar/share/lang/messages.properties
@@ -374,6 +374,7 @@ track.string.count.dialog.tip=Line Count
 track.string.count=Line Count
 
 measure=Measure
+measure.linefeed=Line feed
 measure.first=First Measure
 measure.previous=Previous Measure
 measure.next=Next Measure

--- a/desktop/TuxGuitar/share/lang/messages_bg.properties
+++ b/desktop/TuxGuitar/share/lang/messages_bg.properties
@@ -230,6 +230,7 @@ track.instrument=Инструмент
 # track.string.count=
 
 measure=Такт
+# measure.linefeed=
 measure.first=Първи такт
 measure.previous=Предишен такт
 measure.next=Следващ такт

--- a/desktop/TuxGuitar/share/lang/messages_ca.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ca.properties
@@ -230,6 +230,7 @@ track.name=Nom
 # track.string.count=
 
 measure=Compàs
+# measure.linefeed=
 measure.first=Primer
 measure.previous=Anterior
 measure.next=Següent

--- a/desktop/TuxGuitar/share/lang/messages_cs.properties
+++ b/desktop/TuxGuitar/share/lang/messages_cs.properties
@@ -230,6 +230,7 @@ track.instrument=Nástroj
 # track.string.count=
 
 measure=Takt
+# measure.linefeed=
 measure.first=Jdi na první takt
 measure.previous=Jdi na předchozí takt
 measure.next=Jdi na následnující takt

--- a/desktop/TuxGuitar/share/lang/messages_de.properties
+++ b/desktop/TuxGuitar/share/lang/messages_de.properties
@@ -230,6 +230,7 @@ track.string.count.dialog.tip=Anzahl Zeilen
 track.string.count=Anzahl Zeilen
 
 measure=Takt
+# measure.linefeed=
 measure.first=Erster Takt
 measure.previous=Vorheriger Takt
 measure.next=Nächster Takt

--- a/desktop/TuxGuitar/share/lang/messages_el.properties
+++ b/desktop/TuxGuitar/share/lang/messages_el.properties
@@ -230,6 +230,7 @@ track.instrument=Όργανο
 # track.string.count=
 
 measure=Μέτρο
+# measure.linefeed=
 measure.first=Πρώτο Μέτρο
 measure.previous=Προηγούμενο Μέτρο
 measure.next=Επόμενο Μέτρο

--- a/desktop/TuxGuitar/share/lang/messages_es.properties
+++ b/desktop/TuxGuitar/share/lang/messages_es.properties
@@ -230,6 +230,7 @@ track.string.count.dialog.tip=Número de Líneas
 track.string.count=Número de Líneas
 
 measure=Compás
+# measure.linefeed=
 measure.first=Primero
 measure.previous=Anterior
 measure.next=Siguiente

--- a/desktop/TuxGuitar/share/lang/messages_eu.properties
+++ b/desktop/TuxGuitar/share/lang/messages_eu.properties
@@ -230,6 +230,7 @@ track.instrument=Instrumentua
 # track.string.count=
 
 measure=Kompasa
+# measure.linefeed=
 measure.first=Lehenengoa
 measure.previous=Aurrekoa
 measure.next=Hurrengoa

--- a/desktop/TuxGuitar/share/lang/messages_fi.properties
+++ b/desktop/TuxGuitar/share/lang/messages_fi.properties
@@ -230,6 +230,7 @@ track.instrument=Instrumentti
 # track.string.count=
 
 measure=Tahti
+# measure.linefeed=
 measure.first=Ensimmäinen tahti
 measure.previous=Edellinen tahti
 measure.next=Seuraava tahti

--- a/desktop/TuxGuitar/share/lang/messages_fr.properties
+++ b/desktop/TuxGuitar/share/lang/messages_fr.properties
@@ -230,6 +230,7 @@ track.string.count.dialog.tip=Nombre de lignes
 track.string.count=Nombre de lignes
 
 measure=Mesure
+measure.linefeed=Retour à la ligne
 measure.first=Première mesure
 measure.previous=Mesure précédente
 measure.next=Mesure suivante

--- a/desktop/TuxGuitar/share/lang/messages_hu.properties
+++ b/desktop/TuxGuitar/share/lang/messages_hu.properties
@@ -230,6 +230,7 @@ track.instrument=Hangszer
 # track.string.count=
 
 measure=Ütem
+# measure.linefeed=
 measure.first=Elsõ ütem
 measure.previous=Elõzõ ütem
 measure.next=Következõ ütem

--- a/desktop/TuxGuitar/share/lang/messages_it.properties
+++ b/desktop/TuxGuitar/share/lang/messages_it.properties
@@ -230,6 +230,7 @@ track.string.count.dialog.tip=Numero righe
 track.string.count=Numero righe
 
 measure=Misura
+# measure.linefeed=
 measure.first=Prima misura
 measure.previous=Misura precedente
 measure.next=Misura successiva

--- a/desktop/TuxGuitar/share/lang/messages_ja.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ja.properties
@@ -230,6 +230,7 @@ track.instrument=楽器
 # track.string.count=
 
 measure=小節
+# measure.linefeed=
 measure.first=先頭の小節へ
 measure.previous=前の小節へ
 measure.next=次の小節へ

--- a/desktop/TuxGuitar/share/lang/messages_ko.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ko.properties
@@ -230,6 +230,7 @@ track.instrument=악기
 # track.string.count=
 
 measure=마디
+# measure.linefeed=
 measure.first=첫 마디
 measure.previous=이전 마디
 measure.next=다음 마디

--- a/desktop/TuxGuitar/share/lang/messages_lt.properties
+++ b/desktop/TuxGuitar/share/lang/messages_lt.properties
@@ -230,6 +230,7 @@ track.instrument=Instrumentas
 # track.string.count=
 
 measure=Taktai
+# measure.linefeed=
 measure.first=Pirmas taktas
 measure.previous=Ankstesnis taktas
 measure.next=Kitas taktas

--- a/desktop/TuxGuitar/share/lang/messages_nl.properties
+++ b/desktop/TuxGuitar/share/lang/messages_nl.properties
@@ -230,6 +230,7 @@ track.color=Kleur
 # track.string.count=
 
 measure=Maat
+# measure.linefeed=
 measure.first=Eerste maat
 measure.previous=Vorige maat
 measure.next=Volgende maat

--- a/desktop/TuxGuitar/share/lang/messages_pl.properties
+++ b/desktop/TuxGuitar/share/lang/messages_pl.properties
@@ -230,6 +230,7 @@ track.color=Kolor
 # track.string.count=
 
 measure=Takt
+# measure.linefeed=
 measure.first=Pierwszy takt
 measure.previous=Poprzedni takt
 measure.next=Następny takt

--- a/desktop/TuxGuitar/share/lang/messages_pt.properties
+++ b/desktop/TuxGuitar/share/lang/messages_pt.properties
@@ -230,6 +230,7 @@ track.instrument=Instrumento
 # track.string.count=
 
 measure=Compasso
+# measure.linefeed=
 measure.first=Primeiro Compasso
 measure.previous=Compasso anterior
 measure.next=Próximo Compasso

--- a/desktop/TuxGuitar/share/lang/messages_ru.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ru.properties
@@ -230,6 +230,7 @@ track.instrument=Инструмент
 # track.string.count=
 
 measure=Такт
+# measure.linefeed=
 measure.first=Первый
 measure.previous=Предыдущий
 measure.next=Следующий

--- a/desktop/TuxGuitar/share/lang/messages_sr.properties
+++ b/desktop/TuxGuitar/share/lang/messages_sr.properties
@@ -230,6 +230,7 @@ track.color=Boja
 # track.string.count=
 
 measure=Takt
+# measure.linefeed=
 measure.first=Prvi takt
 measure.previous=Prethodni takt
 measure.next=Sledeci takt

--- a/desktop/TuxGuitar/share/lang/messages_sv.properties
+++ b/desktop/TuxGuitar/share/lang/messages_sv.properties
@@ -230,6 +230,7 @@ track.color=Färg
 # track.string.count=
 
 measure=Takt
+# measure.linefeed=
 measure.first=Första takten
 measure.previous=Föregående takt
 measure.next=Nästa takt

--- a/desktop/TuxGuitar/share/lang/messages_uk.properties
+++ b/desktop/TuxGuitar/share/lang/messages_uk.properties
@@ -230,6 +230,7 @@ track.instrument=Інструмент
 # track.string.count=
 
 measure=Такт
+# measure.linefeed=
 measure.first=Перший такт
 measure.previous=Попередній такт
 measure.next=Наступний такт

--- a/desktop/TuxGuitar/share/lang/messages_vi.properties
+++ b/desktop/TuxGuitar/share/lang/messages_vi.properties
@@ -230,6 +230,7 @@ track.instrument=Nhạc cụ
 # track.string.count=
 
 measure=Ô nhịp
+# measure.linefeed=
 measure.first=Ô nhịp đầu tiên
 measure.previous=Ô nhịp trước
 measure.next=Ô nhịp kế

--- a/desktop/TuxGuitar/share/lang/messages_zh.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh.properties
@@ -230,6 +230,7 @@ track.string.count.dialog.tip=行数
 track.string.count=行数
 
 measure=小节
+# measure.linefeed=
 measure.first=第一小节
 measure.previous=上一小节
 measure.next=下一小节

--- a/desktop/TuxGuitar/share/lang/messages_zh_GB.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh_GB.properties
@@ -230,6 +230,7 @@ track.instrument=器乐
 # track.string.count=
 
 measure=小节
+# measure.linefeed=
 measure.first=第一小节
 measure.previous=前面小节
 measure.next=下一小节

--- a/desktop/TuxGuitar/share/lang/messages_zh_TW.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh_TW.properties
@@ -230,6 +230,7 @@ track.instrument=樂器
 # track.string.count=
 
 measure=小節
+# measure.linefeed=
 measure.first=第一小節
 measure.previous=上個小節
 measure.next=下個小節

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGToggleLineFeedAction.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/measure/TGToggleLineFeedAction.java
@@ -1,0 +1,23 @@
+package org.herac.tuxguitar.app.action.impl.measure;
+
+import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
+import org.herac.tuxguitar.editor.action.TGActionBase;
+import org.herac.tuxguitar.graphics.control.TGMeasureHeaderImpl;
+import org.herac.tuxguitar.util.TGContext;
+
+public class TGToggleLineFeedAction extends TGActionBase {
+	
+	public static final String NAME = "action.measure.toggle-linefeed";
+	
+	public TGToggleLineFeedAction(TGContext context) {
+		super(context, NAME);
+	}
+
+	@Override
+	protected void processAction(TGActionContext context) {
+		TGMeasureHeaderImpl header = (TGMeasureHeaderImpl) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_HEADER);
+		header.toggleLineFeed();
+	}
+
+}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
@@ -87,6 +87,7 @@ import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureCleanDialogActio
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureCopyDialogAction;
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasurePasteDialogAction;
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureRemoveDialogAction;
+import org.herac.tuxguitar.app.action.impl.measure.TGToggleLineFeedAction;
 import org.herac.tuxguitar.app.action.impl.note.TGOpenBeatMoveDialogAction;
 import org.herac.tuxguitar.app.action.impl.note.TGOpenStrokeDownDialogAction;
 import org.herac.tuxguitar.app.action.impl.note.TGOpenStrokeUpDialogAction;
@@ -423,6 +424,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		this.map(TGChangeTrackPropertiesAction.NAME, LOCKABLE | DISABLE_ON_PLAY);
 		
 		//measure actions
+		this.map(TGToggleLineFeedAction.NAME, LOCKABLE | DISABLE_ON_PLAY);
 		this.map(TGAddMeasureAction.NAME, LOCKABLE | DISABLE_ON_PLAY, new TGUpdateAddedMeasureController(), new TGUndoableAddMeasureController());
 		this.map(TGAddMeasureListAction.NAME, LOCKABLE | DISABLE_ON_PLAY);
 		this.map(TGCleanMeasureAction.NAME, LOCKABLE | DISABLE_ON_PLAY, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionInstaller.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionInstaller.java
@@ -88,6 +88,7 @@ import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureCleanDialogActio
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureCopyDialogAction;
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasurePasteDialogAction;
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureRemoveDialogAction;
+import org.herac.tuxguitar.app.action.impl.measure.TGToggleLineFeedAction;
 import org.herac.tuxguitar.app.action.impl.note.TGOpenBeatMoveDialogAction;
 import org.herac.tuxguitar.app.action.impl.note.TGOpenStrokeDownDialogAction;
 import org.herac.tuxguitar.app.action.impl.note.TGOpenStrokeUpDialogAction;
@@ -355,6 +356,7 @@ public class TGActionInstaller {
 		installAction(new TGChangeTrackPropertiesAction(context));
 		
 		//measure actions
+		installAction(new TGToggleLineFeedAction(context));
 		installAction(new TGAddMeasureAction(context));
 		installAction(new TGAddMeasureListAction(context));
 		installAction(new TGCleanMeasureAction(context));

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/MeasureMenuItem.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/MeasureMenuItem.java
@@ -10,16 +10,19 @@ import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureCleanDialogActio
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureCopyDialogAction;
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasurePasteDialogAction;
 import org.herac.tuxguitar.app.action.impl.measure.TGOpenMeasureRemoveDialogAction;
+import org.herac.tuxguitar.app.action.impl.measure.TGToggleLineFeedAction;
 import org.herac.tuxguitar.app.view.menu.TGMenuItem;
 import org.herac.tuxguitar.editor.clipboard.TGClipboard;
 import org.herac.tuxguitar.graphics.control.TGMeasureImpl;
 import org.herac.tuxguitar.ui.menu.UIMenu;
 import org.herac.tuxguitar.ui.menu.UIMenuActionItem;
+import org.herac.tuxguitar.ui.menu.UIMenuCheckableItem;
 import org.herac.tuxguitar.ui.menu.UIMenuSubMenuItem;
 
 public class MeasureMenuItem extends TGMenuItem {
 
 	private UIMenuSubMenuItem measureMenuItem;
+	private UIMenuCheckableItem lineFeed;
 	private UIMenuActionItem first;
 	private UIMenuActionItem last;
 	private UIMenuActionItem next;
@@ -35,6 +38,13 @@ public class MeasureMenuItem extends TGMenuItem {
 	}
 
 	public void showItems(){
+		//--LINEFEED--
+		this.lineFeed = this.measureMenuItem.getMenu().createCheckItem();
+		this.lineFeed.addSelectionListener(this.createActionProcessor(TGToggleLineFeedAction.NAME));
+		
+		//--SEPARATOR--
+		this.measureMenuItem.getMenu().createSeparator();
+
 		//--FIRST--
 		this.first = this.measureMenuItem.getMenu().createActionItem();
 		this.first.addSelectionListener(this.createActionProcessor(TGGoFirstMeasureAction.NAME));
@@ -86,6 +96,8 @@ public class MeasureMenuItem extends TGMenuItem {
 		boolean running = TuxGuitar.getInstance().getPlayer().isRunning();
 		boolean isFirst = (measure.getNumber() == 1);
 		boolean isLast = (measure.getNumber() == measure.getTrack().countMeasures());
+		this.lineFeed.setEnabled(!running);
+		this.lineFeed.setChecked(measure.isLineFeed());
 		this.first.setEnabled(!isFirst);
 		this.previous.setEnabled(!isFirst);
 		this.next.setEnabled(!isLast);
@@ -99,6 +111,7 @@ public class MeasureMenuItem extends TGMenuItem {
 
 	public void loadProperties(){
 		setMenuItemTextAndAccelerator(this.measureMenuItem, "measure", null);
+		setMenuItemTextAndAccelerator(this.lineFeed, "measure.linefeed", TGToggleLineFeedAction.NAME);
 		setMenuItemTextAndAccelerator(this.first, "measure.first", TGGoFirstMeasureAction.NAME);
 		setMenuItemTextAndAccelerator(this.last, "measure.last", TGGoLastMeasureAction.NAME);
 		setMenuItemTextAndAccelerator(this.previous, "measure.previous", TGGoPreviousMeasureAction.NAME);


### PR DESCRIPTION
added possibility to insert linefeed at beginning of measure. effective in page layout, pdf export and print

Work in progress
TODO:
- add an icon in measure menu
- I'm not sure of the label of menu item ("line feed")
- save lineFeed info in .tg file