### PR TITLE
Highlight played beat

### DIFF
--- a/android/TuxGuitar-android/src/org/herac/tuxguitar/android/view/tablature/TGSongViewController.java
+++ b/android/TuxGuitar-android/src/org/herac/tuxguitar/android/view/tablature/TGSongViewController.java
@@ -50,7 +50,7 @@ public class TGSongViewController implements TGController {
 		this.resourceFactory = new TGResourceFactoryImpl();
 		this.bufferController = new TGSongViewBufferController(this);
 		this.layoutPainter = new TGSongViewLayoutPainter(this);
-		this.layout = new TGLayoutVertical(this, TGLayout.DISPLAY_TABLATURE | TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_COMPACT);
+		this.layout = new TGLayoutVertical(this, TGLayout.DISPLAY_TABLATURE | TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_COMPACT | TGLayout.HIGHLIGHT_PLAYED_BEAT);
 		this.caret = new TGCaret(this);
 		this.scroll = new TGScroll();
 		this.smartMenu = new TGSongViewSmartMenu(this);

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGBeatImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGBeatImpl.java
@@ -1,12 +1,16 @@
 package org.herac.tuxguitar.graphics.control;
 
+import java.util.Iterator;
+
 import org.herac.tuxguitar.song.factory.TGFactory;
 import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGChord;
+import org.herac.tuxguitar.song.models.TGNote;
 import org.herac.tuxguitar.song.models.TGNoteEffect;
 import org.herac.tuxguitar.song.models.TGStroke;
 import org.herac.tuxguitar.song.models.TGVoice;
 import org.herac.tuxguitar.ui.resource.UIPainter;
+import org.herac.tuxguitar.ui.resource.UIRectangle;
 
 public class TGBeatImpl extends TGBeat{
 	/**
@@ -40,6 +44,7 @@ public class TGBeatImpl extends TGBeat{
 	private TGBeatGroup group;
 	
 	private TGBeatSpacing bs;
+	private float effectWidth;
 	
 	private boolean accentuated;
 	private boolean heavyAccentuated;
@@ -72,6 +77,10 @@ public class TGBeatImpl extends TGBeat{
 	
 	public void setWidth(float width) {
 		this.width = width;
+	}
+	
+	public void setEffectWidth(float width) {
+		this.effectWidth = width;
 	}
 	
 	public TGNoteImpl getMinNote(){
@@ -305,6 +314,33 @@ public class TGBeatImpl extends TGBeat{
 			if(getStroke().getDirection() != TGStroke.STROKE_NONE){
 				paintStroke(layout, painter, fromX, fromY);
 			}
+		}
+		if(layout.isPlayModeEnabled() && isPlaying(layout)){
+			TGMeasureImpl measureImpl = getMeasureImpl();
+			UIRectangle playedMeasure = measureImpl.getVerticalPosition(layout);
+			float scale = layout.getScale();
+			float leftSpacing = 8f* scale;
+			float rightSpacing = 15f* scale;
+			float width = this.effectWidth + leftSpacing + rightSpacing;
+			int style = layout.getStyle();
+			float yHighestNote = 0;
+			if ( (style & TGLayout.DISPLAY_SCORE) != 0) {
+				for( int v = 0; v < MAX_VOICES; v ++){
+					TGVoiceImpl voice = (TGVoiceImpl)getVoice(v);
+					if(!voice.isEmpty()){
+						Iterator<TGNote> it = voice.getNotes().iterator();
+						while(it.hasNext()){
+							TGNoteImpl note = (TGNoteImpl)it.next();
+							yHighestNote = (note.getScorePosY()<yHighestNote) ? note.getScorePosY() : yHighestNote;
+						}
+					}
+				}
+			}
+			painter.setLineWidth(layout.getLineWidth(1));
+			painter.initPath();
+			painter.setAntialias(false);
+			painter.addRoundedRectangle(fromX+getPosX()-leftSpacing+getSpacing(layout), playedMeasure.getY()+yHighestNote, width , playedMeasure.getHeight()-yHighestNote, 3f*scale);
+			painter.closePath();
 		}
 	}
 	

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGBeatImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGBeatImpl.java
@@ -299,7 +299,7 @@ public class TGBeatImpl extends TGBeat{
 		}
 	}
 	
-	public void paint(TGLayout layout,UIPainter painter, float fromX, float fromY) {
+	public void paint(TGLayout layout,UIPainter painter, float fromX, float fromY, boolean highlightPlayedBeat) {
 		if(!layout.isPlayModeEnabled() && (layout.getStyle() & TGLayout.DISPLAY_SCORE) != 0 ){
 			paintExtraLines(painter, layout,fromX, fromY);
 		}
@@ -315,7 +315,7 @@ public class TGBeatImpl extends TGBeat{
 				paintStroke(layout, painter, fromX, fromY);
 			}
 		}
-		if(layout.isPlayModeEnabled() && isPlaying(layout)){
+		if(layout.isPlayModeEnabled() && isPlaying(layout) && highlightPlayedBeat){
 			TGMeasureImpl measureImpl = getMeasureImpl();
 			UIRectangle playedMeasure = measureImpl.getVerticalPosition(layout);
 			float scale = layout.getScale();

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGChordImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGChordImpl.java
@@ -226,7 +226,7 @@ public class TGChordImpl extends TGChord {
 	}
 	
 	public void paint(TGLayout layout, UIPainter painter, float fromX, float fromY) {
-		layout.setChordStyle(this);
+		layout.setChordStyle(this, this.getBeatImpl().getMeasureImpl().isPlaying(layout));
 		this.setPosY(getPaintPosition(TGTrackSpacing.POSITION_CHORD));
 		this.setEditing(false);
 		this.update(painter, layout.getComponent().getResourceFactory(), (layout.isBufferEnabled() ? layout.getResourceBuffer() : null));

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayout.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayout.java
@@ -278,9 +278,6 @@ public abstract class TGLayout {
 	public void paintPlayMode(UIPainter painter, TGMeasureImpl measure, TGBeatImpl beat){
 		this.playModeEnabled = true;
 		
-		//pinto el compas
-		measure.paintPlayMode(this, painter);
-		
 		//pinto el pulso
 		if( beat != null ){
 			beat.paint(this,painter,measure.getPosX()  + measure.getHeaderImpl().getLeftSpacing(this), measure.getPosY());
@@ -293,7 +290,12 @@ public abstract class TGLayout {
 	}
 	
 	public void fillBackground(UIPainter painter, UIRectangle area) {
-		painter.setBackground(this.getLightColor(this.getResources().getBackgroundColor()));
+		fillBackground(painter, area, false);
+	}
+
+	public void fillBackground(UIPainter painter, UIRectangle area, boolean isPlaying) {
+		UIColor background = isPlaying ? this.getResources().getBackgroundColorPlaying() : this.getResources().getBackgroundColor();
+		painter.setBackground(this.getLightColor(background));
 		painter.initPath(UIPainter.PATH_FILL);
 		painter.addRectangle(area.getX(), area.getY(), area.getWidth(), area.getHeight());
 		painter.closePath();
@@ -399,11 +401,6 @@ public abstract class TGLayout {
 		painter.setFont(getResources().getDefaultFont());
 		painter.setForeground(getDarkColor(getResources().getForegroundColor()));
 		painter.setBackground( ( fontStyle ? getLightColor(getResources().getBackgroundColor()) : getDarkColor(getResources().getForegroundColor()) ));
-	}
-	
-	public void setMeasurePlayingStyle(UIPainter painter){
-		painter.setBackground(getLightColor(getResources().getBackgroundColor()));
-		painter.setForeground(getDarkColor(getResources().getForegroundColor()));
 	}
 	
 	public void setLyricStyle(UIPainter painter,boolean playMode){
@@ -533,10 +530,14 @@ public abstract class TGLayout {
 		painter.setFont(getResources().getDefaultFont());
 	}
 	
-	public void setChordStyle(TGChordImpl chord){
+	public void setChordStyle(TGChordImpl chord, boolean isPlaying){
 		chord.setFont(getResources().getChordFont());
 		chord.setForegroundColor(getDarkColor(getResources().getForegroundColor()));
-		chord.setBackgroundColor(getLightColor(getResources().getBackgroundColor()));
+		if (isPlaying) {
+			chord.setBackgroundColor(getResources().getBackgroundColorPlaying());
+		} else {
+			chord.setBackgroundColor(getLightColor(getResources().getBackgroundColor()));
+		}
 		chord.setColor(getDarkColor(getResources().getLineColor()));
 		chord.setNoteColor(getDarkColor(getResources().getTabNoteColor()));
 		chord.setTonicColor(getDarkColor(getResources().getTabNoteColor()));

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayout.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayout.java
@@ -30,6 +30,7 @@ public abstract class TGLayout {
 	public static final int DISPLAY_CHORD_NAME = 0x10;
 	public static final int DISPLAY_CHORD_DIAGRAM = 0x20;
 	public static final int DISPLAY_MODE_BLACK_WHITE = 0x40;
+	public static final int HIGHLIGHT_PLAYED_BEAT = 0x80;
 	
 	private int style;
 	private float scale;
@@ -280,7 +281,8 @@ public abstract class TGLayout {
 		
 		//pinto el pulso
 		if( beat != null ){
-			beat.paint(this,painter,measure.getPosX()  + measure.getHeaderImpl().getLeftSpacing(this), measure.getPosY());
+			beat.paint(this,painter,measure.getPosX()  + measure.getHeaderImpl().getLeftSpacing(this),
+					measure.getPosY(), (this.style & HIGHLIGHT_PLAYED_BEAT)!=0);
 		}
 		
 		//pinto los lyrics

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayoutStyles.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayoutStyles.java
@@ -44,6 +44,7 @@ public class TGLayoutStyles {
 	private UIFontModel chordFretFont;
 	private UIColorModel foregroundColor;
 	private UIColorModel backgroundColor;
+	private UIColorModel backgroundColorPlaying;
 	private UIColorModel lineColor;
 	private UIColorModel scoreNoteColor;
 	private UIColorModel tabNoteColor;
@@ -367,6 +368,17 @@ public class TGLayoutStyles {
 
 	public void setBackgroundColor(UIColorModel backgroundColor) {
 		this.backgroundColor = backgroundColor;
+	}
+
+	public UIColorModel getBackgroundColorPlaying() {
+		if (this.backgroundColorPlaying !=  null) {
+			return this.backgroundColorPlaying;
+		}
+		return backgroundColor;
+	}
+
+	public void setBackgroundColorPlaying(UIColorModel backgroundColorPlaying) {
+		this.backgroundColorPlaying = backgroundColorPlaying;
 	}
 
 	public UIColorModel getLineColor() {

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGMeasureImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGMeasureImpl.java
@@ -26,6 +26,7 @@ import org.herac.tuxguitar.song.models.TGMeasureHeader;
 import org.herac.tuxguitar.song.models.TGNote;
 import org.herac.tuxguitar.ui.resource.UIColor;
 import org.herac.tuxguitar.ui.resource.UIPainter;
+import org.herac.tuxguitar.ui.resource.UIRectangle;
 import org.herac.tuxguitar.ui.resource.UIResourceFactory;
 import org.herac.tuxguitar.util.TGMusicKeyUtils;
 
@@ -129,6 +130,8 @@ public class TGMeasureImpl extends TGMeasure{
 	private boolean[][] registeredAccidentals;
 	
 	private boolean readyToPaint;
+	
+	private boolean wasPlayingWhenLastPainted;
 	
 	@SuppressWarnings("unchecked")
 	public TGMeasureImpl(TGMeasureHeader header) {
@@ -283,6 +286,7 @@ public class TGMeasureImpl extends TGMeasure{
 					previousVoices[v] = voice;
 				}
 			}
+			beat.setEffectWidth(beatEffectWidth);
 			if (emptyBeat){
 				System.out.println( "Empty Beat !!!!!! " + beat.getStart() + "  " + i);
 			}
@@ -620,13 +624,16 @@ public class TGMeasureImpl extends TGMeasure{
 			boolean bufferEnabled = layout.isBufferEnabled();
 			TGResourceBuffer resourceBuffer = layout.getResourceBuffer();
 			
-			if(!bufferEnabled || shouldRepaintBuffer(resourceBuffer)){
+			UIColor background = this.isPlaying(layout) ? layout.getResources().getBackgroundColorPlaying() : layout.getResources().getBackgroundColor();
+			painter.setBackground(background);
+			
+			if(!bufferEnabled || shouldRepaintBuffer(resourceBuffer, this.isPlaying(layout))){
 				UIPainter bufferPainter = painter;
 				float x = (bufferEnabled ? 0 : getPosX());
 				float y = (bufferEnabled ? 0 : getPosY());
 				if( bufferEnabled ){
 					UIResourceFactory factory = layout.getComponent().getResourceFactory();
-					bufferPainter = getBuffer().createBuffer(resourceBuffer, factory, getWidth(layout) + getSpacing(), getTs().getSize(), layout.getResources().getBackgroundColor());
+					bufferPainter = getBuffer().createBuffer(resourceBuffer, factory, getWidth(layout) + getSpacing(), getTs().getSize(), background);
 				}
 				layout.paintLines(getTrackImpl(), getTs(), bufferPainter, x, y, getWidth(layout) + getSpacing());
 				paintTimeSignature(layout, bufferPainter, x, y);
@@ -639,7 +646,7 @@ public class TGMeasureImpl extends TGMeasure{
 				setBufferCreated(true);
 			}
 			if( bufferEnabled ){
-				painter.setBackground(layout.getResources().getBackgroundColor());
+				painter.setBackground(background);
 				getBuffer().paintBuffer(resourceBuffer, painter, getPosX(), getPosY());
 			}
 			
@@ -649,13 +656,13 @@ public class TGMeasureImpl extends TGMeasure{
 			this.paintTripletFeel(layout,painter);
 			this.paintDivisions(layout,painter);
 			this.paintRepeatEnding(layout,painter);
-			this.paintPlayMode(layout,painter);
 			this.paintLoopMarker(layout, painter);
 		}
+		this.wasPlayingWhenLastPainted = this.isPlaying(layout);
 	}
 	
-	private boolean shouldRepaintBuffer(TGResourceBuffer resourceBuffer){
-		return (!isBufferCreated() || getBuffer().isDisposed(resourceBuffer));
+	private boolean shouldRepaintBuffer(TGResourceBuffer resourceBuffer, boolean isPlaying){
+		return (!isBufferCreated() || getBuffer().isDisposed(resourceBuffer) || (isPlaying != this.wasPlayingWhenLastPainted));
 	}
 	
 	public void paintRepeatEnding(TGLayout layout,UIPainter painter){
@@ -1158,34 +1165,22 @@ public class TGMeasureImpl extends TGMeasure{
 		}
 	}
 	
-	public void paintPlayMode(TGLayout layout,UIPainter painter){
-		if(layout.isPlayModeEnabled() && isPlaying(layout)){
-			float scale = layout.getScale();
-			float width = getWidth(layout) + getSpacing();
-			float y1 = getPosY();
-			float y2 = getPosY();
-			int style = layout.getStyle();
-			if( (style & (TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_TABLATURE)) == (TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_TABLATURE) ){
-				y1 += (getTs().getPosition(TGTrackSpacing.POSITION_SCORE_MIDDLE_LINES) - layout.getScoreLineSpacing());
-				y2 += (getTs().getPosition(TGTrackSpacing.POSITION_TABLATURE) + getTrackImpl().getTabHeight() + layout.getStringSpacing());
-			}else if( (style & TGLayout.DISPLAY_SCORE) != 0 ){
-				y1 += (getTs().getPosition(TGTrackSpacing.POSITION_SCORE_MIDDLE_LINES) - layout.getScoreLineSpacing());
-				y2 += (getTs().getPosition(TGTrackSpacing.POSITION_SCORE_MIDDLE_LINES) + (layout.getScoreLineSpacing() * 5));
-			} else if( (style & TGLayout.DISPLAY_TABLATURE) != 0 ){
-				y1 += (getTs().getPosition(TGTrackSpacing.POSITION_TABLATURE) - layout.getStringSpacing());
-				y2 += (getTs().getPosition(TGTrackSpacing.POSITION_TABLATURE) + getTrackImpl().getTabHeight() + layout.getStringSpacing());
-			}
-			layout.setMeasurePlayingStyle(painter);
-			// Don't uncomment "lineStyle" until be sure SWT bug has fixed.
-			// See bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=225725
-			//painter.setLineStyle(SWT.LINE_DASH);
-			painter.setLineWidth(layout.getLineWidth(1));
-			painter.initPath();
-			painter.setAntialias(false);
-			painter.addRectangle(getPosX() + (5f * scale),y1,width - (10f * scale),(y2 - y1));
-			painter.closePath();
-			//painter.setLineStyle(SWT.LINE_SOLID);
+	// returns vertical position of measure, only y data is relevant
+	public UIRectangle getVerticalPosition(TGLayout layout){
+		float y1 = getPosY();
+		float y2 = y1;
+		int style = layout.getStyle();
+		if( (style & (TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_TABLATURE)) == (TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_TABLATURE) ){
+			y1 += (getTs().getPosition(TGTrackSpacing.POSITION_SCORE_MIDDLE_LINES) - layout.getScoreLineSpacing());
+			y2 += (getTs().getPosition(TGTrackSpacing.POSITION_TABLATURE) + getTrackImpl().getTabHeight() + layout.getStringSpacing());
+		}else if( (style & TGLayout.DISPLAY_SCORE) != 0 ){
+			y1 += (getTs().getPosition(TGTrackSpacing.POSITION_SCORE_MIDDLE_LINES) - layout.getScoreLineSpacing());
+			y2 += (getTs().getPosition(TGTrackSpacing.POSITION_SCORE_MIDDLE_LINES) + (layout.getScoreLineSpacing() * 5));
+		} else if( (style & TGLayout.DISPLAY_TABLATURE) != 0 ){
+			y1 += (getTs().getPosition(TGTrackSpacing.POSITION_TABLATURE) - layout.getStringSpacing());
+			y2 += (getTs().getPosition(TGTrackSpacing.POSITION_TABLATURE) + getTrackImpl().getTabHeight() + layout.getStringSpacing());
 		}
+		return new UIRectangle(0,y1,0,y2-y1);
 	}
 	
 	/**

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGMeasureImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGMeasureImpl.java
@@ -699,7 +699,7 @@ public class TGMeasureImpl extends TGMeasure{
 		Iterator<TGBeat> it = getBeats().iterator();
 		while(it.hasNext()) {
 			TGBeatImpl beat = (TGBeatImpl)it.next();
-			beat.paint(layout, painter, x, fromY);
+			beat.paint(layout, painter, x, fromY, false);
 		}
 		
 		this.paintDivisionTypes(layout, painter, x, fromY);

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGNoteImpl.java
@@ -1005,7 +1005,7 @@ public class TGNoteImpl extends TGNote {
 		uiRectangle.getSize().setWidth(margin.getLeft() + margin.getRight());
 		uiRectangle.getSize().setHeight(margin.getTop() + margin.getBottom());
 		
-		layout.fillBackground(painter, uiRectangle);
+		layout.fillBackground(painter, uiRectangle, getMeasureImpl().isPlaying(layout));
 	}
 	
 	public String getNoteLabel(TGNote note) {

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGResources.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGResources.java
@@ -27,6 +27,7 @@ public class TGResources {
 	private UIFont chordFretFont;
 	private UIColor foregroundColor;
 	private UIColor backgroundColor;
+	private UIColor backgroundColorPlaying;
 	private UIColor lineColor;
 	private UIColor scoreNoteColor;
 	private UIColor tabNoteColor;
@@ -93,6 +94,10 @@ public class TGResources {
 		return this.backgroundColor;
 	}
 	
+	public UIColor getBackgroundColorPlaying() {
+		return this.backgroundColorPlaying;
+	}
+	
 	public UIColor getLineColor() {
 		return this.lineColor;
 	}
@@ -148,6 +153,7 @@ public class TGResources {
 	private void initColors(TGLayoutStyles style){
 		this.foregroundColor = getColor(style.getForegroundColor());
 		this.backgroundColor = getColor(style.getBackgroundColor());
+		this.backgroundColorPlaying = getColor(style.getBackgroundColorPlaying());
 		this.lineColor = getColor(style.getLineColor());
 		this.scoreNoteColor = getColor(style.getScoreNoteColor());
 		this.tabNoteColor = getColor(style.getTabNoteColor());

--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -261,6 +261,7 @@ view.layout.multitrack=Multitrack
 view.layout.score-enabled=Show Score
 view.layout.tablature-enabled=Show Tablature
 view.layout.compact=Compact
+view.layout.highlight-played-beat=Highlight Played Beat
 view.layout.chord-style=Chord Style
 view.layout.chord-name=Chord Name
 view.layout.chord-diagram=Chord Diagram

--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -670,6 +670,7 @@ settings.config.styles.font.marker=Marker Font
 settings.config.styles.color.score-note=Score Note Color
 settings.config.styles.color.tab-note=Tab Note Color
 settings.config.styles.color.play-note=Play Note Color
+settings.config.styles.color.play-measure=Play Measure Color
 settings.config.styles.color.selection=Selection Color
 settings.config.styles.color.lines=Horizontal Lines Color
 settings.config.language=Language

--- a/common/resources/lang/messages_bg.properties
+++ b/common/resources/lang/messages_bg.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Многопистова
 view.layout.score-enabled=Показване на партитура
 view.layout.tablature-enabled=Показване на таблатура
 view.layout.compact=Компактна
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Стил на акорд
 view.layout.chord-name=Име на акорд
 view.layout.chord-diagram=Диаграма на акорд

--- a/common/resources/lang/messages_bg.properties
+++ b/common/resources/lang/messages_bg.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Шрифт на текста
 # settings.config.styles.color.score-note=
 # settings.config.styles.color.tab-note=
 # settings.config.styles.color.play-note=
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Цвят на хоризонтални линии
 settings.config.language=Език

--- a/common/resources/lang/messages_ca.properties
+++ b/common/resources/lang/messages_ca.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Multipista
 view.layout.score-enabled=Mostra la partitura
 view.layout.tablature-enabled=Mostra la tabulatura
 view.layout.compact=Mode compacte
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Estil d'acords
 view.layout.chord-name=Mostra el nom
 view.layout.chord-diagram=Mostra el diagrama

--- a/common/resources/lang/messages_ca.properties
+++ b/common/resources/lang/messages_ca.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Font dels texts
 settings.config.styles.color.score-note=Color de les notes de la partitura
 settings.config.styles.color.tab-note=Color de les notes de la tabulatura
 settings.config.styles.color.play-note=Color de les notes en reproducció
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Color de les línies divisòries
 settings.config.language=Llengua

--- a/common/resources/lang/messages_cs.properties
+++ b/common/resources/lang/messages_cs.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.note=Notový font
 settings.config.styles.color.score-note=Barva not
 settings.config.styles.color.tab-note=Barva znaků tabulatury
 settings.config.styles.color.play-note=Barva právě hrané noty
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Barva notových čar
 settings.config.language=Jazyk

--- a/common/resources/lang/messages_cs.properties
+++ b/common/resources/lang/messages_cs.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Vícestopé rozvržení
 view.layout.score-enabled=Ukázat notaci
 # view.layout.tablature-enabled=
 # view.layout.compact=
+# view.layout.highlight-played-beat=
 # view.layout.chord-style=
 # view.layout.chord-name=
 # view.layout.chord-diagram=

--- a/common/resources/lang/messages_de.properties
+++ b/common/resources/lang/messages_de.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Mehrspuransicht
 view.layout.score-enabled=Partitur anzeigen
 view.layout.tablature-enabled=Tabulatur anzeigen
 view.layout.compact=Kompakte Anzeige
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Akkordanzeige
 view.layout.chord-name=Akkordname
 view.layout.chord-diagram=Akkordtabelle

--- a/common/resources/lang/messages_de.properties
+++ b/common/resources/lang/messages_de.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.marker=Schriftart der Markierungen
 settings.config.styles.color.score-note=Partiturfarbe
 settings.config.styles.color.tab-note=Tabulaturfarbe
 settings.config.styles.color.play-note=Farbe der aktuellen Note
+# settings.config.styles.color.play-measure=
 settings.config.styles.color.selection=Farbe der Auswahl
 settings.config.styles.color.lines=Farbe der Horizontallinien
 settings.config.language=Sprache

--- a/common/resources/lang/messages_el.properties
+++ b/common/resources/lang/messages_el.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Γραμματοσειρά Κειμένου
 settings.config.styles.color.score-note=Χρώμα Νότας Παρτιτούρας
 settings.config.styles.color.tab-note=Χρώμα Νότας Ταμπλατούρας
 settings.config.styles.color.play-note=Αναπαραγωγή Χρωματισμένης Νότας
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Χρώμα οριζοντίων γραμμών
 settings.config.language=Γλώσσα

--- a/common/resources/lang/messages_el.properties
+++ b/common/resources/lang/messages_el.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Πολυκάναλη
 view.layout.score-enabled=Προβολή Παρτιτούρας
 view.layout.tablature-enabled=Προβολή Ταμπλατούρας
 view.layout.compact=Συμπαγής
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Στυλ Συγχορδίας
 view.layout.chord-name=Ονομασία Συγχορδίας
 view.layout.chord-diagram=Διάγραμμα Συγχορδίας

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Multipista
 view.layout.score-enabled=Mostrar Partitura
 view.layout.tablature-enabled=Mostrar Tablatura
 view.layout.compact=Modo Compacto
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Estilo de Acordes
 view.layout.chord-name=Mostrar Nombre
 view.layout.chord-diagram=Mostrar Diagrama

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Fuente de Textos
 settings.config.styles.color.score-note=Color de Notas de Partitura
 settings.config.styles.color.tab-note=Color de Notas de Tablatura
 settings.config.styles.color.play-note=Color de Notas en Reproduccion
+# settings.config.styles.color.play-measure=
 settings.config.styles.color.selection=Selección de Color
 settings.config.styles.color.lines=Color de Lineas Divisorias
 settings.config.language=Idioma

--- a/common/resources/lang/messages_eu.properties
+++ b/common/resources/lang/messages_eu.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Multipista moduan
 view.layout.score-enabled=Erakutsi Partitura
 view.layout.tablature-enabled=Erakutsi Tablatura
 view.layout.compact=Modu kompaktoan
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Akordeen Estiloa
 view.layout.chord-name=Izena erakutsi
 view.layout.chord-diagram=Erakutsi Diagrama

--- a/common/resources/lang/messages_eu.properties
+++ b/common/resources/lang/messages_eu.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Fuente de Textos
 settings.config.styles.color.score-note=Color de Notas de Partitura
 settings.config.styles.color.tab-note=Color de Notas de Tablatura
 settings.config.styles.color.play-note=Color de Notas en Reproduccion
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Color de Lineas Divisorias
 settings.config.language=Hizkuntza

--- a/common/resources/lang/messages_fi.properties
+++ b/common/resources/lang/messages_fi.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Moniraitainen
 view.layout.score-enabled=Näytä nuottiviivasto
 view.layout.tablature-enabled=Näytä tabulatuuri
 view.layout.compact=Tiivis ulkoasu
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Näytä soinnusta
 view.layout.chord-name=Soinnun nimi
 view.layout.chord-diagram=Sointukuva

--- a/common/resources/lang/messages_fi.properties
+++ b/common/resources/lang/messages_fi.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Tekstin kirjaisinlaji
 settings.config.styles.color.score-note=Nuotin väli nuottiviivastolla
 settings.config.styles.color.tab-note=Nuotin väri tabulatuurissa
 settings.config.styles.color.play-note=Soitettavan nuotin väri
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Vaakaviivojen väri
 settings.config.language=Kieli

--- a/common/resources/lang/messages_fr.properties
+++ b/common/resources/lang/messages_fr.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.marker=Police de caractères des marqueurs
 settings.config.styles.color.score-note=Couleur des notes de la partition
 settings.config.styles.color.tab-note=Couleur des notes de la tablature
 settings.config.styles.color.play-note=Couleur des notes jouées
+settings.config.styles.color.play-measure=Couleur de la mesure jouée
 settings.config.styles.color.selection=Couleur de la sélection
 settings.config.styles.color.lines=Couleur des lignes
 settings.config.language=Langues

--- a/common/resources/lang/messages_fr.properties
+++ b/common/resources/lang/messages_fr.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Mode multipiste
 view.layout.score-enabled=Afficher la portée
 view.layout.tablature-enabled=Afficher la tablature
 view.layout.compact=Mode compact
+view.layout.highlight-played-beat=Encadrer le temps joué
 view.layout.chord-style=Accords
 view.layout.chord-name=Noms des accords
 view.layout.chord-diagram=Diagrammes d'accords

--- a/common/resources/lang/messages_hu.properties
+++ b/common/resources/lang/messages_hu.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Többsávos
 view.layout.score-enabled=Kotta látszik
 # view.layout.tablature-enabled=
 # view.layout.compact=
+# view.layout.highlight-played-beat=
 # view.layout.chord-style=
 # view.layout.chord-name=
 # view.layout.chord-diagram=

--- a/common/resources/lang/messages_hu.properties
+++ b/common/resources/lang/messages_hu.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.note=Hangjegy betûtípusa
 settings.config.styles.color.score-note=Hangjegy színe
 settings.config.styles.color.tab-note=Tabulatúra színe
 settings.config.styles.color.play-note=Lejátszott hang színe
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Vízszintes vonalak színe
 settings.config.language=Nyelv

--- a/common/resources/lang/messages_it.properties
+++ b/common/resources/lang/messages_it.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Multitraccia
 view.layout.score-enabled=Mostra pentagramma
 view.layout.tablature-enabled=Mostra tablatura
 view.layout.compact=Compatto
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Stile accordo
 view.layout.chord-name=Nome accordo
 view.layout.chord-diagram=Schema accordo

--- a/common/resources/lang/messages_it.properties
+++ b/common/resources/lang/messages_it.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.marker=Carattere degli indicatori
 settings.config.styles.color.score-note=Colore del valore della nota
 settings.config.styles.color.tab-note=Colore della nota sulla tablatura
 settings.config.styles.color.play-note=Colore della nota suonata
+# settings.config.styles.color.play-measure=
 settings.config.styles.color.selection=Colore della selezione
 settings.config.styles.color.lines=Colore linee orizzontali
 settings.config.language=Lingua

--- a/common/resources/lang/messages_ja.properties
+++ b/common/resources/lang/messages_ja.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=マルチトラック
 view.layout.score-enabled=五線表記
 view.layout.tablature-enabled=TAB譜
 view.layout.compact=コンパクト
+# view.layout.highlight-played-beat=
 view.layout.chord-style=コードスタイル
 view.layout.chord-name=コード名を表示
 view.layout.chord-diagram=コードダイアグラムを表示

--- a/common/resources/lang/messages_ja.properties
+++ b/common/resources/lang/messages_ja.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=テキスト
 settings.config.styles.color.score-note=五線譜の演奏記号
 settings.config.styles.color.tab-note=TAB譜の演奏記号
 settings.config.styles.color.play-note=再生中の音符
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=五線
 settings.config.language=言語/Language

--- a/common/resources/lang/messages_ko.properties
+++ b/common/resources/lang/messages_ko.properties
@@ -526,6 +526,7 @@ settings.config.styles=스타일
 # settings.config.styles.color.score-note=
 # settings.config.styles.color.tab-note=
 # settings.config.styles.color.play-note=
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 # settings.config.styles.color.lines=
 settings.config.language=언어

--- a/common/resources/lang/messages_ko.properties
+++ b/common/resources/lang/messages_ko.properties
@@ -117,6 +117,7 @@ view.layout.linear=선형 레이아웃
 view.layout.score-enabled=악보 보기
 view.layout.tablature-enabled=타브악보 보기
 # view.layout.compact=
+# view.layout.highlight-played-beat=
 view.layout.chord-style=코드 스타일
 view.layout.chord-name=코드 이름
 view.layout.chord-diagram=코드표

--- a/common/resources/lang/messages_lt.properties
+++ b/common/resources/lang/messages_lt.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Daug takelių
 view.layout.score-enabled=Natos
 view.layout.tablature-enabled=Tabulatūra
 view.layout.compact=Glaustai
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Akordų vaizdavimo būdas
 view.layout.chord-name=Akordo pavadinimas
 view.layout.chord-diagram=Akordo diagrama

--- a/common/resources/lang/messages_lt.properties
+++ b/common/resources/lang/messages_lt.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Teksto šriftas
 settings.config.styles.color.score-note=Penklinės natų spalva
 settings.config.styles.color.tab-note=Tabų natos spalva
 settings.config.styles.color.play-note=Grojamos natos spalva
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Horizontalių linijų spalva
 settings.config.language=Kalba

--- a/common/resources/lang/messages_nl.properties
+++ b/common/resources/lang/messages_nl.properties
@@ -117,6 +117,7 @@ view.layout.linear=Lineare Layout
 view.layout.score-enabled=Laat Score zien
 view.layout.tablature-enabled=Bekijk TAB
 view.layout.compact=Compacte Layout
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Akkoord Stijl
 view.layout.chord-name=Akkoord Naam
 view.layout.chord-diagram=Akkoord Diagram

--- a/common/resources/lang/messages_nl.properties
+++ b/common/resources/lang/messages_nl.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Tekst Lettertype
 settings.config.styles.color.score-note=Score Noot Kleur
 settings.config.styles.color.tab-note=Tab Noot Kleur
 settings.config.styles.color.play-note=Afspeel Noot Kleur
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Horizontale Lijn Kleur
 settings.config.language=Taal

--- a/common/resources/lang/messages_pl.properties
+++ b/common/resources/lang/messages_pl.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Czcionka tekstu
 settings.config.styles.color.score-note=Kolor nut na pięciolini
 settings.config.styles.color.tab-note=Kolor cyfr w tabulaturze
 settings.config.styles.color.play-note=Kolor podczas odtwarzania
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Kolor linii tabulatury i pieciolinii
 settings.config.language=Język

--- a/common/resources/lang/messages_pl.properties
+++ b/common/resources/lang/messages_pl.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Wielościeżkowy
 view.layout.score-enabled=Pokaż zapis nutowy
 view.layout.tablature-enabled=Pokaż tabulaturę
 view.layout.compact=Kompaktowy
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Wygląd akordów
 view.layout.chord-name=Nazwa akordu
 view.layout.chord-diagram=Diagram akordu

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Fonte do texto
 settings.config.styles.color.score-note=Cor das notas da Partitura
 settings.config.styles.color.tab-note=Cor das notas da Tablatura
 settings.config.styles.color.play-note=Cor da nota tocando
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Cor das Linhas Horizontais
 settings.config.language=Idioma

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Multi-Pistas
 view.layout.score-enabled=Exibir Partitura
 view.layout.tablature-enabled=Mostrar tablatura
 view.layout.compact=Compacto
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Estilo de acorde
 view.layout.chord-name=Nome do acorde
 view.layout.chord-diagram=Diagrama de acorde

--- a/common/resources/lang/messages_ru.properties
+++ b/common/resources/lang/messages_ru.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Шрифт для текста
 settings.config.styles.color.score-note=Цвет ноты партитуры
 settings.config.styles.color.tab-note=Цвет ноты табулатуры
 settings.config.styles.color.play-note=Цвет проигрываемой ноты
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Цвет горизонтальных линий
 settings.config.language=Язык

--- a/common/resources/lang/messages_ru.properties
+++ b/common/resources/lang/messages_ru.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Мультитрек
 view.layout.score-enabled=Показать партитуру
 view.layout.tablature-enabled=Показать табулатуру
 view.layout.compact=Компактный
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Стиль аккорда
 view.layout.chord-name=Название
 view.layout.chord-diagram=Диаграмма

--- a/common/resources/lang/messages_sr.properties
+++ b/common/resources/lang/messages_sr.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Više instrumenata
 view.layout.score-enabled=Prikaži note
 view.layout.tablature-enabled=Prikaži tablaturu
 view.layout.compact=Kompaktan prikaz
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Prikaz akorda
 view.layout.chord-name=Naziv akorda
 view.layout.chord-diagram=Dijagram akorda

--- a/common/resources/lang/messages_sr.properties
+++ b/common/resources/lang/messages_sr.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Font za tekst
 settings.config.styles.color.score-note=Boja nota
 settings.config.styles.color.tab-note=Boja tablatura
 settings.config.styles.color.play-note=Boja svirajuće note
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Boja horizontalnih linija
 settings.config.language=Jezik

--- a/common/resources/lang/messages_sv.properties
+++ b/common/resources/lang/messages_sv.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Flera spår
 view.layout.score-enabled=Visa partitur
 view.layout.tablature-enabled=Visa tabulatur
 view.layout.compact=Kompakt
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Ackordutseende
 view.layout.chord-name=Ackordnamn
 view.layout.chord-diagram=Ackorddiagram

--- a/common/resources/lang/messages_sv.properties
+++ b/common/resources/lang/messages_sv.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Texttypsnitt
 settings.config.styles.color.score-note=Notfärg i partitur
 settings.config.styles.color.tab-note=Notfärg i tabulatur
 settings.config.styles.color.play-note=Färg på spelad not
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Vågräta linjers färg
 settings.config.language=Språk

--- a/common/resources/lang/messages_uk.properties
+++ b/common/resources/lang/messages_uk.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Шрифт тексту
 settings.config.styles.color.score-note=Колір нот партитури
 settings.config.styles.color.tab-note=Колір нот табулатури
 settings.config.styles.color.play-note=Колір ноти, що програється
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Колір нотного стану
 settings.config.language=Мова

--- a/common/resources/lang/messages_uk.properties
+++ b/common/resources/lang/messages_uk.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Багато доріжок
 view.layout.score-enabled=Показати партитуру
 view.layout.tablature-enabled=Показати табулатуру
 view.layout.compact=Компактно
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Вигляд акордів
 view.layout.chord-name=Ім'я
 view.layout.chord-diagram=Діаграма

--- a/common/resources/lang/messages_vi.properties
+++ b/common/resources/lang/messages_vi.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=Phông văn bản
 settings.config.styles.color.score-note=Màu nốt trên bản nhạc
 settings.config.styles.color.tab-note=Màu nốt trên Tab
 settings.config.styles.color.play-note=Màu nốt đang phát
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=Màu các đường kẻ ngang
 settings.config.language=Ngôn ngữ

--- a/common/resources/lang/messages_vi.properties
+++ b/common/resources/lang/messages_vi.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=Nhiều dải
 view.layout.score-enabled=Hiện nốt nhạc
 view.layout.tablature-enabled=Hiện tab
 view.layout.compact=Thu gọn
+# view.layout.highlight-played-beat=
 view.layout.chord-style=Kiểu hợp âm
 view.layout.chord-name=Tên hợp âm
 view.layout.chord-diagram=Sơ đồ hợp âm

--- a/common/resources/lang/messages_zh.properties
+++ b/common/resources/lang/messages_zh.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=多轨
 view.layout.score-enabled=显示五线谱
 view.layout.tablature-enabled=显示六线谱
 view.layout.compact=紧凑模式
+# view.layout.highlight-played-beat=
 view.layout.chord-style=和弦样式
 view.layout.chord-name=和弦名
 view.layout.chord-diagram=和弦图

--- a/common/resources/lang/messages_zh.properties
+++ b/common/resources/lang/messages_zh.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=文本字体
 settings.config.styles.color.score-note=五线谱音符颜色
 settings.config.styles.color.tab-note=六线谱音符颜色
 settings.config.styles.color.play-note=播放中的音符颜色
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=水平线颜色
 settings.config.language=语言

--- a/common/resources/lang/messages_zh_GB.properties
+++ b/common/resources/lang/messages_zh_GB.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=多轨
 view.layout.score-enabled=显示五线谱
 view.layout.tablature-enabled=显示六线谱
 view.layout.compact=紧缩模式
+# view.layout.highlight-played-beat=
 view.layout.chord-style=和弦样式
 view.layout.chord-name=和弦名
 view.layout.chord-diagram=和弦图

--- a/common/resources/lang/messages_zh_GB.properties
+++ b/common/resources/lang/messages_zh_GB.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=文本字体
 settings.config.styles.color.score-note=五线谱音符颜色
 settings.config.styles.color.tab-note=六线谱音符颜色
 settings.config.styles.color.play-note=播放中的音符颜色
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=水平线颜色
 settings.config.language=语言

--- a/common/resources/lang/messages_zh_TW.properties
+++ b/common/resources/lang/messages_zh_TW.properties
@@ -117,6 +117,7 @@ view.layout.multitrack=多軌
 view.layout.score-enabled=顯示總譜
 view.layout.tablature-enabled=顯示吉他譜
 view.layout.compact=精簡版
+# view.layout.highlight-played-beat=
 view.layout.chord-style=和弦風格
 view.layout.chord-name=和弦名稱
 view.layout.chord-diagram=和弦圖表

--- a/common/resources/lang/messages_zh_TW.properties
+++ b/common/resources/lang/messages_zh_TW.properties
@@ -526,6 +526,7 @@ settings.config.styles.font.text=文字字型
 settings.config.styles.color.score-note=五線譜音符顏色
 settings.config.styles.color.tab-note=六線譜音符顏色
 settings.config.styles.color.play-note=播放中的音符顏色
+# settings.config.styles.color.play-measure=
 # settings.config.styles.color.selection=
 settings.config.styles.color.lines=水平線顏色
 settings.config.language=語言

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/layout/TGToggleHighlightPlayedBeatAction.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/layout/TGToggleHighlightPlayedBeatAction.java
@@ -1,0 +1,23 @@
+package org.herac.tuxguitar.app.action.impl.layout;
+
+import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
+import org.herac.tuxguitar.editor.action.TGActionBase;
+import org.herac.tuxguitar.graphics.control.TGLayout;
+import org.herac.tuxguitar.util.TGContext;
+
+public class TGToggleHighlightPlayedBeatAction extends TGActionBase {
+	
+	public static final String NAME = "action.view.layout-highlight-played-beat";
+
+	public TGToggleHighlightPlayedBeatAction(TGContext context) {
+		super(context, NAME);
+	}
+
+	@Override
+	protected void processAction(TGActionContext context) {
+		TGLayout layout = TablatureEditor.getInstance(getContext()).getTablature().getViewLayout();
+		layout.setStyle( ( layout.getStyle() ^ TGLayout.HIGHLIGHT_PLAYED_BEAT ) );
+	}
+
+}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionConfigMap.java
@@ -68,6 +68,7 @@ import org.herac.tuxguitar.app.action.impl.layout.TGSetMultitrackViewAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetPageLayoutAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetScoreEnabledAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetTablatureEnabledAction;
+import org.herac.tuxguitar.app.action.impl.layout.TGToggleHighlightPlayedBeatAction;
 import org.herac.tuxguitar.app.action.impl.marker.TGGoFirstMarkerAction;
 import org.herac.tuxguitar.app.action.impl.marker.TGGoLastMarkerAction;
 import org.herac.tuxguitar.app.action.impl.marker.TGGoNextMarkerAction;
@@ -552,6 +553,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		this.map(TGSetCompactViewAction.NAME, LOCKABLE | SHORTCUT, UPDATE_SONG_CTL);
 		this.map(TGSetChordNameEnabledAction.NAME, LOCKABLE | SHORTCUT, UPDATE_SONG_CTL);
 		this.map(TGSetChordDiagramEnabledAction.NAME, LOCKABLE | SHORTCUT, UPDATE_SONG_CTL);
+		this.map(TGToggleHighlightPlayedBeatAction.NAME, LOCKABLE, UPDATE_SONG_CTL);
 		
 		this.map(TGSetLayoutScaleAction.NAME, LOCKABLE | SYNC_THREAD, UPDATE_SONG_CTL);
 		this.map(TGSetLayoutScaleIncrementAction.NAME, LOCKABLE | SHORTCUT | SYNC_THREAD, UPDATE_SONG_CTL);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionInstaller.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/installer/TGActionInstaller.java
@@ -69,6 +69,7 @@ import org.herac.tuxguitar.app.action.impl.layout.TGSetMultitrackViewAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetPageLayoutAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetScoreEnabledAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetTablatureEnabledAction;
+import org.herac.tuxguitar.app.action.impl.layout.TGToggleHighlightPlayedBeatAction;
 import org.herac.tuxguitar.app.action.impl.marker.TGGoFirstMarkerAction;
 import org.herac.tuxguitar.app.action.impl.marker.TGGoLastMarkerAction;
 import org.herac.tuxguitar.app.action.impl.marker.TGGoNextMarkerAction;
@@ -488,6 +489,7 @@ public class TGActionInstaller {
 		installAction(new TGSetLayoutScaleIncrementAction(context));
 		installAction(new TGSetLayoutScaleDecrementAction(context));
 		installAction(new TGSetLayoutScaleResetAction(context));
+		installAction(new TGToggleHighlightPlayedBeatAction(context));
 		
 		//tools
 		installAction(new TGSelectScaleAction(context));

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -43,7 +43,7 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.SHOW_EDIT_TOOLBAR, true);
 		loadProperty(properties, TGConfigKeys.SHOW_TRACKS, true);
 		loadProperty(properties, TGConfigKeys.LAYOUT_MODE, TGLayout.MODE_VERTICAL);
-		loadProperty(properties, TGConfigKeys.LAYOUT_STYLE, (TGLayout.DISPLAY_TABLATURE | TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_COMPACT | TGLayout.DISPLAY_CHORD_DIAGRAM));
+		loadProperty(properties, TGConfigKeys.LAYOUT_STYLE, (TGLayout.DISPLAY_TABLATURE | TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_COMPACT | TGLayout.DISPLAY_CHORD_DIAGRAM | TGLayout.HIGHLIGHT_PLAYED_BEAT));
 		loadProperty(properties, TGConfigKeys.LANGUAGE, "");
 		loadProperty(properties, TGConfigKeys.EDITOR_MOUSE_MODE, EditorKit.MOUSE_MODE_SELECTION);
 		loadProperty(properties, TGConfigKeys.EDITOR_NATURAL_KEY_MODE, true);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -64,6 +64,7 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.FONT_ABOUT_DIALOG_TITLE, (DEFAULT_FONT_NAME + ",36,true,true"));
 		loadProperty(properties, TGConfigKeys.COLOR_FOREGROUND, "0,0,0");
 		loadProperty(properties, TGConfigKeys.COLOR_BACKGROUND, "255,255,255");
+		loadProperty(properties, TGConfigKeys.COLOR_BACKGROUND_PLAYING, "225,255,225");
 		loadProperty(properties, TGConfigKeys.COLOR_LINE, "214,214,214");
 		loadProperty(properties, TGConfigKeys.COLOR_SCORE_NOTE, "64,64,64");
 		loadProperty(properties, TGConfigKeys.COLOR_TAB_NOTE, "64,64,64");

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigKeys.java
@@ -49,6 +49,9 @@ public class TGConfigKeys {
 	public static final String FONT_ABOUT_DIALOG_TITLE = "font.about.dialog.title";
 	public static final String COLOR_FOREGROUND = "color.foreground";
 	public static final String COLOR_BACKGROUND = "color.background";
+	
+	public static final String COLOR_BACKGROUND_PLAYING = "color.background.playing";
+	
 	public static final String COLOR_LINE = "color.line";
 	public static final String COLOR_SCORE_NOTE = "color.score.note";
 	public static final String COLOR_TAB_NOTE = "color.tab.note";

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TablatureStyles.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TablatureStyles.java
@@ -46,6 +46,7 @@ public class TablatureStyles extends TGLayoutStyles {
 		this.setChordFretFont(config.getFontModelConfigValue(TGConfigKeys.FONT_CHORD_FRET));
 		this.setForegroundColor(config.getColorModelConfigValue(TGConfigKeys.COLOR_FOREGROUND));
 		this.setBackgroundColor(config.getColorModelConfigValue(TGConfigKeys.COLOR_BACKGROUND));
+		this.setBackgroundColorPlaying(config.getColorModelConfigValue(TGConfigKeys.COLOR_BACKGROUND_PLAYING));
 		this.setLineColor(config.getColorModelConfigValue(TGConfigKeys.COLOR_LINE));
 		this.setScoreNoteColor(config.getColorModelConfigValue(TGConfigKeys.COLOR_SCORE_NOTE));
 		this.setTabNoteColor(config.getColorModelConfigValue(TGConfigKeys.COLOR_TAB_NOTE));

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/settings/items/StylesOption.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/settings/items/StylesOption.java
@@ -54,6 +54,7 @@ public class StylesOption extends TGSettingsOption {
 	private UIColorButton scoreNoteColorButton;
 	private UIColorButton tabNoteColorButton;
 	private UIColorButton playNoteColorButton;
+	private UIColorButton playMeasureColorButton;
 	private UIColorButton selectionColorButton;
 	private UIColorButton linesColorButton;
 
@@ -109,11 +110,14 @@ public class StylesOption extends TGSettingsOption {
 		showLabel(mainSection, TuxGuitar.getProperty("settings.config.styles.color.play-note") + ":", false, 8, 1);
 		this.playNoteColorButton = this.createColorButton(mainSection, TuxGuitar.getProperty("choose"), 8, 2);
 
-		showLabel(mainSection, TuxGuitar.getProperty("settings.config.styles.color.selection") + ":", false, 9, 1);
-		this.selectionColorButton = this.createColorButton(mainSection, TuxGuitar.getProperty("choose"), 9, 2);
+		showLabel(mainSection, TuxGuitar.getProperty("settings.config.styles.color.play-measure") + ":", false, 9, 1);
+		this.playMeasureColorButton = this.createColorButton(mainSection, TuxGuitar.getProperty("choose"), 9, 2);
 
-		showLabel(mainSection, TuxGuitar.getProperty("settings.config.styles.color.lines") + ":", false, 10, 1);
-		this.linesColorButton = this.createColorButton(mainSection, TuxGuitar.getProperty("choose"), 10, 2);
+		showLabel(mainSection, TuxGuitar.getProperty("settings.config.styles.color.selection") + ":", false, 10, 1);
+		this.selectionColorButton = this.createColorButton(mainSection, TuxGuitar.getProperty("choose"), 10, 2);
+
+		showLabel(mainSection, TuxGuitar.getProperty("settings.config.styles.color.lines") + ":", false, 11, 1);
+		this.linesColorButton = this.createColorButton(mainSection, TuxGuitar.getProperty("choose"), 11, 2);
 
 		//=================================================== PRINTER STYLES ===================================================//
 		showLabel(getPanel(), TuxGuitar.getProperty("settings.config.styles.printer"), true, 3, 1);
@@ -222,6 +226,7 @@ public class StylesOption extends TGSettingsOption {
 				final UIColorModel scoreNoteRGB  = getConfig().getColorModelConfigValue(TGConfigKeys.COLOR_SCORE_NOTE);
 				final UIColorModel tabNoteRGB  = getConfig().getColorModelConfigValue(TGConfigKeys.COLOR_TAB_NOTE);
 				final UIColorModel playNoteRGB  = getConfig().getColorModelConfigValue(TGConfigKeys.COLOR_PLAY_NOTE);
+				final UIColorModel playMeasureRGB  = getConfig().getColorModelConfigValue(TGConfigKeys.COLOR_BACKGROUND_PLAYING);
 				final UIColorModel selectionRGB  = getConfig().getColorModelConfigValue(TGConfigKeys.COLOR_SELECTION);
 				final UIColorModel linesRGB  = getConfig().getColorModelConfigValue(TGConfigKeys.COLOR_LINE);
 				TGSynchronizer.getInstance(getViewContext().getContext()).executeLater(new Runnable() {
@@ -239,6 +244,7 @@ public class StylesOption extends TGSettingsOption {
 							StylesOption.this.scoreNoteColorButton.loadColor(scoreNoteRGB);
 							StylesOption.this.tabNoteColorButton.loadColor(tabNoteRGB);
 							StylesOption.this.playNoteColorButton.loadColor(playNoteRGB);
+							StylesOption.this.playMeasureColorButton.loadColor(playMeasureRGB);
 							StylesOption.this.selectionColorButton.loadColor(selectionRGB);
 							StylesOption.this.linesColorButton.loadColor(linesRGB);
 							StylesOption.this.initialized = true;
@@ -264,6 +270,7 @@ public class StylesOption extends TGSettingsOption {
 			getConfig().setValue(TGConfigKeys.COLOR_SCORE_NOTE,this.scoreNoteColorButton.getValue());
 			getConfig().setValue(TGConfigKeys.COLOR_TAB_NOTE,this.tabNoteColorButton.getValue());
 			getConfig().setValue(TGConfigKeys.COLOR_PLAY_NOTE,this.playNoteColorButton.getValue());
+			getConfig().setValue(TGConfigKeys.COLOR_BACKGROUND_PLAYING,this.playMeasureColorButton.getValue());
 			getConfig().setValue(TGConfigKeys.COLOR_SELECTION,this.selectionColorButton.getValue());
 			getConfig().setValue(TGConfigKeys.COLOR_LINE,this.linesColorButton.getValue());
 		}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/ViewMenuItem.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/ViewMenuItem.java
@@ -13,6 +13,7 @@ import org.herac.tuxguitar.app.action.impl.layout.TGSetMultitrackViewAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetPageLayoutAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetScoreEnabledAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetTablatureEnabledAction;
+import org.herac.tuxguitar.app.action.impl.layout.TGToggleHighlightPlayedBeatAction;
 import org.herac.tuxguitar.app.action.impl.view.TGToggleChannelsDialogAction;
 import org.herac.tuxguitar.app.action.impl.view.TGToggleEditToolbarAction;
 import org.herac.tuxguitar.app.action.impl.view.TGToggleFretBoardEditorAction;
@@ -53,6 +54,7 @@ public class ViewMenuItem extends TGMenuItem {
 	private UIMenuCheckableItem scoreEnabled;
 	private UIMenuCheckableItem tablatureEnabled;
 	private UIMenuCheckableItem compact;
+	private UIMenuCheckableItem highlightPlayedBeat;
 	private UIMenuActionItem zoomIn;
 	private UIMenuActionItem zoomOut;
 	private UIMenuActionItem zoomReset;
@@ -125,6 +127,10 @@ public class ViewMenuItem extends TGMenuItem {
 		this.compact = this.layoutMenuItem.getMenu().createCheckItem();
 		this.compact.addSelectionListener(this.createActionProcessor(TGSetCompactViewAction.NAME));
 
+		//--HIGHLIGHT PLAYED BEAT--
+		this.highlightPlayedBeat = this.layoutMenuItem.getMenu().createCheckItem();
+		this.highlightPlayedBeat.addSelectionListener(this.createActionProcessor(TGToggleHighlightPlayedBeatAction.NAME));
+
 		this.layoutMenuItem.getMenu().createSeparator();
 
 		//--CHORD STYLE--
@@ -172,6 +178,7 @@ public class ViewMenuItem extends TGMenuItem {
 		this.tablatureEnabled.setChecked( (style & TGLayout.DISPLAY_TABLATURE) != 0 );
 		this.compact.setChecked( (style & TGLayout.DISPLAY_COMPACT) != 0 );
 		this.compact.setEnabled((style & TGLayout.DISPLAY_MULTITRACK) == 0 || tablature.getViewLayout().getSong().countTracks() == 1);
+		this.highlightPlayedBeat.setChecked( (style & TGLayout.HIGHLIGHT_PLAYED_BEAT) != 0 );
 		this.chordName.setChecked( (style & TGLayout.DISPLAY_CHORD_NAME) != 0 );
 		this.chordDiagram.setChecked( (style & TGLayout.DISPLAY_CHORD_DIAGRAM) != 0 );
 		this.zoomReset.setEnabled(!Tablature.DEFAULT_SCALE.equals(tablature.getScale()));
@@ -193,6 +200,7 @@ public class ViewMenuItem extends TGMenuItem {
 		setMenuItemTextAndAccelerator(this.scoreEnabled, "view.layout.score-enabled", TGSetScoreEnabledAction.NAME);
 		setMenuItemTextAndAccelerator(this.tablatureEnabled, "view.layout.tablature-enabled", TGSetTablatureEnabledAction.NAME);
 		setMenuItemTextAndAccelerator(this.compact, "view.layout.compact", TGSetCompactViewAction.NAME);
+		setMenuItemTextAndAccelerator(this.highlightPlayedBeat, "view.layout.highlight-played-beat", TGToggleHighlightPlayedBeatAction.NAME);
 		setMenuItemTextAndAccelerator(this.chordMenuItem, "view.layout.chord-style", null);
 		setMenuItemTextAndAccelerator(this.chordName, "view.layout.chord-name", TGSetChordNameEnabledAction.NAME);
 		setMenuItemTextAndAccelerator(this.chordDiagram, "view.layout.chord-diagram", TGSetChordDiagramEnabledAction.NAME);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/toolbar/main/TGMainToolBarSectionLayout.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/toolbar/main/TGMainToolBarSectionLayout.java
@@ -5,6 +5,7 @@ import org.herac.tuxguitar.app.action.impl.layout.TGSetLinearLayoutAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetMultitrackViewAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetPageLayoutAction;
 import org.herac.tuxguitar.app.action.impl.layout.TGSetScoreEnabledAction;
+import org.herac.tuxguitar.app.action.impl.layout.TGToggleHighlightPlayedBeatAction;
 import org.herac.tuxguitar.graphics.control.TGLayout;
 import org.herac.tuxguitar.graphics.control.TGLayoutHorizontal;
 import org.herac.tuxguitar.graphics.control.TGLayoutVertical;
@@ -20,6 +21,7 @@ public class TGMainToolBarSectionLayout extends TGMainToolBarSection {
 	private UIMenuActionItem multitrack;
 	private UIMenuActionItem scoreEnabled;
 	private UIMenuActionItem compact;
+	private UIMenuActionItem highlightPlayedBeat;
 	
 	public TGMainToolBarSectionLayout(TGMainToolBar toolBar) {
 		super(toolBar);
@@ -43,6 +45,9 @@ public class TGMainToolBarSectionLayout extends TGMainToolBarSection {
 		this.compact = this.menuItem.getMenu().createActionItem();
 		this.compact.addSelectionListener(this.createActionProcessor(TGSetCompactViewAction.NAME));
 		
+		this.highlightPlayedBeat = this.menuItem.getMenu().createActionItem();
+		this.highlightPlayedBeat.addSelectionListener(this.createActionProcessor(TGToggleHighlightPlayedBeatAction.NAME));
+		
 		this.loadIcons();
 		this.loadProperties();
 	}
@@ -57,6 +62,7 @@ public class TGMainToolBarSectionLayout extends TGMainToolBarSection {
 		this.multitrack.setText(this.getText("view.layout.multitrack", ( (style & TGLayout.DISPLAY_MULTITRACK) != 0 )));
 		this.scoreEnabled.setText(this.getText("view.layout.score-enabled", ( (style & TGLayout.DISPLAY_SCORE) != 0 )));
 		this.compact.setText(this.getText("view.layout.compact", ( (style & TGLayout.DISPLAY_COMPACT) != 0 )));
+		this.highlightPlayedBeat.setText(this.getText("view.layout.highlight-played-beat", ( (style & TGLayout.HIGHLIGHT_PLAYED_BEAT) != 0 )));
 	}
 	
 	public void loadIcons(){
@@ -78,5 +84,6 @@ public class TGMainToolBarSectionLayout extends TGMainToolBarSection {
 		this.scoreEnabled.setText(this.getText("view.layout.score-enabled", ( (style & TGLayout.DISPLAY_SCORE) != 0 )));
 		this.compact.setText(this.getText("view.layout.compact", ( (style & TGLayout.DISPLAY_COMPACT) != 0 )));
 		this.compact.setEnabled((style & TGLayout.DISPLAY_MULTITRACK) == 0 || this.getSong().countTracks() == 1);
+		this.highlightPlayedBeat.setText(this.getText("view.layout.highlight-played-beat", ( (style & TGLayout.HIGHLIGHT_PLAYED_BEAT) != 0 )));
 	}
 }


### PR DESCRIPTION
a first step in the implementation of #365:
- highlight currently played measure with dedicated (configurable) background color
- remove rectangle around currently played measure
- add, optionally, a rounded rectangle around currently played beat (see menu "View/Highlight Played Beat")

Still some improvement needed:
- icon for menu item
- update of help section