### PR TITLE
add app version in user config file

### DIFF
--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -134,6 +134,7 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.STYLE_DURATION_WIDTHS, new float[] {30f, 25f, 21f, 20f, 19f,18f});
 
 		loadProperty(properties, TGConfigKeys.HOMEPAGE_URL, "https://tuxguitar.app");
+		loadProperty(properties, TGConfigKeys.CONFIG_APP_VERSION, "");
 	}
 
 	private static void loadProperty(TGProperties properties, String key,String value){

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigKeys.java
@@ -121,4 +121,5 @@ public class TGConfigKeys {
 	public static final String STYLE_DURATION_WIDTHS = "style.durationWidths";
 
 	public static final String HOMEPAGE_URL = "homepage.url";
+	public static final String CONFIG_APP_VERSION = "config.app.version";
 }

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigManager.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigManager.java
@@ -4,6 +4,7 @@ import org.herac.tuxguitar.app.system.properties.TGPropertiesUIUtil;
 import org.herac.tuxguitar.ui.resource.UIColorModel;
 import org.herac.tuxguitar.ui.resource.UIFontModel;
 import org.herac.tuxguitar.util.TGContext;
+import org.herac.tuxguitar.util.TGVersion;
 import org.herac.tuxguitar.util.singleton.TGSingletonFactory;
 import org.herac.tuxguitar.util.singleton.TGSingletonUtil;
 
@@ -29,6 +30,11 @@ public class TGConfigManager extends org.herac.tuxguitar.util.configuration.TGCo
 	
 	public UIColorModel getColorModelConfigValue(String key){
 		return TGPropertiesUIUtil.getColorModelValue(this.getContext(), this.getProperties(), key);
+	}
+	
+	public void save(){
+		setValue(TGConfigKeys.CONFIG_APP_VERSION, TGVersion.CURRENT.toString());
+		super.save();
 	}
 	
 	public static TGConfigManager getInstance(TGContext context) {


### PR DESCRIPTION
yet unused: no functional consequence, for future use
targeted use case: to handle smooth transitions between app versions when user upgrades/downgrades app

example: would have been useful for 3190ae77b9ff3f186cbfc76a0bbdf7fe615f58b4 to adapt default behavior when user upgrades from an old version