### PR TITLE
enable pdf export and print NOT in compact mode

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
@@ -28,7 +28,7 @@ public class TGPrintLayout extends TGLayout {
 	private UIFont songAuthorFont;
 	
 	public TGPrintLayout(TGController controller, TGPrintSettings settings){
-		super(controller,( settings.getStyle() | DISPLAY_COMPACT ) );
+		super(controller, settings.getStyle());
 		this.settings = settings;
 	}
 	

--- a/desktop/TuxGuitar/share/lang/messages.properties
+++ b/desktop/TuxGuitar/share/lang/messages.properties
@@ -210,6 +210,7 @@ export.score-enabled=Show Score
 export.chord-name-enabled=Show Chord Names
 export.chord-diagram-enabled=Show Chord Diagrams
 export.black-and-white=Black And White Mode
+export.compact=Compact
 export.all-tracks=Export all Tracks
 file.print-preview=Print Preview
 print.preview=Print Preview

--- a/desktop/TuxGuitar/share/lang/messages_bg.properties
+++ b/desktop/TuxGuitar/share/lang/messages_bg.properties
@@ -66,6 +66,7 @@ export.score-enabled=Показване на партитура
 export.chord-name-enabled=Показване на имена на акорди
 export.chord-diagram-enabled=Показване диаграми на акорди
 export.black-and-white=Черно-бял режим
+export.compact=Компактна
 # export.all-tracks=
 file.print-preview=Преглед за печат
 print.preview=Преглед за печат

--- a/desktop/TuxGuitar/share/lang/messages_ca.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ca.properties
@@ -66,6 +66,7 @@ export.score-enabled=Mostra la partitura
 export.chord-name-enabled=Mostra els noms dels acords
 export.chord-diagram-enabled=Mostra els diagrames d'acords
 export.black-and-white=Mode blanc i negre
+export.compact=Mode compacte
 # export.all-tracks=
 file.print-preview=Previsualitzeu la impressió
 print.preview=Previsualitzeu la impressió

--- a/desktop/TuxGuitar/share/lang/messages_cs.properties
+++ b/desktop/TuxGuitar/share/lang/messages_cs.properties
@@ -66,6 +66,7 @@ export.score-enabled=Zobrazit notaci
 # export.chord-name-enabled=
 # export.chord-diagram-enabled=
 # export.black-and-white=
+# export.compact=
 # export.all-tracks=
 file.print-preview=Náhled tisku
 print.preview=Náhled tisku

--- a/desktop/TuxGuitar/share/lang/messages_de.properties
+++ b/desktop/TuxGuitar/share/lang/messages_de.properties
@@ -66,6 +66,7 @@ export.score-enabled=Partitur anzeigen
 export.chord-name-enabled=Akkordnamen anzeigen
 export.chord-diagram-enabled=Akkordtabellen anzeigen
 export.black-and-white=Schwarzweißmodus
+export.compact=Kompakte Anzeige
 export.all-tracks=Alle Spuren exportieren
 file.print-preview=Druckvorschau
 print.preview=Druckvorschau

--- a/desktop/TuxGuitar/share/lang/messages_el.properties
+++ b/desktop/TuxGuitar/share/lang/messages_el.properties
@@ -66,6 +66,7 @@ export.score-enabled=Προβολή Παρτιτούρας
 export.chord-name-enabled=Εμφάνιση των ονομάτων των συγχορδιών
 export.chord-diagram-enabled=Εμφάνιση των διαγραμμάτων των συγχορδιών
 export.black-and-white=Ασπρόμαυρη Λειτουργία
+export.compact=Συμπαγής
 # export.all-tracks=
 file.print-preview=Προεπισκόπηση εκτύπωσης
 print.preview=Προεπισκόπηση Εκτύπωση

--- a/desktop/TuxGuitar/share/lang/messages_es.properties
+++ b/desktop/TuxGuitar/share/lang/messages_es.properties
@@ -66,6 +66,7 @@ export.score-enabled=Mostrar partitura
 export.chord-name-enabled=Mostrar nombre de acordes
 export.chord-diagram-enabled=Mostrar diagrama de acordes
 export.black-and-white=Modo Blanco y Negro
+export.compact=Modo Compacto
 export.all-tracks=Exportar todas las pistas
 file.print-preview=Vista Preliminar
 print.preview=Vista Preliminar

--- a/desktop/TuxGuitar/share/lang/messages_eu.properties
+++ b/desktop/TuxGuitar/share/lang/messages_eu.properties
@@ -66,6 +66,7 @@ export.score-enabled=partitura erakutsi
 # export.chord-name-enabled=
 # export.chord-diagram-enabled=
 export.black-and-white=Beltz-Txuri moduan
+export.compact=Modu kompaktoan
 # export.all-tracks=
 file.print-preview=Itxura Preliminarra
 print.preview=Vista Preliminar

--- a/desktop/TuxGuitar/share/lang/messages_fi.properties
+++ b/desktop/TuxGuitar/share/lang/messages_fi.properties
@@ -66,6 +66,7 @@ export.score-enabled=Näytä nuottiviivasto
 export.chord-name-enabled=Näytä sointujen nimet
 export.chord-diagram-enabled=Näytä sointujen kuvat
 export.black-and-white=Mustavalkoinen tila
+export.compact=Tiivis ulkoasu
 # export.all-tracks=
 file.print-preview=Tulostuksen esikatselu
 print.preview=Tulostuksen esikatselu

--- a/desktop/TuxGuitar/share/lang/messages_fr.properties
+++ b/desktop/TuxGuitar/share/lang/messages_fr.properties
@@ -66,6 +66,7 @@ export.score-enabled=Afficher la portée
 export.chord-name-enabled=Afficher le nom des accords
 export.chord-diagram-enabled=Afficher les diagrammes d'accords
 export.black-and-white=Mode noir et blanc
+export.compact=Mode compact
 export.all-tracks=Exporter toutes les pistes
 file.print-preview=Aperçu avant impression
 print.preview=Aperçu avant impression

--- a/desktop/TuxGuitar/share/lang/messages_hu.properties
+++ b/desktop/TuxGuitar/share/lang/messages_hu.properties
@@ -66,6 +66,7 @@ export.score-enabled=Kotta látszik
 # export.chord-name-enabled=
 # export.chord-diagram-enabled=
 # export.black-and-white=
+# export.compact=
 # export.all-tracks=
 file.print-preview=Nyomtatási kép
 print.preview=Nyomtatási kép

--- a/desktop/TuxGuitar/share/lang/messages_it.properties
+++ b/desktop/TuxGuitar/share/lang/messages_it.properties
@@ -66,6 +66,7 @@ export.score-enabled=Mostra pentagramma
 export.chord-name-enabled=Abilita nome accordo
 export.chord-diagram-enabled=Mostra schema accordo
 export.black-and-white=Bianco e nero
+export.compact=Compatto
 export.all-tracks=Tutte le tracce
 file.print-preview=Anteprima di stampa
 print.preview=Anteprima stampa

--- a/desktop/TuxGuitar/share/lang/messages_ja.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ja.properties
@@ -66,6 +66,7 @@ export.score-enabled=五線譜を表示
 export.chord-name-enabled=コード名を表示
 export.chord-diagram-enabled=コード・ダイアグラムを表示
 export.black-and-white=白黒モード
+export.compact=コンパクト
 # export.all-tracks=
 file.print-preview=印刷プレビュ
 print.preview=印刷プレビュ

--- a/desktop/TuxGuitar/share/lang/messages_ko.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ko.properties
@@ -66,6 +66,7 @@ export.score-enabled=악보 보기
 export.chord-name-enabled=코드 이름 보기
 export.chord-diagram-enabled=코드표 보기
 # export.black-and-white=
+# export.compact=
 # export.all-tracks=
 file.print-preview=인쇄 미리보기
 print.preview=인쇄 미리보기

--- a/desktop/TuxGuitar/share/lang/messages_lt.properties
+++ b/desktop/TuxGuitar/share/lang/messages_lt.properties
@@ -66,6 +66,7 @@ export.score-enabled=Rodyti penklinę
 export.chord-name-enabled=Rodyti akordus
 export.chord-diagram-enabled=Rodyti akordų diagramą
 export.black-and-white=Juodai balta
+export.compact=Glaustai
 # export.all-tracks=
 file.print-preview=Spaudinio peržiūra
 print.preview=Spaudinio peržiūra

--- a/desktop/TuxGuitar/share/lang/messages_nl.properties
+++ b/desktop/TuxGuitar/share/lang/messages_nl.properties
@@ -66,6 +66,7 @@ export.score-enabled=Laat Score zien
 # export.chord-name-enabled=
 # export.chord-diagram-enabled=
 # export.black-and-white=
+export.compact=Compacte Layout
 # export.all-tracks=
 file.print-preview=Afdruk Voorbeeld
 print.preview=Afdruk Voorbeeld

--- a/desktop/TuxGuitar/share/lang/messages_pl.properties
+++ b/desktop/TuxGuitar/share/lang/messages_pl.properties
@@ -66,6 +66,7 @@ export.score-enabled=Pokaż zapis nutowy
 # export.chord-name-enabled=
 # export.chord-diagram-enabled=
 export.black-and-white=Tryb czarno-biały
+export.compact=Kompaktowy
 # export.all-tracks=
 file.print-preview=Podgląd wydruku
 print.preview=Podgląd wydruku

--- a/desktop/TuxGuitar/share/lang/messages_pt.properties
+++ b/desktop/TuxGuitar/share/lang/messages_pt.properties
@@ -66,6 +66,7 @@ export.score-enabled=Mostrar Partitura
 # export.chord-name-enabled=
 # export.chord-diagram-enabled=
 export.black-and-white=Modo Preto e Branco
+export.compact=Compacto
 # export.all-tracks=
 file.print-preview=Visualizar Impressão
 print.preview=Visualizar impressão

--- a/desktop/TuxGuitar/share/lang/messages_ru.properties
+++ b/desktop/TuxGuitar/share/lang/messages_ru.properties
@@ -66,6 +66,7 @@ export.score-enabled=Показать партитуру
 export.chord-name-enabled=Показать названия аккордов
 export.chord-diagram-enabled=Показать диаграммы аккордов
 export.black-and-white=Черно-белый режим
+export.compact=Компактный
 # export.all-tracks=
 file.print-preview=Предварительный просмотр
 print.preview=Предварительный просмотр

--- a/desktop/TuxGuitar/share/lang/messages_sr.properties
+++ b/desktop/TuxGuitar/share/lang/messages_sr.properties
@@ -66,6 +66,7 @@ export.score-enabled=Uvrsti note
 # export.chord-name-enabled=
 # export.chord-diagram-enabled=
 # export.black-and-white=
+export.compact=Kompaktan prikaz
 # export.all-tracks=
 file.print-preview=Pregled pre štampe
 print.preview=Pregled pre štampe

--- a/desktop/TuxGuitar/share/lang/messages_sv.properties
+++ b/desktop/TuxGuitar/share/lang/messages_sv.properties
@@ -66,6 +66,7 @@ export.score-enabled=Visa partitur
 export.chord-name-enabled=Visa ackordnamn
 export.chord-diagram-enabled=Visa ackorddiagram
 export.black-and-white=Svartvitt läge
+export.compact=Kompakt
 # export.all-tracks=
 file.print-preview=Förhandsgranska utskrift
 print.preview=Förhandskgranska utskrift

--- a/desktop/TuxGuitar/share/lang/messages_uk.properties
+++ b/desktop/TuxGuitar/share/lang/messages_uk.properties
@@ -66,6 +66,7 @@ export.score-enabled=Показати партитуру
 # export.chord-name-enabled=
 # export.chord-diagram-enabled=
 # export.black-and-white=
+export.compact=Компактно
 # export.all-tracks=
 file.print-preview=Попередній перегляд
 print.preview=Попередній перегляд

--- a/desktop/TuxGuitar/share/lang/messages_vi.properties
+++ b/desktop/TuxGuitar/share/lang/messages_vi.properties
@@ -66,6 +66,7 @@ export.score-enabled=Hiện bản nhạc
 export.chord-name-enabled=Hiện tên hợp âm
 export.chord-diagram-enabled=Hiện sơ đồ hợp âm
 # export.black-and-white=
+export.compact=Thu gọn
 # export.all-tracks=
 file.print-preview=Xem thử
 print.preview=Xem thử

--- a/desktop/TuxGuitar/share/lang/messages_zh.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh.properties
@@ -66,6 +66,7 @@ export.score-enabled=显示五线谱
 export.chord-name-enabled=显示和弦名
 export.chord-diagram-enabled=显示和弦图
 export.black-and-white=黑白模式
+export.compact=紧凑模式
 export.all-tracks=导出所有声部
 file.print-preview=打印预览
 print.preview=打印预览

--- a/desktop/TuxGuitar/share/lang/messages_zh_GB.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh_GB.properties
@@ -66,6 +66,7 @@ export.score-enabled=显示五线谱
 export.chord-name-enabled=显示和弦名
 export.chord-diagram-enabled=显示和弦图
 export.black-and-white=单色模式
+export.compact=紧缩模式
 # export.all-tracks=
 file.print-preview=打印预览
 print.preview=打印预览

--- a/desktop/TuxGuitar/share/lang/messages_zh_TW.properties
+++ b/desktop/TuxGuitar/share/lang/messages_zh_TW.properties
@@ -66,6 +66,7 @@ export.score-enabled=顯示五線譜
 export.chord-name-enabled=顯示和絃名稱
 export.chord-diagram-enabled=顯示和絃指圖
 export.black-and-white=黑和白的模式
+export.compact=精簡版
 # export.all-tracks=
 file.print-preview=預覽列印
 print.preview=預覽列印

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/printer/TGPrintSettingsDialog.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/printer/TGPrintSettingsDialog.java
@@ -153,6 +153,12 @@ public class TGPrintSettingsDialog {
 		blackAndWhite.setSelected(true);
 		optionsLayout.set(blackAndWhite, 5, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
 		
+		final UICheckBox compactMode = uiFactory.createCheckBox(options);
+		compactMode.setText(TuxGuitar.getProperty("export.compact"));
+		compactMode.setSelected(true);
+		optionsLayout.set(compactMode, 6, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
+
+		
 		tablatureEnabled.addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				if(!tablatureEnabled.isSelected()){
@@ -185,6 +191,7 @@ public class TGPrintSettingsDialog {
 				style |= (chordNameEnabled.isSelected() ? TGLayout.DISPLAY_CHORD_NAME : 0);
 				style |= (chordDiagramEnabled.isSelected() ? TGLayout.DISPLAY_CHORD_DIAGRAM : 0);
 				style |= (blackAndWhite.isSelected() ? TGLayout.DISPLAY_MODE_BLACK_WHITE : 0);
+				style |= (compactMode.isSelected() ? TGLayout.DISPLAY_COMPACT : 0);
 				
 				Integer selectedTrack = (!trackAllCheck.isSelected() ? trackCombo.getSelectedValue() : null);
 				


### PR DESCRIPTION
main objective: enable pdf export/print of detailed bends representation
default remains "compact mode = true", to save paper
see #202