### PR TITLE
make caret more visible

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/ui/resource/UIPainter.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/ui/resource/UIPainter.java
@@ -30,6 +30,23 @@ public interface UIPainter extends UIResource {
 	
 	void addRectangle(float x,float y,float width,float height);
 	
+	default void addRoundedRectangle(float x1, float y1, float w, float h, float br) {
+		//control point
+		float cp =  (float) (br - br * 4.*(Math.sqrt(2.)-1.)/3.);
+		float x2 = x1 + w;
+		float y2 = y1 + h;
+		
+		moveTo(x1 + br, y1);
+		cubicTo(x1 + cp, y1, x1, y1 + cp, x1, y1 + br);
+		lineTo(x1, y2 - br);
+		cubicTo(x1, y2 - cp, x1 + cp, y2, x1 + br, y2);
+		lineTo(x2 - br, y2);
+		cubicTo(x2 - cp, y2, x2, y2 - cp, x2, y2 - br);
+		lineTo(x2, y1 + br);
+		cubicTo(x2, y1 + cp, x2 - cp, y1, x2 - br, y1);
+		lineTo(x1 + br, y1);
+	}
+	
 	void setFont(UIFont font);
 	
 	void setForeground(UIColor color);

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/util/configuration/TGConfigManager.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/util/configuration/TGConfigManager.java
@@ -14,9 +14,25 @@ public class TGConfigManager {
 	private String module;
 	
 	public TGConfigManager(TGContext context, String module){
+		this(context,module, null);
+	}
+	
+	/* Since TuxGuitar 1.6.0, user configuration files are preserved when user upgrades TuxGuitar version
+	 * Therefore, it is possible to find in a user configuration file some deprecated parameters
+	 * Such parameter names SHALL NOT be re-used again in a future version, to avoid possible confusion.
+	 * When depreciating an old parameter, add its name in a list of obsoleteKeys, and provide it here
+	 * Depreciated parameters will then be deleted from user's configuration file
+	 */
+	
+	public TGConfigManager(TGContext context, String module, String[] obsoleteKeys){
 		this.context = context;
 		this.module = module;
 		this.initialize();
+		if (obsoleteKeys != null) {
+			for (String key : obsoleteKeys) {
+				this.properties.remove(key);
+			}
+		}
 	}
 	
 	public void initialize(){

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -69,8 +69,9 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.COLOR_TAB_NOTE, "64,64,64");
 		loadProperty(properties, TGConfigKeys.COLOR_PLAY_NOTE, "255,0,0");
 		loadProperty(properties, TGConfigKeys.COLOR_SELECTION, "116,152,208");
-		loadProperty(properties, TGConfigKeys.COLOR_CARET_1, "127,127,127");
-		loadProperty(properties, TGConfigKeys.COLOR_CARET_2, "165,42,42");
+		loadProperty(properties, TGConfigKeys.COLOR_CARET_CURRENT_VOICE, "5,5,5");
+		loadProperty(properties, TGConfigKeys.COLOR_CARET_OTHER_VOICE, "200,10,10");
+		loadProperty(properties, TGConfigKeys.COLOR_CARET_ALPHA, "12");
 		loadProperty(properties, TGConfigKeys.COLOR_LOOP_S_MARKER, "42,165,42");
 		loadProperty(properties, TGConfigKeys.COLOR_LOOP_E_MARKER, "165,42,42");
 		loadProperty(properties, TGConfigKeys.COLOR_MEASURE_NUMBER, "128,0,0");

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigKeys.java
@@ -1,7 +1,17 @@
 package org.herac.tuxguitar.app.system.config;
 
 public class TGConfigKeys {
+	
+	/* list of obsolete configuration key names
+	 * these keys were used in previous versions of TuxGuitar, and SHALL NOT be re-used for new configuration parameters 
+	 * as old values (with an old signification) can be found in user's configuration file (when user upgrades TuxGuitar from an old version)
+	 */
+	static final String[] OBSOLETE_KEYS = {
+			"color.caret.1",
+			"color.caret.2",
+			};
 
+	// valid configuration key names
 	public static final String SKIN = "skin";
 	public static final String WINDOW_TITLE = "window.title";
 	public static final String SHOW_SPLASH = "show.splash";
@@ -44,8 +54,9 @@ public class TGConfigKeys {
 	public static final String COLOR_TAB_NOTE = "color.tab.note";
 	public static final String COLOR_PLAY_NOTE = "color.play.note";
 	public static final String COLOR_SELECTION = "color.selection";
-	public static final String COLOR_CARET_1 = "color.caret.1";
-	public static final String COLOR_CARET_2 = "color.caret.2";
+	public static final String COLOR_CARET_CURRENT_VOICE = "color.caret.voice.current";
+	public static final String COLOR_CARET_OTHER_VOICE = "color.caret.voice.other";
+	public static final String COLOR_CARET_ALPHA = "color.caret.alpha";
 	public static final String COLOR_LOOP_S_MARKER = "color.loop.s.marker";
 	public static final String COLOR_LOOP_E_MARKER = "color.loop.e.marker";
 	public static final String COLOR_MEASURE_NUMBER = "color.measure.number";

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigManager.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigManager.java
@@ -11,8 +11,8 @@ public class TGConfigManager extends org.herac.tuxguitar.util.configuration.TGCo
 	
 	public static final String CONFIGURATION_MODULE = "tuxguitar";
 	
-	public TGConfigManager(TGContext context){
-		super(context, CONFIGURATION_MODULE);
+	private TGConfigManager(TGContext context, String[] obsoleteKeys){
+		super(context, CONFIGURATION_MODULE, obsoleteKeys);
 	}
 	
 	public void setValue(String key, UIColorModel model){
@@ -34,7 +34,7 @@ public class TGConfigManager extends org.herac.tuxguitar.util.configuration.TGCo
 	public static TGConfigManager getInstance(TGContext context) {
 		return TGSingletonUtil.getInstance(context, TGConfigManager.class.getName(), new TGSingletonFactory<TGConfigManager>() {
 			public TGConfigManager createInstance(TGContext context) {
-				return new TGConfigManager(context);
+				return new TGConfigManager(context, TGConfigKeys.OBSOLETE_KEYS);
 			}
 		});
 	}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Caret.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Caret.java
@@ -56,8 +56,9 @@ public class Caret {
 	private boolean restBeat;
 	private boolean changes;
 	
-	private UIColor color1;
-	private UIColor color2;
+	private UIColor colorCurrentVoice;
+	private UIColor colorOtherVoice;
+	private int alpha;
 	
 	public Caret(Tablature tablature) {
 		this.tablature = tablature;
@@ -168,10 +169,13 @@ public class Caret {
 					float y = (this.selectedMeasure.getPosY() + this.selectedMeasure.getTs().getPosition(TGTrackSpacing.POSITION_TABLATURE) + ((this.string * stringSpacing) - stringSpacing) - yMargin);
 					this.setPaintStyle(painter, expectedVoice);
 					
-					painter.initPath();
 					painter.setAntialias(false);
-					painter.addRectangle(x, y, width, height);
-					painter.closePath();
+					for (int style : new int[] {UIPainter.PATH_FILL, UIPainter.PATH_DRAW}) {
+						painter.initPath(style);
+						painter.setAlpha(style == UIPainter.PATH_FILL ? this.alpha : 255);
+						painter.addRoundedRectangle(x, y, width, height, 2f);
+						painter.closePath();
+					}
 				}
 				else if( (layout.getStyle() & TGLayout.DISPLAY_SCORE) != 0){
 					float line = this.tablature.getViewLayout().getScoreLineSpacing();
@@ -197,9 +201,10 @@ public class Caret {
 	}
 	
 	public void setPaintStyle(UIPainter painter, boolean expectedVoice){
-		UIColor foreground = ( expectedVoice ? this.color1 : this.color2 );
-		if( foreground != null ){
-			painter.setForeground( foreground );
+		UIColor color = ( expectedVoice ? this.colorCurrentVoice : this.colorOtherVoice );
+		if( color != null ){
+			painter.setForeground(color);
+			painter.setBackground(color);
 		}
 	}
 	
@@ -396,14 +401,18 @@ public class Caret {
 		return this.restBeat;
 	}
 	
-	public void setColor1(UIColorModel cm){
-		this.disposeResource( this.color1 );
-		this.color1 = this.tablature.getResourceFactory().createColor(cm);
+	public void setColorCurrentVoice(UIColorModel cm){
+		this.disposeResource( this.colorCurrentVoice );
+		this.colorCurrentVoice = this.tablature.getResourceFactory().createColor(cm);
 	}
 	
-	public void setColor2(UIColorModel cm){
-		this.disposeResource( this.color2 );
-		this.color2 = this.tablature.getResourceFactory().createColor(cm);
+	public void setColorOtherVoice(UIColorModel cm){
+		this.disposeResource( this.colorOtherVoice );
+		this.colorOtherVoice = this.tablature.getResourceFactory().createColor(cm);
+	}
+	
+	public void setAlpha(int alpha) {
+		this.alpha = alpha;
 	}
 
 	private void saveState() {
@@ -430,7 +439,7 @@ public class Caret {
 	}
 	
 	public void dispose(){
-		this.disposeResource( this.color1 );
-		this.disposeResource( this.color2 );
+		this.disposeResource( this.colorCurrentVoice );
+		this.disposeResource( this.colorOtherVoice );
 	}
 }

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Tablature.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Tablature.java
@@ -192,8 +192,9 @@ public class Tablature implements TGController {
 	public void loadCaretStyles() {
 		TGConfigManager config = TGConfigManager.getInstance(this.context);
 		
-		getCaret().setColor1(config.getColorModelConfigValue(TGConfigKeys.COLOR_CARET_1));
-		getCaret().setColor2(config.getColorModelConfigValue(TGConfigKeys.COLOR_CARET_2));
+		getCaret().setColorCurrentVoice(config.getColorModelConfigValue(TGConfigKeys.COLOR_CARET_CURRENT_VOICE));
+		getCaret().setColorOtherVoice(config.getColorModelConfigValue(TGConfigKeys.COLOR_CARET_OTHER_VOICE));
+		getCaret().setAlpha(config.getIntegerValue(TGConfigKeys.COLOR_CARET_ALPHA));
 	}
 	
 	public void scale(Float scale) {


### PR DESCRIPTION
Make caret more visible, and change configuration parameters so modification is effective also for users upgrading TuxGuitar version.

@helge17 I would appreciate if you can review:
- the graphical rendering (always subjective)
- could you please check if this is OK also in macOS configuration?
- I would appreciate your opinion about how to depreciate configuration parameters. Since configuration folder is preserved when TuxGuitar is updated, we had already added the possibility to create new parameters in new version. This case, I would like to replace old configuration parameters with new ones. So I have created a list of "obsolete key names", and updated the configuration managers to delete these old parameters. Does it seem reasonable to you?