### PR TITLE
wider caret, for better readability

### DIFF
--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Caret.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Caret.java
@@ -170,7 +170,8 @@ public class Caret {
 					
 					painter.initPath();
 					painter.setAntialias(false);
-					painter.addRectangle(x, y, width, height);
+					painter.addRectangle(x, y, width+1.0f, height+1.0f);
+					painter.addRectangle(x+1, y+1, width-1.0f, height-1.0f);
 					painter.closePath();
 				}
 				else if( (layout.getStyle() & TGLayout.DISPLAY_SCORE) != 0){


### PR DESCRIPTION
Evolution requested by a user on a french-speaking [guitar forum](https://forum-guitare.fr/viewtopic.php?t=58851&start=53)

@helge17: what do you think of this?
It's always a bit subjective when it comes to graphical user interface. Screenshots before and after:
![original](https://github.com/helge17/tuxguitar/assets/129443524/e8512212-5a5d-48bc-adb2-5d21e58fdf2b) ![wider](https://github.com/helge17/tuxguitar/assets/129443524/1bf37193-7378-4e44-82cd-0bd9094b8873)




Implementation details:
frustrating: cannot use painter.setLineWidth(2.0f) This would modify a property of the painter, which is used further to draw other items

Not possible either to restore lineWidth to default (or to previous value) after drawing caret: no available methods for that in UIPainter. Adding such methods in this interface is quite complex, as it has many implementations