### PR TITLE
fix dependency

### DIFF
--- a/desktop/build-scripts/tuxguitar-freebsd-jfx-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-freebsd-jfx-x86_64/pom.xml
@@ -181,6 +181,12 @@
 									<destFileName>commons-compress.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
 								</artifactItem>
+								<artifactItem>
+									<groupId>commons-io</groupId>
+									<artifactId>commons-io</artifactId>
+									<destFileName>commons-io.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+								</artifactItem>
 								<!-- /3RD PARTY LIBRARIES -->
 
 								<!-- PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-freebsd-swt-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-freebsd-swt-x86_64/pom.xml
@@ -149,6 +149,12 @@
 									<destFileName>commons-compress.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
 								</artifactItem>
+								<artifactItem>
+									<groupId>commons-io</groupId>
+									<artifactId>commons-io</artifactId>
+									<destFileName>commons-io.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+								</artifactItem>
 								<!-- /3RD PARTY LIBRARIES -->
 
 								<!-- PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-linux-jfx-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-jfx-x86_64/pom.xml
@@ -181,6 +181,12 @@
 									<destFileName>commons-compress.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
 								</artifactItem>
+								<artifactItem>
+									<groupId>commons-io</groupId>
+									<artifactId>commons-io</artifactId>
+									<destFileName>commons-io.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+								</artifactItem>
 								<!-- /3RD PARTY LIBRARIES -->
 
 								<!-- PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-linux-swt-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-swt-x86_64/pom.xml
@@ -149,6 +149,12 @@
 									<destFileName>commons-compress.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
 								</artifactItem>
+								<artifactItem>
+									<groupId>commons-io</groupId>
+									<artifactId>commons-io</artifactId>
+									<destFileName>commons-io.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+								</artifactItem>
 								<!-- /3RD PARTY LIBRARIES -->
 
 								<!-- PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-macosx-jfx-cocoa-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-macosx-jfx-cocoa-x86_64/pom.xml
@@ -182,6 +182,12 @@
 									<destFileName>commons-compress.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/Contents/MacOS/lib</outputDirectory>
 								</artifactItem>
+								<artifactItem>
+									<groupId>commons-io</groupId>
+									<artifactId>commons-io</artifactId>
+									<destFileName>commons-io.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+								</artifactItem>
 								<!-- /3RD PARTY LIBRARIES -->
 
 								<!-- PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-macosx-swt-cocoa-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-macosx-swt-cocoa-x86_64/pom.xml
@@ -151,6 +151,12 @@
 									<destFileName>commons-compress.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/Contents/MacOS/lib</outputDirectory>
 								</artifactItem>
+								<artifactItem>
+									<groupId>commons-io</groupId>
+									<artifactId>commons-io</artifactId>
+									<destFileName>commons-io.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+								</artifactItem>
 								<!-- /3RD PARTY LIBRARIES -->
 
 								<!-- PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-windows-jfx-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-windows-jfx-x86_64/pom.xml
@@ -180,6 +180,12 @@
 									<destFileName>commons-compress.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
 								</artifactItem>
+								<artifactItem>
+									<groupId>commons-io</groupId>
+									<artifactId>commons-io</artifactId>
+									<destFileName>commons-io.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+								</artifactItem>
 								<!-- /3RD PARTY LIBRARIES -->
 
 								<!-- PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-windows-swt-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-windows-swt-x86_64/pom.xml
@@ -149,6 +149,12 @@
 									<destFileName>commons-compress.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
 								</artifactItem>
+								<artifactItem>
+									<groupId>commons-io</groupId>
+									<artifactId>commons-io</artifactId>
+									<destFileName>commons-io.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/lib</outputDirectory>
+								</artifactItem>
 								<!-- /3RD PARTY LIBRARIES -->
 
 								<!-- PLUGINS -->

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -353,6 +353,11 @@
 				<artifactId>commons-compress</artifactId>
 				<version>1.26.0</version>
 			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.15.1</version>
+			</dependency>
 			<!-- /commons compress -->
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
see #283

following 2f681c7d5c82509fbf6d1ef573ed505070e905ab
commons-compress update now requires explicit dependency to commons-io

needed to open .gp files

tested on Linux (openSUSE Tumbleweed) and Windows 10, SWT and JFX
tested on FreeBSD, SWT only
built but not tested on FreeBSD, JFX

not built not tested on macOS

@helge17 : since it modifies the pom files, I would appreciate if you could test in macOS configuration (I prefer not to merge this PR myself)