### PR TITLE
rationalize definition of maximum fret number

### DIFF
--- a/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGSetNoteFretNumberAction.java
+++ b/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGSetNoteFretNumberAction.java
@@ -40,7 +40,7 @@ public class TGSetNoteFretNumberAction extends TGActionBase  {
 			if( lastAddedStart == start.longValue() && lastAddedString == string.getNumber() ){
 				if( lastAddedFret > 0 && lastAddedFret < 10 && time <  ( lastAddedTime + DELAY ) ){
 					int newFret = ( ( lastAddedFret * 10 ) + fret );
-					if( newFret < 30 || getSongManager(context).isPercussionChannel(song, track.getChannelId()) ){
+					if( newFret <= track.getMaxFret() || getSongManager(context).isPercussionChannel(song, track.getChannelId()) ){
 						fret = newFret;
 					}
 				}

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGSongSegmentHelper.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGSongSegmentHelper.java
@@ -98,7 +98,7 @@ public class TGSongSegmentHelper {
 					measures = getEmptyMeasures(segment.getHeaders().size(), clef, keySignature);
 				}
 				else {
-					this.sm.getTrackManager().allocateMeasureNotesToStrings(tSegment.getStringValues(), measures, currTrack.getStrings());
+					this.sm.getTrackManager().allocateMeasureNotesToStrings(tSegment.getStringValues(), measures, currTrack.getStrings(), currTrack.getMaxFret());
 				}
 			}
 			for(int i = 0;i < measures.size();i++){
@@ -153,7 +153,7 @@ public class TGSongSegmentHelper {
 					this.sm.getMeasureManager().moveAllBeats(measure,move);
 					this.sm.getMeasureManager().removeVoicesOutOfTime(measure);
 					if ((tSegment.isPercussionTrack() == this.sm.isPercussionChannel(song, currTrack.getChannelId()))) {
-						this.sm.getTrackManager().allocateMeasureNotesToStrings(tSegment.getStringValues(), measure, currTrack.getStrings());
+						this.sm.getTrackManager().allocateMeasureNotesToStrings(tSegment.getStringValues(), measure, currTrack.getStrings(), currTrack.getMaxFret());
 						this.sm.getTrackManager().replaceMeasure(currTrack,measure);
 					}
 				}

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/managers/TGTrackManager.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/managers/TGTrackManager.java
@@ -21,7 +21,6 @@ import org.herac.tuxguitar.song.models.TGVoice;
 public class TGTrackManager {
 	
 	private TGSongManager songManager;
-	private final int MAX_FRET = 29;	//included
 	
 	public TGTrackManager(TGSongManager songManager){
 		this.songManager = songManager;
@@ -351,19 +350,19 @@ public class TGTrackManager {
 		}
 	}
 	
-	public void allocateMeasureNotesToStrings(List<Integer> fromStringValues, List<TGMeasure> measures, List<TGString> toStrings) {
+	public void allocateMeasureNotesToStrings(List<Integer> fromStringValues, List<TGMeasure> measures, List<TGString> toStrings, int maxFret) {
 		List<TGBeat> beats = new ArrayList<TGBeat>();
 		for (TGMeasure measure : measures) {
 			beats.addAll(measure.getBeats());
 		}
-		this.allocateNotesToStrings(fromStringValues, beats, toStrings);
+		this.allocateNotesToStrings(fromStringValues, beats, toStrings, maxFret);
 	}
 	
-	public void allocateMeasureNotesToStrings(List<Integer> fromStringValues, TGMeasure measure, List<TGString> toStrings) {
-		this.allocateNotesToStrings(fromStringValues, measure.getBeats(), toStrings);
+	public void allocateMeasureNotesToStrings(List<Integer> fromStringValues, TGMeasure measure, List<TGString> toStrings, int maxFret) {
+		this.allocateNotesToStrings(fromStringValues, measure.getBeats(), toStrings, maxFret);
 	}
 	
-	public void allocateNotesToStrings(List<Integer> fromStringValues, List<TGBeat> beats, List<TGString> toStrings) {
+	public void allocateNotesToStrings(List<Integer> fromStringValues, List<TGBeat> beats, List<TGString> toStrings, int maxFret) {
 		if (fromStringValues==null || fromStringValues.isEmpty() || beats==null || beats.isEmpty() || toStrings==null || toStrings.isEmpty()) {
 			return;
 		}
@@ -373,13 +372,13 @@ public class TGTrackManager {
 		}
 		for (TGBeat beat : beats) {
 			beat.removeChord();
-			allocateNotesToStrings(fromStringValues, beat, toStrings);
+			allocateNotesToStrings(fromStringValues, beat, toStrings, maxFret);
 		}
 	}
 	
-	private void allocateNotesToStrings(List<Integer> fromStringValues, TGBeat beat, List<TGString> toStrings) {
-		if (!this.allocateNotesToClosestString(fromStringValues, beat, toStrings)) {
-			this.allocateNotesToLowestFret(fromStringValues, beat, toStrings);
+	private void allocateNotesToStrings(List<Integer> fromStringValues, TGBeat beat, List<TGString> toStrings, int maxFret) {
+		if (!this.allocateNotesToClosestString(fromStringValues, beat, toStrings, maxFret)) {
+			this.allocateNotesToLowestFret(fromStringValues, beat, toStrings, maxFret);
 		}
 	}
 	
@@ -387,7 +386,7 @@ public class TGTrackManager {
 	// "closest" in terms of string pitch (not string number)
 	// objective is to keep "fingering pattern" globally unchanged (typ. use case: new tuning is 1/2 tone higher for all strings)
 	// returns true in case of success, else false
-	private boolean allocateNotesToClosestString(List<Integer> fromStringValues, TGBeat beat, List<TGString> toStrings) {
+	private boolean allocateNotesToClosestString(List<Integer> fromStringValues, TGBeat beat, List<TGString> toStrings, int maxFret) {
 		// only possible if old tuning is valid
 		boolean oldTuningIsValid = true;
 		for (int stringValue : fromStringValues) {
@@ -418,7 +417,7 @@ public class TGTrackManager {
 					}
 					if (freeStrings.contains(closestString)) {
 						int newFret = noteStringValue + note.getValue() - closestString.getValue();
-						if (newFret>=0 && newFret<=MAX_FRET) {
+						if (newFret>=0 && newFret<=maxFret) {
 							note.setValue(newFret);
 							note.setString(closestString.getNumber());
 							freeStrings.remove(closestString);
@@ -447,7 +446,7 @@ public class TGTrackManager {
 	}
 	
 	// allocate each note to the lowest possible fret, discard notes with no place found
-	private void allocateNotesToLowestFret(List<Integer> fromStringValues, TGBeat beat, List<TGString> toStrings) {
+	private void allocateNotesToLowestFret(List<Integer> fromStringValues, TGBeat beat, List<TGString> toStrings, int maxFret) {
 		List<TGString> freeStrings = new ArrayList<TGString>(toStrings);
 		for (int i=0; i<beat.countVoices(); i++) {
 			TGVoice voice = beat.getVoice(i);
@@ -463,7 +462,7 @@ public class TGTrackManager {
 				TGString newString = null;
 				for (TGString string : freeStrings) {
 					int fret = note.getValue() - string.getValue();
-					if (fret>=0 && fret<=MAX_FRET && (minFret<0 || fret<minFret) ) {
+					if (fret>=0 && fret<=maxFret && (minFret<0 || fret<minFret) ) {
 						newString = string;
 						minFret = fret;
 					}

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGTrack.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGTrack.java
@@ -19,6 +19,8 @@ public abstract class TGTrack {
 	public static final int MAX_OFFSET = 24;
 	public static final int MIN_OFFSET = -24;
 	
+	private final int MAX_FRET = 29;	// included
+	
 	private int number;
 	private int offset;
 	private int channelId;
@@ -159,6 +161,10 @@ public abstract class TGTrack {
 	
 	public void setSong(TGSong song) {
 		this.song = song;
+	}
+	
+	public int getMaxFret() {
+		return this.MAX_FRET; // yet always the default value, TODO: make it configurable
 	}
 	
 	public void clear(){

--- a/common/TuxGuitar-midi/src/org/herac/tuxguitar/io/midi/MidiSongReader.java
+++ b/common/TuxGuitar-midi/src/org/herac/tuxguitar/io/midi/MidiSongReader.java
@@ -788,17 +788,17 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 			Iterator<TGMeasure> it = track.getMeasures();
 			while(it.hasNext()){
 				TGMeasure measure = (TGMeasure)it.next();
-				process(measure, tgSongManager.isPercussionChannel(track.getSong(), track.getChannelId()));
+				process(measure, tgSongManager.isPercussionChannel(track.getSong(), track.getChannelId()), track.getMaxFret());
 			}
 		}
 		
-		public void process(TGMeasure measure, boolean isPercussionTrack){
+		private void process(TGMeasure measure, boolean isPercussionTrack, int maxFret){
 			orderBeats(measure);
 			joinBeats(measure);
-			adjustStrings(measure, isPercussionTrack);
+			adjustStrings(measure, isPercussionTrack, maxFret);
 		}
 		
-		public void joinBeats(TGMeasure measure) {
+		private void joinBeats(TGMeasure measure) {
 			TGBeat previous = null;
 			boolean finish = true;
 			
@@ -867,7 +867,7 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 			}
 		}
 		
-		public void orderBeats(TGMeasure measure){
+		private void orderBeats(TGMeasure measure){
 			for(int i = 0;i < measure.countBeats();i++){
 				TGBeat minBeat = null;
 				for(int j = i;j < measure.countBeats();j++){
@@ -880,7 +880,7 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 			}
 		}
 		
-		private void adjustStrings(TGMeasure measure, boolean isPercussionTrack){
+		private void adjustStrings(TGMeasure measure, boolean isPercussionTrack, int maxFret){
 			TGString string = this.factory.newString();
 			string.setNumber(1);
 			string.setValue(0);
@@ -889,7 +889,7 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 			if (isPercussionTrack) {
 				tgSongManager.getTrackManager().allocatePercussionNotesToStrings(strings, measure.getBeats(), measure.getTrack().getStrings());
 			} else {
-				tgSongManager.getTrackManager().allocateNotesToStrings(strings, measure.getBeats(), measure.getTrack().getStrings());
+				tgSongManager.getTrackManager().allocateNotesToStrings(strings, measure.getBeats(), measure.getTrack().getStrings(), maxFret);
 			}
 		}
 		

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGPasteAction.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/edit/TGPasteAction.java
@@ -48,7 +48,8 @@ public class TGPasteAction extends TGActionBase {
 				// clone clipboard content before modifying it, so it can be re-pasted later
 				TGStoredBeatList beatsListToPaste = beatList.clone(factory);
 				// then adapt notes to destination track (tuning might differ from source track)
-				trackManager.allocateNotesToStrings(beatsListToPaste.getStringValues(), beatsListToPaste.getBeats(), destTrack.getStrings());
+				trackManager.allocateNotesToStrings(beatsListToPaste.getStringValues(), beatsListToPaste.getBeats(),
+						destTrack.getStrings(), destTrack.getMaxFret());
 				
 				// paste
 				List<TGBeat> newBeats = trackManager.addBeats(destTrack, beatsListToPaste, start.getStart());

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/edit/EditorKit.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/edit/EditorKit.java
@@ -264,7 +264,7 @@ public class EditorKit {
 				TGMeasureImpl measure = this.getTablature().getCaret().getMeasure();
 				if(measure.getTs() != null){
 					int minValue = track.getString(track.stringCount()).getValue();
-					int maxValue = track.getString(1).getValue() + 29; //Max frets = 29
+					int maxValue = track.getString(1).getValue() + track.getMaxFret();
 					
 					float lineSpacing = this.getTablature().getViewLayout().getScoreLineSpacing();
 					
@@ -428,7 +428,7 @@ public class EditorKit {
 			if( measure != null && measure.getTs() != null && measure.getTrack().stringCount() > 0 ){
 				float scale = layout.getScale();
 				int minValue = measure.getTrack().getString(measure.getTrack().stringCount()).getValue();
-				int maxValue = measure.getTrack().getString(1).getValue() + 29;
+				int maxValue = measure.getTrack().getString(1).getValue() + measure.getTrack().getMaxFret();
 				float lineSpacing = layout.getScoreLineSpacing();
 				float width = (int)(10.0f * scale);
 				float topHeight = measure.getTs().getPosition(TGTrackSpacing.POSITION_SCORE_MIDDLE_LINES);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/grace/TGGraceDialog.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/grace/TGGraceDialog.java
@@ -12,6 +12,7 @@ import org.herac.tuxguitar.editor.action.effect.TGChangeGraceNoteAction;
 import org.herac.tuxguitar.song.factory.TGFactory;
 import org.herac.tuxguitar.song.models.TGDuration;
 import org.herac.tuxguitar.song.models.TGNote;
+import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.song.models.TGVelocities;
 import org.herac.tuxguitar.song.models.effects.TGEffectGrace;
 import org.herac.tuxguitar.ui.UIFactory;
@@ -57,6 +58,7 @@ public class TGGraceDialog {
 	
 	public void show(final TGViewContext context){
 		TGNoteRange noteRange = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
+		TGTrack track = (TGTrack) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
 		TGEffectGrace grace = null;
 		TGFactory factory = TuxGuitar.getInstance().getSongManager().getFactory();
 
@@ -105,6 +107,7 @@ public class TGGraceDialog {
 			
 			this.fretSpinner = uiFactory.createSpinner(noteGroup);
 			this.fretSpinner.setValue(fret);
+			this.fretSpinner.setMaximum(track.getMaxFret());
 			noteLayout.set(this.fretSpinner, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
 			
 			this.deadButton = uiFactory.createCheckBox(noteGroup);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/matrix/TGMatrixEditor.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/matrix/TGMatrixEditor.java
@@ -379,7 +379,7 @@ public class TGMatrixEditor implements TGEventListener {
 					for(int sNumber = 1; sNumber <= measure.getTrack().stringCount();sNumber ++){
 						TGString string = measure.getTrack().getString(sNumber);
 						this.minNote = Math.min(this.minNote,string.getValue());
-						this.maxNote = Math.max(this.maxNote,(string.getValue() + 20));
+						this.maxNote = Math.max(this.maxNote,(string.getValue() + measure.getTrack().getMaxFret()));
 					}
 					this.minNote = Math.max(this.minNote, TGMusicKeyUtils.MIN_MIDI_NOTE);
 					this.maxNote = Math.min(this.maxNote, TGMusicKeyUtils.MAX_MIDI_NOTE);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/trill/TGTrillDialog.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/trill/TGTrillDialog.java
@@ -11,6 +11,7 @@ import org.herac.tuxguitar.editor.action.TGActionProcessor;
 import org.herac.tuxguitar.editor.action.effect.TGChangeTrillNoteAction;
 import org.herac.tuxguitar.song.models.TGDuration;
 import org.herac.tuxguitar.song.models.TGNote;
+import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.song.models.effects.TGEffectTrill;
 import org.herac.tuxguitar.ui.UIFactory;
 import org.herac.tuxguitar.ui.event.UISelectionEvent;
@@ -39,6 +40,7 @@ public class TGTrillDialog {
 	
 	public void show(final TGViewContext context){
 		final TGNoteRange noteRange = (TGNoteRange) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_NOTE_RANGE);
+		TGTrack track = (TGTrack) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
 		
 		if( (noteRange != null) && !noteRange.isEmpty() ) {
 			final UIFactory uiFactory = TGApplication.getInstance(context.getContext()).getFactory();
@@ -80,7 +82,7 @@ public class TGTrillDialog {
 			
 			this.fretSpinner = uiFactory.createSpinner(noteGroup);
 			this.fretSpinner.setValue(fret);
-			this.fretSpinner.setMaximum(30);
+			this.fretSpinner.setMaximum(track.getMaxFret());
 			this.fretSpinner.setMinimum(0);
 			noteLayout.set(this.fretSpinner, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
 			


### PR DESCRIPTION
See #256
objective: 1 single hardcoded constant for max fret number

implementation:
- constant stored in TGTrack, so it can be customized per track one day
- removed many occurrences of hardcoded limits, use value from TGTrack
  difficult to know if other occurrences still remain, that's possible
- addition of a limit to grace note effect