### PR TITLE
added selection-related menu items, reallocate Ctrl+a shortcut

### DIFF
--- a/desktop/TuxGuitar/dist/tuxguitar-shortcuts.xml
+++ b/desktop/TuxGuitar/dist/tuxguitar-shortcuts.xml
@@ -25,6 +25,7 @@
 	<shortcut keys="Ctrl r" action="action.edit.repeat"/>
 	<shortcut keys="Ctrl y" action="action.edit.redo"/>
 	<shortcut keys="Ctrl z" action="action.edit.undo"/>
+	<shortcut keys="Ctrl a" action="action.selection.select-all"/>
 	<shortcut keys="Ctrl 1" action="action.edit.voice-1"/>
 	<shortcut keys="Ctrl 2" action="action.edit.voice-2"/>
 	<shortcut keys="Alt F4" action="action.file.exit"/>
@@ -57,7 +58,6 @@
 	<shortcut keys="Ctrl Del" action="action.note.general.clean-beat"/>
 	<shortcut keys="Ctrl Up" action="action.beat.general.voice-up"/>
 	<shortcut keys="Ctrl Down" action="action.beat.general.voice-down"/>
-	<shortcut keys="Ctrl a" action="action.beat.general.voice-auto"/>
 	<shortcut keys="Shift Left" action="action.note.general.decrement-semitone"/>
 	<shortcut keys="Shift Right" action="action.note.general.increment-semitone"/>
 	<shortcut keys="Shift Down" action="action.note.general.shift-down"/>

--- a/desktop/TuxGuitar/share/lang/messages.properties
+++ b/desktop/TuxGuitar/share/lang/messages.properties
@@ -226,6 +226,7 @@ edit.paste=Paste
 edit.repeat=Repeat
 edit.undo=Undo
 edit.redo=Redo
+edit.selection.extend=Extend Selection
 edit.mouse-mode-selection=Selection Mode
 edit.mouse-mode-edition=Score Edition Mode
 edit.not-natural-key=Sharp/Flat Mode

--- a/desktop/TuxGuitar/share/lang/messages_bg.properties
+++ b/desktop/TuxGuitar/share/lang/messages_bg.properties
@@ -82,6 +82,7 @@ edit.paste=Поставяне
 # edit.repeat=
 edit.undo=Отмяна
 edit.redo=Повторение
+# edit.selection.extend=
 edit.mouse-mode-selection=Режим на избиране
 # edit.mouse-mode-edition=
 edit.not-natural-key=Режим диез/бемол

--- a/desktop/TuxGuitar/share/lang/messages_ca.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ca.properties
@@ -82,6 +82,7 @@ edit.paste=Enganxa
 # edit.repeat=
 edit.undo=Desfés
 edit.redo=Refés
+# edit.selection.extend=
 edit.mouse-mode-selection=Canvia el punter a mode de selecció
 edit.mouse-mode-edition=Canvia el punter a mode d'edició
 edit.not-natural-key=Sostingut/Bemoll

--- a/desktop/TuxGuitar/share/lang/messages_cs.properties
+++ b/desktop/TuxGuitar/share/lang/messages_cs.properties
@@ -82,6 +82,7 @@ edit.paste=Vložit
 # edit.repeat=
 edit.undo=Zpět
 edit.redo=Vpřed
+# edit.selection.extend=
 edit.mouse-mode-selection=Mód výběru
 edit.mouse-mode-edition=Mód vkládání not
 edit.not-natural-key=Mód posuvek

--- a/desktop/TuxGuitar/share/lang/messages_de.properties
+++ b/desktop/TuxGuitar/share/lang/messages_de.properties
@@ -82,6 +82,7 @@ edit.paste=Einfügen
 edit.repeat=Wiederholen
 edit.undo=Rückgängig
 edit.redo=Wiederherstellen
+# edit.selection.extend=
 edit.mouse-mode-selection=Selektionsmodus
 edit.mouse-mode-edition=Partitureditor-Modus
 edit.not-natural-key=Erhöht/Erniedrigt-Modus

--- a/desktop/TuxGuitar/share/lang/messages_el.properties
+++ b/desktop/TuxGuitar/share/lang/messages_el.properties
@@ -82,6 +82,7 @@ edit.paste=Προορισμός
 # edit.repeat=
 edit.undo=Αναίρεση
 edit.redo=Επανάληψη ενέργειας
+# edit.selection.extend=
 edit.mouse-mode-selection=Λειτουργία Επιλογής
 edit.mouse-mode-edition=Λειτουργία Επεξεργασίας Παρτιτούρας
 edit.not-natural-key=Λειτουργία Δίεσης/Ύφεσης

--- a/desktop/TuxGuitar/share/lang/messages_es.properties
+++ b/desktop/TuxGuitar/share/lang/messages_es.properties
@@ -82,6 +82,7 @@ edit.paste=Pegar
 edit.repeat=Repetir
 edit.undo=Deshacer
 edit.redo=Rehacer
+# edit.selection.extend=
 edit.mouse-mode-selection=Cursor en modo selección
 edit.mouse-mode-edition=Cursor en modo edición
 edit.not-natural-key=Sostenido/Bemol

--- a/desktop/TuxGuitar/share/lang/messages_eu.properties
+++ b/desktop/TuxGuitar/share/lang/messages_eu.properties
@@ -82,6 +82,7 @@ edit.paste=itsatsi
 # edit.repeat=
 edit.undo=Desegin
 edit.redo=Berriro egin
+# edit.selection.extend=
 edit.mouse-mode-selection=Aldatu punteroa hautatzeko modura
 edit.mouse-mode-edition=Aldatu punteroa edizio modura
 edit.not-natural-key=Diesi/Bemola

--- a/desktop/TuxGuitar/share/lang/messages_fi.properties
+++ b/desktop/TuxGuitar/share/lang/messages_fi.properties
@@ -82,6 +82,7 @@ edit.paste=Liitä
 # edit.repeat=
 edit.undo=Kumoa
 edit.redo=Tee uudelleen
+# edit.selection.extend=
 edit.mouse-mode-selection=Valintatila
 edit.mouse-mode-edition=Nuottien muokkaus -tila
 edit.not-natural-key=Ylennys/alennus-tila

--- a/desktop/TuxGuitar/share/lang/messages_fr.properties
+++ b/desktop/TuxGuitar/share/lang/messages_fr.properties
@@ -82,6 +82,7 @@ edit.paste=Coller
 edit.repeat=Répéter
 edit.undo=Annuler
 edit.redo=Rétablir
+edit.selection.extend=Étendre la sélection
 edit.mouse-mode-selection=Mode sélection
 edit.mouse-mode-edition=Mode édition de partition
 edit.not-natural-key=Mode dièses/bémols

--- a/desktop/TuxGuitar/share/lang/messages_hu.properties
+++ b/desktop/TuxGuitar/share/lang/messages_hu.properties
@@ -82,6 +82,7 @@ edit.paste=Beillesztés
 # edit.repeat=
 edit.undo=Visszavonás
 edit.redo=Újra
+# edit.selection.extend=
 edit.mouse-mode-selection=Kijelölõ mód
 edit.mouse-mode-edition=Kottaszerkesztõ mód
 edit.not-natural-key=Módosító-szerkesztõ mód

--- a/desktop/TuxGuitar/share/lang/messages_it.properties
+++ b/desktop/TuxGuitar/share/lang/messages_it.properties
@@ -82,6 +82,7 @@ edit.paste=Incolla
 edit.repeat=Ripeti
 edit.undo=Annulla
 edit.redo=Ripristina
+# edit.selection.extend=
 edit.mouse-mode-selection=Modalità selezione
 edit.mouse-mode-edition=Modalità modifica pentagramma
 edit.not-natural-key=Modalità Diesis/Bemolle

--- a/desktop/TuxGuitar/share/lang/messages_ja.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ja.properties
@@ -82,6 +82,7 @@ edit.paste=貼り付け
 # edit.repeat=
 edit.undo=元に戻す
 edit.redo=やり直す
+# edit.selection.extend=
 edit.mouse-mode-selection=選択・モード
 edit.mouse-mode-edition=スコア編集・モード
 edit.not-natural-key=シャープ/フラット・モード

--- a/desktop/TuxGuitar/share/lang/messages_ko.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ko.properties
@@ -82,6 +82,7 @@ edit.paste=붙여넣기
 # edit.repeat=
 edit.undo=실행 취소
 edit.redo=다시 실행
+# edit.selection.extend=
 edit.mouse-mode-selection=선택 모드
 edit.mouse-mode-edition=악보 편집 모드
 edit.not-natural-key=샤프/플랫 모드

--- a/desktop/TuxGuitar/share/lang/messages_lt.properties
+++ b/desktop/TuxGuitar/share/lang/messages_lt.properties
@@ -82,6 +82,7 @@ edit.paste=Įdėti
 # edit.repeat=
 edit.undo=Atšaukti
 edit.redo=Atstatyti
+# edit.selection.extend=
 edit.mouse-mode-selection=Žymėjimo pele veiksena
 edit.mouse-mode-edition=Partitūros redagavimo veiksena
 edit.not-natural-key=Diezai/bemoliai

--- a/desktop/TuxGuitar/share/lang/messages_nl.properties
+++ b/desktop/TuxGuitar/share/lang/messages_nl.properties
@@ -82,6 +82,7 @@ edit.paste=Plakken
 # edit.repeat=
 edit.undo=Ongedaan maken
 edit.redo=Opnieuw
+# edit.selection.extend=
 edit.mouse-mode-selection=Selectie Modus
 edit.mouse-mode-edition=Score Bewerk Modus
 edit.not-natural-key=Sharp/Flat Modus

--- a/desktop/TuxGuitar/share/lang/messages_pl.properties
+++ b/desktop/TuxGuitar/share/lang/messages_pl.properties
@@ -82,6 +82,7 @@ edit.paste=Wstaw
 # edit.repeat=
 edit.undo=Cofnij
 edit.redo=Przywróć
+# edit.selection.extend=
 edit.mouse-mode-selection=Tryb zaznaczania
 edit.mouse-mode-edition=Tryb edycji
 edit.not-natural-key=Krzyżyk/Bemol

--- a/desktop/TuxGuitar/share/lang/messages_pt.properties
+++ b/desktop/TuxGuitar/share/lang/messages_pt.properties
@@ -82,6 +82,7 @@ edit.paste=Colar
 # edit.repeat=
 edit.undo=Desfazer
 edit.redo=Refazer
+# edit.selection.extend=
 edit.mouse-mode-selection=Modo de Seleção
 edit.mouse-mode-edition=Modo Partitura
 edit.not-natural-key=Modo Sustenido/Bemol

--- a/desktop/TuxGuitar/share/lang/messages_ru.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ru.properties
@@ -82,6 +82,7 @@ edit.paste=Вставить
 # edit.repeat=
 edit.undo=Отменить
 edit.redo=Повторить
+# edit.selection.extend=
 edit.mouse-mode-selection=Режим выделения
 edit.mouse-mode-edition=Режим редактирования
 edit.not-natural-key=Режим диезов/бемолей

--- a/desktop/TuxGuitar/share/lang/messages_sr.properties
+++ b/desktop/TuxGuitar/share/lang/messages_sr.properties
@@ -82,6 +82,7 @@ edit.paste=Zalepi
 # edit.repeat=
 # edit.undo=
 # edit.redo=
+# edit.selection.extend=
 edit.mouse-mode-selection=Režim selekcije
 edit.mouse-mode-edition=Režim prepravljanja
 edit.not-natural-key=Režim povisilica-snizilica

--- a/desktop/TuxGuitar/share/lang/messages_sv.properties
+++ b/desktop/TuxGuitar/share/lang/messages_sv.properties
@@ -82,6 +82,7 @@ edit.paste=Klistra in
 # edit.repeat=
 edit.undo=Ångra
 edit.redo=Gör om
+# edit.selection.extend=
 edit.mouse-mode-selection=Markeringsläge
 edit.mouse-mode-edition=Partiturredigeringsläge
 edit.not-natural-key=Höjnings/Sänkningsläge

--- a/desktop/TuxGuitar/share/lang/messages_uk.properties
+++ b/desktop/TuxGuitar/share/lang/messages_uk.properties
@@ -82,6 +82,7 @@ edit.paste=Вставити
 # edit.repeat=
 edit.undo=Відмінити
 edit.redo=Повернути
+# edit.selection.extend=
 edit.mouse-mode-selection=Режим вибору
 edit.mouse-mode-edition=Режим редагування
 edit.not-natural-key=Дієз/Бемоль

--- a/desktop/TuxGuitar/share/lang/messages_vi.properties
+++ b/desktop/TuxGuitar/share/lang/messages_vi.properties
@@ -82,6 +82,7 @@ edit.paste=Dán
 # edit.repeat=
 edit.undo=Huỷ bước
 edit.redo=Làm lại
+# edit.selection.extend=
 edit.mouse-mode-selection=Chế độ chọn
 edit.mouse-mode-edition=Chế độ soạn thảo
 edit.not-natural-key=Chế độ thăng/giáng

--- a/desktop/TuxGuitar/share/lang/messages_zh.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh.properties
@@ -82,6 +82,7 @@ edit.paste=粘贴
 # edit.repeat=
 edit.undo=撤销
 edit.redo=重做
+# edit.selection.extend=
 edit.mouse-mode-selection=选择模式
 edit.mouse-mode-edition=编辑模式
 edit.not-natural-key=升/降调模式

--- a/desktop/TuxGuitar/share/lang/messages_zh_GB.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh_GB.properties
@@ -82,6 +82,7 @@ edit.paste=粘贴
 # edit.repeat=
 edit.undo=撤销
 edit.redo=重做
+# edit.selection.extend=
 edit.mouse-mode-selection=选择模式
 edit.mouse-mode-edition=乐谱编辑模式
 edit.not-natural-key=升调/降调模式

--- a/desktop/TuxGuitar/share/lang/messages_zh_TW.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh_TW.properties
@@ -82,6 +82,7 @@ edit.paste=貼上
 # edit.repeat=
 edit.undo=上一步
 edit.redo=下一步
+# edit.selection.extend=
 edit.mouse-mode-selection=選擇模式
 edit.mouse-mode-edition=五線譜編輯模式
 edit.not-natural-key=升/降模式

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/EditMenuItem.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/EditMenuItem.java
@@ -10,6 +10,14 @@ import org.herac.tuxguitar.app.action.impl.edit.TGSetMouseModeSelectionAction;
 import org.herac.tuxguitar.app.action.impl.edit.TGSetNaturalKeyAction;
 import org.herac.tuxguitar.app.action.impl.edit.TGSetVoice1Action;
 import org.herac.tuxguitar.app.action.impl.edit.TGSetVoice2Action;
+import org.herac.tuxguitar.app.action.impl.selector.TGClearSelectionAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGExtendSelectionFirstAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGExtendSelectionLastAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGExtendSelectionLeftAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGExtendSelectionNextAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGExtendSelectionPreviousAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGExtendSelectionRightAction;
+import org.herac.tuxguitar.app.action.impl.selector.TGSelectAllAction;
 import org.herac.tuxguitar.app.view.component.tab.Tablature;
 import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.app.view.component.tab.edit.EditorKit;
@@ -31,6 +39,15 @@ public class EditMenuItem extends TGMenuItem{
 	private UIMenuActionItem repeat;
 	private UIMenuActionItem undo;
 	private UIMenuActionItem redo;
+	private UIMenuActionItem selectAll;
+	private UIMenuActionItem selectNone;
+	private UIMenuSubMenuItem extendSelection;
+	private UIMenuActionItem extendSelectionLeft;
+	private UIMenuActionItem extendSelectionRight;
+	private UIMenuActionItem extendSelectionPrevious;
+	private UIMenuActionItem extendSelectionNext;
+	private UIMenuActionItem extendSelectionFirst;
+	private UIMenuActionItem extendSelectionLast;
 	private UIMenuCheckableItem modeSelection;
 	private UIMenuCheckableItem modeEdition;
 	private UIMenuCheckableItem notNaturalKey;
@@ -71,6 +88,30 @@ public class EditMenuItem extends TGMenuItem{
 
 		//--SEPARATOR--
 		this.editMenuItem.getMenu().createSeparator();
+		
+		//--Selection--
+		this.selectAll = this.editMenuItem.getMenu().createActionItem();
+		this.selectAll.addSelectionListener(this.createActionProcessor(TGSelectAllAction.NAME));
+		
+		this.selectNone = this.editMenuItem.getMenu().createActionItem();
+		this.selectNone.addSelectionListener(this.createActionProcessor(TGClearSelectionAction.NAME));
+		
+		this.extendSelection = this.editMenuItem.getMenu().createSubMenuItem();
+		this.extendSelectionLeft = this.extendSelection.getMenu().createActionItem();
+		this.extendSelectionLeft.addSelectionListener(this.createActionProcessor(TGExtendSelectionLeftAction.NAME));
+		this.extendSelectionRight = this.extendSelection.getMenu().createActionItem();
+		this.extendSelectionRight.addSelectionListener(this.createActionProcessor(TGExtendSelectionRightAction.NAME));
+		this.extendSelectionPrevious = this.extendSelection.getMenu().createActionItem();
+		this.extendSelectionPrevious.addSelectionListener(this.createActionProcessor(TGExtendSelectionPreviousAction.NAME));
+		this.extendSelectionNext = this.extendSelection.getMenu().createActionItem();
+		this.extendSelectionNext.addSelectionListener(this.createActionProcessor(TGExtendSelectionNextAction.NAME));
+		this.extendSelectionFirst = this.extendSelection.getMenu().createActionItem();
+		this.extendSelectionFirst.addSelectionListener(this.createActionProcessor(TGExtendSelectionFirstAction.NAME));
+		this.extendSelectionLast = this.extendSelection.getMenu().createActionItem();
+		this.extendSelectionLast.addSelectionListener(this.createActionProcessor(TGExtendSelectionLastAction.NAME));
+		
+		//--SEPARATOR--
+		this.editMenuItem.getMenu().createSeparator();
 
 		//--TABLATURE EDIT MODE--
 		this.modeSelection = this.editMenuItem.getMenu().createRadioItem();
@@ -109,6 +150,15 @@ public class EditMenuItem extends TGMenuItem{
 		this.repeat.setEnabled(!running && tablature.getSelector().isActive());
 		this.undo.setEnabled(!running && TuxGuitar.getInstance().getUndoableManager().canUndo());
 		this.redo.setEnabled(!running && TuxGuitar.getInstance().getUndoableManager().canRedo());
+		this.selectAll.setEnabled(!running);
+		this.selectNone.setEnabled(!running && tablature.getSelector().isActive());
+		this.extendSelection.setEnabled(!running && tablature.getSelector().isActive());
+		this.extendSelectionLeft.setEnabled(!running && tablature.getSelector().isActive());
+		this.extendSelectionRight.setEnabled(!running && tablature.getSelector().isActive());
+		this.extendSelectionPrevious.setEnabled(!running && tablature.getSelector().isActive());
+		this.extendSelectionNext.setEnabled(!running && tablature.getSelector().isActive());
+		this.extendSelectionFirst.setEnabled(!running && tablature.getSelector().isActive());
+		this.extendSelectionLast.setEnabled(!running && tablature.getSelector().isActive());
 		this.modeSelection.setChecked(kit.getMouseMode() == EditorKit.MOUSE_MODE_SELECTION);
 		this.modeSelection.setEnabled(!running);
 		this.modeEdition.setChecked(kit.getMouseMode() == EditorKit.MOUSE_MODE_EDITION);
@@ -127,6 +177,15 @@ public class EditMenuItem extends TGMenuItem{
 		setMenuItemTextAndAccelerator(this.repeat, "edit.repeat", TGRepeatAction.NAME);
 		setMenuItemTextAndAccelerator(this.undo, "edit.undo", TGUndoAction.NAME);
 		setMenuItemTextAndAccelerator(this.redo, "edit.redo", TGRedoAction.NAME);
+		setMenuItemTextAndAccelerator(this.selectAll, "action.selection.select-all", TGSelectAllAction.NAME);
+		setMenuItemTextAndAccelerator(this.selectNone, "action.selection.clear", TGClearSelectionAction.NAME);
+		setMenuItemTextAndAccelerator(this.extendSelection, "edit.selection.extend", null);
+		setMenuItemTextAndAccelerator(this.extendSelectionLeft, "action.selection.extend-left", TGExtendSelectionLeftAction.NAME);
+		setMenuItemTextAndAccelerator(this.extendSelectionRight, "action.selection.extend-right", TGExtendSelectionRightAction.NAME);
+		setMenuItemTextAndAccelerator(this.extendSelectionPrevious, "action.selection.extend-previous", TGExtendSelectionPreviousAction.NAME);
+		setMenuItemTextAndAccelerator(this.extendSelectionNext, "action.selection.extend-next", TGExtendSelectionNextAction.NAME);
+		setMenuItemTextAndAccelerator(this.extendSelectionFirst, "action.selection.extend-first", TGExtendSelectionFirstAction.NAME);
+		setMenuItemTextAndAccelerator(this.extendSelectionLast, "action.selection.extend-last", TGExtendSelectionLastAction.NAME);
 		setMenuItemTextAndAccelerator(this.modeSelection, "edit.mouse-mode-selection", TGSetMouseModeSelectionAction.NAME);
 		setMenuItemTextAndAccelerator(this.modeEdition, "edit.mouse-mode-edition", TGSetMouseModeEditionAction.NAME);
 		setMenuItemTextAndAccelerator(this.notNaturalKey, "edit.not-natural-key", TGSetNaturalKeyAction.NAME);


### PR DESCRIPTION
See #220 
added menu items: to make actions visible to user
Ctrl+A is a usual shortcut for "select all" action in many applications