### PR TITLE
split README in 2 independent files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,10 @@ TuxGuitar includes the following third party products:
 
 ## Installation
 
-You can find ready to use installation packages for Linux, Windows, MacOS, FreeBSD and Android on
+You can find ready to use installation packages for Linux, Windows, MacOS, FreeBSD and Android here: [releases](https://github.com/helge17/tuxguitar/releases/)
 
-https://github.com/helge17/tuxguitar/releases/
-
-To build TuxGuitar from source code, refer to the INSTALL.md file.
+To build TuxGuitar from source code, refer to the [INSTALL.md](INSTALL.md) file.
 
 ## Contribute
 
-If you want to contribute to TuxGuitar, you will find a helpful description in the file contribute.md.
+If you want to contribute to TuxGuitar, you will find a helpful description in the file [contribute.md](doc/contribute.md).

--- a/desktop/TuxGuitar/dist/about_description.dist
+++ b/desktop/TuxGuitar/dist/about_description.dist
@@ -1,1 +1,34 @@
-../../../README.md
+# TuxGuitar
+
+## Description
+
+TuxGuitar is an Open Source multitrack tablature editor and player written in Java.
+
+## License
+
+TuxGuitar is released under the GNU Lesser General Public License.
+
+Copyright (C) 2005-2022 Julian Gabriel Casadesus
+
+## Third party products
+
+TuxGuitar includes the following third party products:
+
+* SWT version: SWT (Standard Widget Toolkit): https://www.eclipse.org/swt/
+* JFX version: JavaFX (Java client application platform): https://openjfx.io/
+* Gervill (Software Synthesizer): https://gervill.dev.java.net/
+* iText (Free Java-PDF library): https://itextpdf.com/
+* Magic Sound Font v2.0 - Contributed by Dennis Deutschmann
+
+## Installation
+
+You can find ready to use installation packages for Linux, Windows, MacOS, FreeBSD and Android on
+https://github.com/helge17/tuxguitar/releases/
+
+To build TuxGuitar from source code, refer to file:
+https://github.com/helge17/tuxguitar/blob/master/INSTALL.md
+
+## Contribute
+
+If you want to contribute to TuxGuitar, you will find a helpful description in file:
+https://github.com/helge17/tuxguitar/doc/contribute.md.


### PR DESCRIPTION
@helge17: I will not merge this PR myself, I would like you to review it first.

My objective is mainly to ease access to "contribute.md" from repo's main page (link was deleted at my request, because of markdown syntax appearing in help/about dialog: 566b3c5b5ae5a1de4430e20b477dc3746d9fad00)
Not very comfortable to split "README" in 2, especially for future maintenance. Not ideal also to embed in deskop app an absolute link to "contribute.md".
Don't hesitate to reject PR if you can think of a better solution.
