### PR TITLE
Add recurse mkdir

### DIFF
--- a/misc/build_tuxguitar_from_source.sh
+++ b/misc/build_tuxguitar_from_source.sh
@@ -467,7 +467,7 @@ for GUI_TK in swt jfx; do
   mvn --batch-mode -e clean verify
 
   # Copy locally installed openjdk (from Homebrew) to get it integrated in the APP.TAR.GZ packages
-  mkdir target/tuxguitar-$TGVERSION-macosx-$GUI_TK-cocoa-$BUILD_ARCH.app/Contents/MacOS/jre
+  mkdir -p target/tuxguitar-$TGVERSION-macosx-$GUI_TK-cocoa-$BUILD_ARCH.app/Contents/MacOS/jre
   cp -ai /usr/local/opt/openjdk/* target/tuxguitar-$TGVERSION-macosx-$GUI_TK-cocoa-$BUILD_ARCH.app/Contents/MacOS/jre
 
   tar --uname=root --gname=root --directory=target -czf $DIST_DIR/tuxguitar-$TGVERSION-macosx-$GUI_TK-cocoa-$BUILD_ARCH.app.tar.gz tuxguitar-$TGVERSION-macosx-$GUI_TK-cocoa-$BUILD_ARCH.app


### PR DESCRIPTION
mkdir fails on a fresh cloned repository in my case. Adding -p to mkdir fix it.