### PR TITLE
Adds basic musicxml lyric support

### DIFF
--- a/desktop/TuxGuitar-musicxml/src/org/herac/tuxguitar/io/musicxml/MusicXMLLyricWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/org/herac/tuxguitar/io/musicxml/MusicXMLLyricWriter.java
@@ -1,0 +1,193 @@
+package org.herac.tuxguitar.io.musicxml;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.herac.tuxguitar.graphics.control.TGMeasureImpl;
+import org.herac.tuxguitar.song.models.TGTrack;
+
+/**
+ * MusicXMLLyricWriter is used to convert TGLyric to multiple MusicXMLMeasureLyric chunks.
+ * @author Menno Vossen
+ */
+public class MusicXMLLyricWriter {
+	/**
+	 * Syllabic enum.
+	 * See the MusicXML specification: <a href="https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/syllabic/">syllabic</a>
+	 */
+	public enum Syllabic {
+		NONE,
+		SINGLE,
+		BEGIN,
+		MIDDLE,
+		END;
+		
+		@Override
+		public String toString() {
+			switch(this.ordinal()) {
+			case 0:
+				return "none"; // NOTE: not a official syllabic but used in state machine.
+			case 1:
+				return "single";
+			case 2:
+				return "begin";
+			case 3:
+				return "middle";
+			case 4:
+				return "end";
+			default:
+				return "single";
+			}
+		}
+	}
+	/**
+	 * MusicXMLMeasureLyric contains the syllabic and text for one note.
+	 * See the MusicXML specification:
+	 * <a href="https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/lyric/">lyric</a>
+	 */
+	public class MusicXMLMeasureLyric {
+		public Syllabic syllabic;
+		public String text;
+		
+		/**
+		 * Class constructor.
+		 * @param syllabic
+		 * @param text
+		 */
+		public MusicXMLMeasureLyric(Syllabic syllabic, String text) {
+			this.syllabic = syllabic;
+			this.text = text;
+		}
+	}
+	/**
+	 * Helper function.
+	 * @param string
+	 * @return
+	 */
+	private static String removeLastChar(String string) {
+	    return (string == null || string.length() == 0)
+	    		? null : (string.substring(0, string.length() - 1));
+	}
+	
+	/**
+	 * Helper function.
+	 * The lyrics in TGLyric are for one track. The lyricStrings are lyric per note.
+	 * @param lyricStrings		string array source
+	 * @param start				start index for the slice
+	 * @param number			number of strings to get
+	 *
+	 * @return 	The string Array is used for one measure.
+	 */
+	private static String[] getLyricSlice(String[] lyricStrings, int start, int number) {
+		try {
+			return Arrays.stream(lyricStrings, start, start+number).toArray(String[]::new);
+		} catch (ArrayIndexOutOfBoundsException exception) {
+			// ignore
+			// more lyrics than notes!?
+		}
+		
+		// we need to return a default
+		String[] empty = {""};
+		return empty;
+	}
+	
+	/**
+	 * Holds the lyrics for the complete track.
+	 */
+	private String[] lyrics;
+	/**
+	 * Used to keep track off our position in the lyrics array.
+	 */
+	private int lyricIndex;
+	/**
+	 * Used to store the start of lyrics offset in Measures.
+	 */
+	private int lyricFrom;
+	/**
+	 * Used in the generateLyricList method, which is a state machine.
+	 */
+	private Syllabic syllabicState;
+	
+	
+	/**
+	 * MusicXMLLyricWriter Constructor.
+	 * @param track 	Holds track currently being processed.
+	 */
+	public MusicXMLLyricWriter(TGTrack track) {
+		lyricFrom = track.getLyrics().getFrom();
+		lyrics = track.getLyrics().getLyricBeats();
+		lyricIndex = 0; // in lyrics (Strings)
+		syllabicState = Syllabic.NONE;
+	}
+	/**
+	 * State machine, use only sequential calls to get lyrics from track.
+	 * @param measureImpl
+	 * @return returns an Array containing the text and syllabics for the passed in measure.
+	 */
+	public MusicXMLMeasureLyric[] generateLyricList(TGMeasureImpl measureImpl) {
+
+		if (measureImpl.getNumber() < lyricFrom) {
+			return null;
+		}
+		
+		int number = measureImpl.getNotEmptyBeats();
+		
+		ArrayList<MusicXMLMeasureLyric> measureLyrics = new ArrayList<MusicXMLMeasureLyric>();
+		
+		
+		String[] measureLyricStrings = getLyricSlice(lyrics, lyricIndex, number);
+		this.lyricIndex += number;
+		
+		Syllabic syllabic = Syllabic.NONE;
+
+		// Turn strings in MusicXMLMeasureLyric.
+		for (int i = 0; i < measureLyricStrings.length; i++) {
+			switch (this.syllabicState) {
+				case NONE:
+					if (measureLyricStrings[i].endsWith("-")) {
+						measureLyricStrings[i] = removeLastChar(measureLyricStrings[i]);
+						syllabic = Syllabic.BEGIN;
+						syllabicState = Syllabic.BEGIN; // new state
+					} else {
+						syllabic = Syllabic.SINGLE;
+						syllabicState = Syllabic.NONE; // new state
+					}
+					break;
+				case SINGLE:
+					syllabic = Syllabic.END;
+					syllabicState = Syllabic.NONE;
+					break;
+				case BEGIN:
+					if (measureLyricStrings[i].endsWith("-")) {
+						measureLyricStrings[i] = removeLastChar(measureLyricStrings[i]);
+						syllabic = Syllabic.MIDDLE;
+						syllabicState = Syllabic.MIDDLE;
+					} else {
+						syllabic = Syllabic.END;
+						syllabicState = Syllabic.NONE;
+					}
+					break;
+				case MIDDLE:
+					if (measureLyricStrings[i].endsWith("-")) {
+						measureLyricStrings[i] = removeLastChar(measureLyricStrings[i]);
+						syllabic = Syllabic.MIDDLE;
+						syllabicState = Syllabic.MIDDLE;
+					} else {
+						syllabic = Syllabic.END;
+						syllabicState = Syllabic.NONE;
+					}
+					break;
+				case END:
+					syllabic = Syllabic.NONE;
+					syllabicState = Syllabic.NONE;
+					break;
+			}
+
+			measureLyrics.add(new MusicXMLMeasureLyric(syllabic, measureLyricStrings[i]));
+		}
+		
+		MusicXMLMeasureLyric[] measureLyricArray = new MusicXMLMeasureLyric[measureLyrics.size()];
+		measureLyrics.toArray(measureLyricArray);
+		return 	measureLyricArray;
+	}
+}

--- a/desktop/TuxGuitar-musicxml/src/org/herac/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/org/herac/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -333,7 +333,9 @@ public class MusicXMLWriter {
 			
 			} else {
 				int noteCount = voice.countNotes();
-				
+
+				// Note: The order of elements is important 
+				// see https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/note/
 				for(int n = 0; n < noteCount; n ++){
 					TGNote note = voice.getNote( n );
 					
@@ -343,18 +345,8 @@ public class MusicXMLWriter {
 					
 					if(n > 0){
 						this.addNode(noteNode,"chord");
-					} else {
-						// Attach lyric to the first note
-						try {
-							MusicXMLMeasureLyric measureLyric = lyrics[lyricIndex++];
-							writeLyric(noteNode, measureLyric);
-						} catch (Exception e) {
-							// ignore
-							// can be out of bound? when there are more lyrics than text
-							// can be null if there is an offset
-						}
 					}
-					
+										
 					Node pitchNode = this.addNode(noteNode,"pitch");
 					this.writeNote(pitchNode, "", value, ks);
 					this.writeDuration(noteNode, voice.getDuration(), note.isTiedNote());
@@ -363,6 +355,17 @@ public class MusicXMLWriter {
 						Node technicalNode = this.addNode(this.addNode(noteNode, "notations"), "technical");
 						this.addNode(technicalNode,"fret", Integer.toString( note.getValue() ));
 						this.addNode(technicalNode,"string", Integer.toString( note.getString() ));
+					
+					} else if(n==0) {
+						// Attach lyric to the first note
+						try {
+							MusicXMLMeasureLyric measureLyric = lyrics[lyricIndex++];
+							writeLyric(noteNode, measureLyric);
+						} catch (Exception e) {
+							// ignore
+							// can be out of bound? when there are more lyrics than text
+							// can be null if there is an offset
+						}											
 					}
 				}
 			}


### PR DESCRIPTION
Adds basic musicxml lyric support

my notes on the state machine:
[Quick sheets.pdf](https://github.com/helge17/tuxguitar/files/14605513/Quick.sheets.pdf)

Not sure about the naming of my methods and classes.

Now it will export the lyrics twice, to the main track and to the tablature. Not sure about this, maybe only on the main track is better.

In the `getLyricSlice` function I'm using `Arrays.stream`,  the are other ways to do this if this is only supported in newer Java versions.

I did add javadoc compatible comments. I let it generate in `doc/java_docs` but the config for this is not in this request.

Take your time with the review. Java is a language I didn't touch in a decade, so there are probably better ways to do some things.

Cheers,

Menno