### PR TITLE
Adds maven versions plugin

### DIFF
--- a/common/TuxGuitar-compat/pom.xml
+++ b/common/TuxGuitar-compat/pom.xml
@@ -1,6 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
 		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<parent>
 		<artifactId>tuxguitar-pom</artifactId>
 		<groupId>org.herac.tuxguitar</groupId>
@@ -12,6 +13,8 @@
 	<artifactId>tuxguitar-compat</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/common/TuxGuitar-editor-utils/pom.xml
+++ b/common/TuxGuitar-editor-utils/pom.xml
@@ -12,6 +12,8 @@
 	<artifactId>tuxguitar-editor-utils</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/common/TuxGuitar-gm-utils/pom.xml
+++ b/common/TuxGuitar-gm-utils/pom.xml
@@ -12,6 +12,8 @@
 	<artifactId>tuxguitar-gm-utils</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/common/TuxGuitar-gpx/pom.xml
+++ b/common/TuxGuitar-gpx/pom.xml
@@ -12,6 +12,8 @@
 	<artifactId>tuxguitar-gpx</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/common/TuxGuitar-gtp/pom.xml
+++ b/common/TuxGuitar-gtp/pom.xml
@@ -12,6 +12,8 @@
 	<artifactId>tuxguitar-gtp</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/common/TuxGuitar-lib/pom.xml
+++ b/common/TuxGuitar-lib/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.herac.tuxguitar</groupId>
 	<artifactId>tuxguitar-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>SNAPSHOT</version>
+	<version>1.6.2-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 
 	<properties>

--- a/common/TuxGuitar-lilypond/pom.xml
+++ b/common/TuxGuitar-lilypond/pom.xml
@@ -12,6 +12,8 @@
 	<artifactId>tuxguitar-lilypond</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/common/TuxGuitar-midi/pom.xml
+++ b/common/TuxGuitar-midi/pom.xml
@@ -12,6 +12,8 @@
 	<artifactId>tuxguitar-midi</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/common/TuxGuitar-pdf/pom.xml
+++ b/common/TuxGuitar-pdf/pom.xml
@@ -12,6 +12,8 @@
 	<artifactId>tuxguitar-pdf</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/common/TuxGuitar-ptb/pom.xml
+++ b/common/TuxGuitar-ptb/pom.xml
@@ -12,6 +12,8 @@
 	<artifactId>tuxguitar-ptb</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-AudioUnit/pom.xml
+++ b/desktop/TuxGuitar-AudioUnit/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-audiounit</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-alsa/pom.xml
+++ b/desktop/TuxGuitar-alsa/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-alsa</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-ascii/pom.xml
+++ b/desktop/TuxGuitar-ascii/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-ascii</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-awt-graphics/pom.xml
+++ b/desktop/TuxGuitar-awt-graphics/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-awt-graphics</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-browser-ftp/pom.xml
+++ b/desktop/TuxGuitar-browser-ftp/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-browser-ftp</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-cocoa-integration-swt/pom.xml
+++ b/desktop/TuxGuitar-cocoa-integration-swt/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-cocoa-integration-swt</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-converter/pom.xml
+++ b/desktop/TuxGuitar-converter/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-converter</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-debug-helper/pom.xml
+++ b/desktop/TuxGuitar-debug-helper/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-debug-helper</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-fluidsynth/pom.xml
+++ b/desktop/TuxGuitar-fluidsynth/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-fluidsynth</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-gervill/pom.xml
+++ b/desktop/TuxGuitar-gervill/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-gervill</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-gm-settings/pom.xml
+++ b/desktop/TuxGuitar-gm-settings/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-gm-settings</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-gtp-ui/pom.xml
+++ b/desktop/TuxGuitar-gtp-ui/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-gtp-ui</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-image-swt/pom.xml
+++ b/desktop/TuxGuitar-image-swt/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-image-swt</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-jack-ui/pom.xml
+++ b/desktop/TuxGuitar-jack-ui/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-jack-ui</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-jack/pom.xml
+++ b/desktop/TuxGuitar-jack/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-jack</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-jsa/pom.xml
+++ b/desktop/TuxGuitar-jsa/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-jsa</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-lilypond-ui/pom.xml
+++ b/desktop/TuxGuitar-lilypond-ui/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-lilypond-ui</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-midi-ui/pom.xml
+++ b/desktop/TuxGuitar-midi-ui/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-midi-ui</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-musicxml/pom.xml
+++ b/desktop/TuxGuitar-musicxml/pom.xml
@@ -10,6 +10,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tuxguitar-musicxml</artifactId>
 	<packaging>jar</packaging>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 
 	<build>

--- a/desktop/TuxGuitar-pdf-ui/pom.xml
+++ b/desktop/TuxGuitar-pdf-ui/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-pdf-ui</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-svg/pom.xml
+++ b/desktop/TuxGuitar-svg/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-svg</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-synth-export/pom.xml
+++ b/desktop/TuxGuitar-synth-export/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-synth-export</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-synth-gervill/pom.xml
+++ b/desktop/TuxGuitar-synth-gervill/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-synth-gervill</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-synth-lv2/pom.xml
+++ b/desktop/TuxGuitar-synth-lv2/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-synth-lv2</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/desktop/TuxGuitar-synth-vst/pom.xml
+++ b/desktop/TuxGuitar-synth-vst/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-synth-vst</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-synth/pom.xml
+++ b/desktop/TuxGuitar-synth/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-synth</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-tef/pom.xml
+++ b/desktop/TuxGuitar-tef/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-tef</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-test/pom.xml
+++ b/desktop/TuxGuitar-test/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-test</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-tray-swt/pom.xml
+++ b/desktop/TuxGuitar-tray-swt/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-tray-swt</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-tuner/pom.xml
+++ b/desktop/TuxGuitar-tuner/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-tuner</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-ui-toolkit-jfx/pom.xml
+++ b/desktop/TuxGuitar-ui-toolkit-jfx/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-ui-toolkit-jfx</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-ui-toolkit-swt/pom.xml
+++ b/desktop/TuxGuitar-ui-toolkit-swt/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-ui-toolkit-swt</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-ui-toolkit/pom.xml
+++ b/desktop/TuxGuitar-ui-toolkit/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-ui-toolkit</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar-winmm/pom.xml
+++ b/desktop/TuxGuitar-winmm/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar-winmm</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/TuxGuitar/pom.xml
+++ b/desktop/TuxGuitar/pom.xml
@@ -11,6 +11,8 @@
 	<artifactId>tuxguitar</artifactId>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
+	<groupId>org.herac.tuxguitar</groupId>
+	<version>1.6.2-SNAPSHOT</version>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/desktop/build-scripts/tuxguitar-linux-swt-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-swt-x86_64/pom.xml
@@ -10,6 +10,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tuxguitar-linux-swt-x86_64</artifactId>
+	<version>1.6.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>${project.artifactId}</name>
 
@@ -366,6 +367,14 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.16.2</version>
+				<configuration>
+					<allowSnapshots>true</allowSnapshots>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Adds the plugin to the root pom.xml
Adds missing 'version', and 'groupId' element in other pom.xml files

Maybe add merge it in a dev branch. Probably the build scripts needs to be adjusted.

In the `tuxguitar/desktop/build-scripts/tuxguitar-linux-swt-x86_64` folder do `

`mvn versions:set -DnewVersion=1.6.2-SNAPSHOT -DoldVersion=* -DgroupId=org.herac.tuxguitar -DartifactId=*`

Note the groupId, so it is confined.

`mvn clean verify`

`mvn versions:commit` when happy.

`mvn versions:revert` when not happy.

`mvn versions:help` for other options.