### PR TITLE
Configurable tuning presets in xml file using priority attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ desktop/build-scripts/native-modules/tuxguitar-synth-vst-*/include/
 .project
 android/build-scripts/tuxguitar-android/local.properties
 android/build-scripts/tuxguitar-android/.idea/
+desktop/build-scripts/*
+00-Binary_Packages/

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/tuning/TuningManager.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/tuning/TuningManager.java
@@ -13,72 +13,92 @@ import org.herac.tuxguitar.util.singleton.TGSingletonUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TuningManager {
 
-	static String TG_TUNING_FILE = "tunings" + File.separator + "tunings.xml";
-	
-	private TGContext context;
-	
-	private TuningGroup tgTuningsGroup;
-	private TuningGroup customTuningsGroup;
+        static String TG_TUNING_FILE = "tunings" + File.separator + "tunings.xml";
+        
+        private TGContext context;
+        
+        private TuningGroup tgTuningsGroup;
+        private TuningGroup customTuningsGroup;
 
-	private TuningManager(TGContext context){
-		this.context = context;
-		this.tgTuningsGroup = new TuningGroup();
-		this.customTuningsGroup = new TuningGroup();
-		this.loadTunings();
-	}
-	
-	public TuningGroup getTgTuningsGroup() {
-		return this.tgTuningsGroup;
-	}
-	
-	public TuningGroup getCustomTuningsGroup() {
-		return this.customTuningsGroup;
-	}
-	
-	private List<TGTuning> getTuningsInGroup(String prefix, TuningGroup group) {
-		List<TGTuning> list = new ArrayList<TGTuning>();
-		for (TuningGroup subGroup : group.getGroups()) {
-			String groupPrefix = (prefix.equals("") ? "" : (prefix + " / ")) + subGroup.getName();
-			list.addAll(getTuningsInGroup(groupPrefix, subGroup));
-		}
-		for (TuningPreset preset : group.getTunings()) {
-			TuningPreset tgTuning = new TuningPreset(null, prefix + " / " + preset.getName(), preset.getValues());
-			list.add((TGTuning)tgTuning);
-		}
-		return(list);
-	}
-	
-	// flat list of tunings, prefixed with group names (recursively)
-	public List<TGTuning> getTgTunings() {
-		return (getTuningsInGroup("", tgTuningsGroup));
-	}
-	
-	public void saveCustomTunings(TuningGroup group) {
-		TuningWriter.write(group, TGUserFileUtils.PATH_USER_TUNINGS);
-	}
-	
-	private void loadTunings(){
-		try{
-			TuningReader tuningReader = new TuningReader();
-			tuningReader.loadTunings(this.tgTuningsGroup, TGResourceManager.getInstance(this.context).getResourceAsStream(TG_TUNING_FILE) );
-			File file = new File(TGUserFileUtils.PATH_USER_TUNINGS);
-			if (TGUserFileUtils.isExistentAndReadable(file)) {
-				tuningReader.loadTunings(this.customTuningsGroup, new FileInputStream(TGUserFileUtils.PATH_USER_TUNINGS));
-			}
-		} catch (Throwable e) {
-			TGErrorManager.getInstance(this.context).handleError(e);
-		}
-	}
-	
-	public static TuningManager getInstance(TGContext context) {
-		return TGSingletonUtil.getInstance(context, TuningManager.class.getName(), new TGSingletonFactory<TuningManager>() {
-			public TuningManager createInstance(TGContext context) {
-				return new TuningManager(context);
-			}
-		});
-	}
+        private TuningManager(TGContext context){
+                this.context = context;
+                this.tgTuningsGroup = new TuningGroup();
+                this.customTuningsGroup = new TuningGroup();
+                this.loadTunings();
+        }
+        
+        public TuningGroup getTgTuningsGroup() {
+                return this.tgTuningsGroup;
+        }
+        
+        public TuningGroup getCustomTuningsGroup() {
+                return this.customTuningsGroup;
+        }
+        
+        private List<TGTuning> getTuningsInGroup(String prefix, TuningGroup group, boolean isPrioritized) {
+                List<TGTuning> list = new ArrayList<TGTuning>();
+                for (TuningGroup subGroup : group.getGroups()) {
+                        String groupPrefix = (prefix.equals("") ? "" : (prefix + " / ")) + subGroup.getName();
+                        list.addAll(getTuningsInGroup(groupPrefix, subGroup, isPrioritized));
+                }
+                for (TuningPreset preset : group.getTunings()) {
+                        TuningPreset tgTuning = new TuningPreset(null, prefix + " / " + preset.getName(), preset.getValues());
+
+                        if (!isPrioritized)
+                                list.add((TGTuning)tgTuning);
+                        else { 
+                                if (preset.getPriority() != null) {
+                                        tgTuning.setPriority(preset.getPriority().intValue());
+                                        list.add((TGTuning)tgTuning);
+                                }
+                        }
+
+                }
+                return(list);
+        }
+        
+        // flat list of tunings, prefixed with group names (recursively)
+        public List<TGTuning> getTgTunings() {
+                return (getTuningsInGroup("", tgTuningsGroup, false));
+        }
+
+        public List<TGTuning> getPrioritizedTgTunings() {
+                List<TGTuning> prioritiezedTunings = getTuningsInGroup("", tgTuningsGroup, true);
+                Collections.sort(prioritiezedTunings);
+                return prioritiezedTunings;
+        }
+        
+        public void saveCustomTunings(TuningGroup group) {
+                TuningWriter.write(group, TGUserFileUtils.PATH_USER_TUNINGS);
+        }
+        
+        private void loadTunings(){
+                try{
+                        TuningReader tuningReader = new TuningReader();
+
+                        String defaultTuningFilePath = TGUserFileUtils.PATH_HOME + File.separator + "share" + File.separator + TG_TUNING_FILE;
+
+                        tuningReader.loadTunings(this.tgTuningsGroup, new FileInputStream(defaultTuningFilePath));
+
+                        File file = new File(TGUserFileUtils.PATH_USER_TUNINGS);
+                        if (TGUserFileUtils.isExistentAndReadable(file)) {
+                                tuningReader.loadTunings(this.customTuningsGroup, new FileInputStream(TGUserFileUtils.PATH_USER_TUNINGS));
+                        }
+                } catch (Throwable e) {
+                        TGErrorManager.getInstance(this.context).handleError(e);
+                }
+        }
+        
+        public static TuningManager getInstance(TGContext context) {
+                return TGSingletonUtil.getInstance(context, TuningManager.class.getName(), new TGSingletonFactory<TuningManager>() {
+                        public TuningManager createInstance(TGContext context) {
+                                return new TuningManager(context);
+                        }
+                });
+        }
 }

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/tuning/xml/TuningReader.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/tuning/xml/TuningReader.java
@@ -20,6 +20,7 @@ public class TuningReader {
 	static final String GROUP_TAG = "group";
 	static final String NAME_ATTRIBUTE = "name";
 	static final String NOTES_ATTRIBUTE = "notes";
+        static final String PRIORITY_ATTRIBUTE = "priority";
 	static final String KEY_SEPARATOR = ",";
 	
 	public void loadTunings(TuningGroup group, InputStream stream){
@@ -62,6 +63,7 @@ public class TuningReader {
 				if (name == null || notes == null || name.trim().equals("") || notes.trim().equals("")){
 					throw new RuntimeException("Invalid Tuning file format.");
 				}
+
 				String[] noteStrings = notes.split(KEY_SEPARATOR);
 				int[] noteValues = new int[noteStrings.length];
 				for (int j = 0; j < noteStrings.length; j++){
@@ -74,7 +76,19 @@ public class TuningReader {
 				}
 				
 				TuningPreset tuning = new TuningPreset(group, name, noteValues);
+
+                                // Add priority attribute if available
+                                if (params.getNamedItem(PRIORITY_ATTRIBUTE) != null) {
+                                        String prioStr = params.getNamedItem(PRIORITY_ATTRIBUTE).getNodeValue();
+                                        // make sure priority string is valid
+                                        if (prioStr != null && !prioStr.equals("") && prioStr.matches("\\d+"))
+                                                tuning.setPriority(Integer.parseInt(prioStr));
+                                }
+
 				group.getTunings().add(tuning);
+				
+				System.out.print(group.getTunings().toString());
+
 			} else if (nodeName.equals(GROUP_TAG)) {
 				NamedNodeMap params = child.getAttributes();
 				String name = params.getNamedItem(NAME_ATTRIBUTE).getNodeValue();

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGTuning.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGTuning.java
@@ -1,9 +1,10 @@
 package org.herac.tuxguitar.song.models;
 
-public class TGTuning {
+public class TGTuning implements Comparable<TGTuning>{
 
 	private String name;
 	private int[] values;
+        private Integer priority = null; 
 
 	public void setName(String name) {
 		this.name = name;
@@ -12,10 +13,31 @@ public class TGTuning {
 	public void setValues(int[] values) {
 		this.values = values;
 	}
+
+        public void setPriority(int prio) {
+                this.priority = prio;
+        }
+
 	public String getName() {
 		return this.name;
 	}
 	public int[] getValues() {
 		return this.values;
 	}
+
+        public Integer getPriority() { 
+                return this.priority;
+        }
+
+        @Override
+        public int compareTo(TGTuning other) {
+                if (this.priority == null && other.getPriority() == null)
+                        return 0;
+                else if (this.priority != null && other.getPriority() == null)
+                        return -1;
+                else if (this.priority == null && other.getPriority() != null)
+                        return 1;
+
+                return this.priority.intValue() - other.getPriority().intValue();
+        }
 }

--- a/common/TuxGuitar-midi/src/org/herac/tuxguitar/io/midi/MidiSongReader.java
+++ b/common/TuxGuitar-midi/src/org/herac/tuxguitar/io/midi/MidiSongReader.java
@@ -18,6 +18,7 @@ import org.herac.tuxguitar.io.midi.base.MidiSequence;
 import org.herac.tuxguitar.io.midi.base.MidiTrack;
 import org.herac.tuxguitar.player.base.MidiControllers;
 import org.herac.tuxguitar.song.factory.TGFactory;
+import org.herac.tuxguitar.song.helpers.tuning.TuningManager;
 import org.herac.tuxguitar.song.managers.TGSongManager;
 import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGChannel;
@@ -32,6 +33,8 @@ import org.herac.tuxguitar.song.models.TGString;
 import org.herac.tuxguitar.song.models.TGTempo;
 import org.herac.tuxguitar.song.models.TGTimeSignature;
 import org.herac.tuxguitar.song.models.TGTrack;
+import org.herac.tuxguitar.song.models.TGTuning;
+import org.herac.tuxguitar.util.TGContext;
 
 public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 	
@@ -698,44 +701,44 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 		
 		public List<TGString> getStrings(int maxFret) {
 			List<TGString> strings = new ArrayList<TGString>();
+
+                        TuningManager tuningManager = TuningManager.getInstance(new TGContext());
+                        List<TGTuning> tunings = tuningManager.getPrioritizedTgTunings();
 			
+                        // E Standard
 			if(this.minValue >= 40 && this.maxValue <= 64 + maxFret){
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,1, 64));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,2, 59));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,3, 55));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,4, 50));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,5, 45));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,6, 40));
+                                int[] notes = tunings.get(0).getValues();
+                                for ( int i = 0; i < notes.length; i++ ) {
+                                        strings.add(TGSongManager.newString(MidiSongReader.this.factory, i+1, notes[i]));
+                                }
 			}
+                        // Drop D
 			else if(this.minValue >= 38 && this.maxValue <= 64 + maxFret){
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,1, 64));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,2, 59));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,3, 55));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,4, 50));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,5, 45));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,6, 38));
+                                int[] notes = tunings.get(1).getValues();
+                                for ( int i = 0; i < notes.length; i++ ) {
+                                        strings.add(TGSongManager.newString(MidiSongReader.this.factory, i+1, notes[i]));
+                                }
 			}
+                        // 7-String, B Standrd
 			else if(this.minValue >= 35 && this.maxValue <= 64 + maxFret){
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,1, 64));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,2, 59));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,3, 55));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,4, 50));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,5, 45));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,6, 40));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,7, 35));
+                                int[] notes = tunings.get(2).getValues();
+                                for ( int i = 0; i < notes.length; i++ ) {
+                                        strings.add(TGSongManager.newString(MidiSongReader.this.factory, i+1, notes[i]));
+                                }
 			}
+                              // Bass, E Standard
 			else if(this.minValue >= 28 && this.maxValue <= 43 + maxFret){
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,1, 43));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,2, 38));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,3, 33));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,4, 28));
+                                int[] notes = tunings.get(3).getValues();
+                                for ( int i = 0; i < notes.length; i++ ) {
+                                        strings.add(TGSongManager.newString(MidiSongReader.this.factory, i+1, notes[i]));
+                                }
 			}
+                        // Bass 5-string, B Standard
 			else if(this.minValue >= 23 && this.maxValue <= 43 + maxFret){
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,1, 43));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,2, 38));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,3, 33));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,4, 28));
-				strings.add(TGSongManager.newString(MidiSongReader.this.factory,5, 23));
+                                int[] notes = tunings.get(4).getValues();
+                                for ( int i = 0; i < notes.length; i++ ) {
+				  strings.add(TGSongManager.newString(MidiSongReader.this.factory, i+1, notes[i]));
+                                }
 			}else{
 				int stringCount = 6;
 				int stringSpacing = ((this.maxValue - (maxFret - 4) - this.minValue) / stringCount);

--- a/desktop/TuxGuitar/share/tunings/tunings.xml
+++ b/desktop/TuxGuitar/share/tunings/tunings.xml
@@ -2,7 +2,7 @@
 <tunings>
 	<group name="Guitar">
 		<group name="6-String">
-			<tuning name="E Tuning" notes="64,59,55,50,45,40" />
+			<tuning name="E Tuning" notes="64,59,55,50,45,40" priority="1" />
 			<tuning name="D# Tuning" notes="63,58,54,49,44,39" />
 			<tuning name="D Tuning" notes="62,57,53,48,43,38" />
 			<tuning name="C# Tuning" notes="61,56,52,47,42,37" />
@@ -10,7 +10,7 @@
 			<tuning name="B Tuning" notes="59,54,50,45,40,35" />
 			<tuning name="A# Tuning" notes="58,53,49,44,39,34" />
 			<tuning name="F Tuning" notes="65,60,56,51,46,41" />
-			<tuning name="Dropped D" notes="64,59,55,50,45,38" />
+			<tuning name="Dropped D" notes="64,59,55,50,45,38" priority="2" />
 			<tuning name="Dropped C#" notes="63,58,54,49,44,37" />
 			<tuning name="Dropped C" notes="62,57,53,48,43,36" />
 			<tuning name="Dropped B" notes="61,56,52,47,42,35" />
@@ -29,7 +29,7 @@
 			<tuning name="NST" notes="67,64,57,50,43,36" />
 		</group>
 		<group name="7-String">
-			<tuning name="B Tuning" notes="64,59,55,50,45,40,35" />
+			<tuning name="B Tuning" notes="64,59,55,50,45,40,35" priority="3" />
 			<tuning name="Dropped A" notes="64,59,55,50,45,40,33" />
 		</group>
 		<group name="8-String">
@@ -44,7 +44,7 @@
 			<tuning name="E Tuning" notes="38,33,28" />
 		</group>
 		<group name="4-String">
-			<tuning name="E Tuning" notes="43,38,33,28" />
+			<tuning name="E Tuning" notes="43,38,33,28" priority="4" />
 			<tuning name="Dropped D" notes="43,38,33,26" />
 			<tuning name="Tenor" notes="48,43,38,33" />
 			<tuning name="D# Tuning" notes="42,37,32,27" />
@@ -55,7 +55,7 @@
 			<tuning name="A# Tuning" notes="37,32,27,22" />
 		</group>
 		<group name="5-String">
-			<tuning name="B Tuning" notes="43,38,33,28,23" />
+			<tuning name="B Tuning" notes="43,38,33,28,23" priority="5" />
 			<tuning name="Tenor" notes="48,43,38,33,28" />
 		</group>
 		<group name="6-String">

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/about/TGAboutDialog.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/about/TGAboutDialog.java
@@ -30,7 +30,7 @@ import org.herac.tuxguitar.util.TGVersion;
 
 public class TGAboutDialog {
 	
-	private static final String RELEASE_NAME = (TGApplication.NAME + " " + TGVersion.CURRENT.getVersion());
+	private static final String RELEASE_NAME = (TGApplication.NAME + " 2024-03-12-Issue#269");
 	private static final String PROPERTY_PREFIX = ("help.about.");
 	
 	private static final float IMAGE_WIDTH = 100;


### PR DESCRIPTION
- Add an optional attribute priority to tuning presets in tuning.xml file
- Add an integer attribute priority in TGTuning class, with value imported from xml file content
- Implement Comparable<TGTuning> interface in TGTuning class, so instances can be sorted by priority order
- Add method getPrioritizedTgTunings(), which returns all TG tuning presets with a defined priority attribute, discard tuning presets with no priority.