### PR TITLE
make "instrument" column resizable in track table

### DIFF
--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTable.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTable.java
@@ -84,9 +84,9 @@ public class TGTable {
 		this.createColumnHeaderLayout(uiLayout, this.columnNumber, ++columnIndex, false, null);
 		this.createColumnHeaderLayout(uiLayout, this.columnSoloMute, ++columnIndex, false, null);
 		this.createColumnHeaderLayout(uiLayout, this.columnName, ++columnIndex, false, 250f);
-		this.createColumnDividerLayout(uiLayout, dividerHelper.createDivider(this.columnName, this.columnInstrument), ++columnIndex);
+		this.createColumnDividerLayout(uiLayout, dividerHelper.createDivider(this.columnName, this.columnInstrument, false), ++columnIndex);
 		this.createColumnHeaderLayout(uiLayout, this.columnInstrument, ++columnIndex, false, 250f);
-		this.createColumnDividerLayout(uiLayout, dividerHelper.createDivider(this.columnInstrument, this.columnCanvas), ++columnIndex);
+		this.createColumnDividerLayout(uiLayout, dividerHelper.createDivider(this.columnInstrument, this.columnCanvas, true), ++columnIndex);
 		this.createColumnHeaderLayout(uiLayout, this.columnCanvas, ++columnIndex, true, null);
 		
 		this.columnControl.setLayout(uiLayout);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableDividerHelper.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableDividerHelper.java
@@ -12,10 +12,11 @@ public class TGTableDividerHelper {
 		this.table = table;
 	}
 
-	public UIDivider createDivider(TGTableHeader leftColumn, TGTableHeader rightColumn) {
+	public UIDivider createDivider(TGTableHeader leftColumn, TGTableHeader rightColumn, boolean atEnd) {
 		UIFactory uiFactory = this.table.getUIFactory();
 		UIDivider uiDivider = uiFactory.createVerticalDivider(this.table.getColumnControl());
-		uiDivider.addMouseDragListener(new TGTableDividerListener(this.table, leftColumn, rightColumn));
+		uiDivider.setBgColor(this.table.getViewer().getColorModel().getColor(TGTableColorModel.CELL_BACKGROUND));
+		uiDivider.addMouseDragListener(new TGTableDividerListener(this.table, leftColumn, rightColumn, atEnd));
 		uiDivider.setCursor(UICursor.SIZEWE);
 		
 		return uiDivider;

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableDividerListener.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableDividerListener.java
@@ -14,37 +14,47 @@ public class TGTableDividerListener implements UIMouseDragListener {
 	private TGTable table;
 	private TGTableHeader leftColumn;
 	private TGTableHeader rightColumn;
+	private final boolean atEnd;
 	
-	public TGTableDividerListener(TGTable table, TGTableHeader leftColumn, TGTableHeader rightColumn) {
+	public TGTableDividerListener(TGTable table, TGTableHeader leftColumn, TGTableHeader rightColumn, boolean atEnd) {
 		this.table = table;
 		this.leftColumn = leftColumn;
 		this.rightColumn = rightColumn;
-	}
+		this.atEnd = atEnd;
+		}
 
 	public void onMouseDrag(UIMouseEvent event) {
 		float move = event.getPosition().getX();
 		
-		Float leftWidth = this.computeWidth(this.leftColumn.getControl(), move);
-		Float rightWidth = this.computeWidth(this.rightColumn.getControl(), -move);
+		Float leftWidth = this.computeWidth(this.leftColumn.getControl(), move, false);
+		Float rightWidth = this.computeWidth(this.rightColumn.getControl(), -move, atEnd);
 		if( leftWidth != null && rightWidth != null ) {
 			UITableLayout uiLayout = (UITableLayout) this.table.getColumnControl().getLayout();
 			uiLayout.set(this.leftColumn.getControl(), UITableLayout.MINIMUM_PACKED_WIDTH, leftWidth);
-			uiLayout.set(this.rightColumn.getControl(), UITableLayout.MINIMUM_PACKED_WIDTH, rightWidth);
+			if (!atEnd) {
+				uiLayout.set(this.rightColumn.getControl(), UITableLayout.MINIMUM_PACKED_WIDTH, rightWidth);
+			}
 			
 			this.table.update();
 		}
 	}
 	
-	private Float computeWidth(UIControl control, float move) {
-		UISize currentPackedSize = control.getPackedSize();
-		
-		control.computePackedSize(null, null);
-		UISize computedPackedSize = control.getPackedSize();
-		
-		control.computePackedSize(currentPackedSize.getWidth(), currentPackedSize.getHeight());
+	private Float computeWidth(UIControl control, float move, boolean atEnd) {
+		float minWidth;
+		if (atEnd) {
+			// at least a few measures + space for vertical scroll
+			minWidth = 2*this.table.getRowHeight();
+			minWidth += this.table.getViewer().getTableVScrollSize().getWidth();
+		} else {
+			UISize currentPackedSize = control.getPackedSize();
+			control.computePackedSize(null, null);
+			UISize computedPackedSize = control.getPackedSize();
+			control.computePackedSize(currentPackedSize.getWidth(), currentPackedSize.getHeight());
+			minWidth = computedPackedSize.getWidth();
+		}
 		
 		float newWidth = (control.getBounds().getWidth() + move);
-		if( newWidth >= computedPackedSize.getWidth()) {
+		if( newWidth >= minWidth) {
 			return newWidth;
 		}
 		return null;

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/table/TGTableViewer.java
@@ -40,6 +40,7 @@ import org.herac.tuxguitar.ui.event.UISelectionListener;
 import org.herac.tuxguitar.ui.layout.UIScrollBarPanelLayout;
 import org.herac.tuxguitar.ui.layout.UITableLayout;
 import org.herac.tuxguitar.ui.menu.UIPopupMenu;
+import org.herac.tuxguitar.ui.resource.UISize;
 import org.herac.tuxguitar.ui.widget.UIContainer;
 import org.herac.tuxguitar.ui.widget.UIPanel;
 import org.herac.tuxguitar.ui.widget.UIScrollBar;
@@ -223,6 +224,14 @@ public class TGTableViewer implements TGEventListener {
 		return this.hScroll.getValue();
 	}
 	
+	public UISize getTableHScrollSize() {
+		return this.trackTableComposite.getHScroll().getSize();
+	}
+	
+	public UISize getTableVScrollSize() {
+		return this.trackTableComposite.getVScroll().getSize();
+	}
+	
 	public UIFactory getUIFactory() {
 		return TGApplication.getInstance(this.context).getFactory();
 	}
@@ -358,7 +367,7 @@ public class TGTableViewer implements TGEventListener {
 		else if(this.trackCount != trackCount){
 			float tableHeight = this.composite.getLayout().computePackedSize(this.trackTableComposite).getHeight();
 			// margin for scroll bar
-			tableHeight += this.trackTableComposite.getHScroll().getSize().getHeight();
+			tableHeight += getTableHScrollSize().getHeight();
 
 			uiWindow.getLayout().set(this.composite, UITableLayout.PACKED_HEIGHT, tableHeight);
 			uiWindow.layout();


### PR DESCRIPTION
#330 bug fix, this column's width could only be reduced, not increased. Bug was introduced with 2cfb9c919119eedece46eb52d656c88000b4af66
New format of track table was (partially) back-ported from TuxGuitar2.0beta fork
Modification of TGTableDividerListener was forgotten