### PR TITLE
highlight playing measure (fix)

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGBeatImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGBeatImpl.java
@@ -324,6 +324,7 @@ public class TGBeatImpl extends TGBeat{
 			float width = this.effectWidth + leftSpacing + rightSpacing;
 			int style = layout.getStyle();
 			float yHighestNote = 0;
+			float yLowestNote = 0;
 			if ( (style & TGLayout.DISPLAY_SCORE) != 0) {
 				for( int v = 0; v < MAX_VOICES; v ++){
 					TGVoiceImpl voice = (TGVoiceImpl)getVoice(v);
@@ -331,15 +332,26 @@ public class TGBeatImpl extends TGBeat{
 						Iterator<TGNote> it = voice.getNotes().iterator();
 						while(it.hasNext()){
 							TGNoteImpl note = (TGNoteImpl)it.next();
-							yHighestNote = (note.getScorePosY()<yHighestNote) ? note.getScorePosY() : yHighestNote;
+							yHighestNote = Math.min(note.getScorePosY(), yHighestNote);
+							yLowestNote = Math.max(note.getScorePosY(), yLowestNote);
 						}
 					}
 				}
 			}
+			float y1 = playedMeasure.getY();
+			float y2 = y1 + playedMeasure.getHeight();
+			// adapt to lowest note, only if tablature is not displayed
+			if ((layout.getStyle() & TGLayout.DISPLAY_TABLATURE) == 0) {
+				y2 = Math.max(y2, y1 + yLowestNote + 3*layout.getScoreLineSpacing());
+			}
+			// adapt to highest note, only if score is displayed
+			if ((layout.getStyle() & TGLayout.DISPLAY_SCORE) != 0) {
+				y1 += yHighestNote;
+			}
 			painter.setLineWidth(layout.getLineWidth(1));
 			painter.initPath();
 			painter.setAntialias(false);
-			painter.addRoundedRectangle(fromX+getPosX()-leftSpacing+getSpacing(layout), playedMeasure.getY()+yHighestNote, width , playedMeasure.getHeight()-yHighestNote, 3f*scale);
+			painter.addRoundedRectangle(fromX+getPosX()-leftSpacing+getSpacing(layout), y1, width , y2-y1, 3f*scale);
 			painter.closePath();
 		}
 	}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/settings/items/StylesOption.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/settings/items/StylesOption.java
@@ -290,6 +290,7 @@ public class StylesOption extends TGSettingsOption {
 			getConfig().setValue(TGConfigKeys.COLOR_SCORE_NOTE, getDefaults().getValue(TGConfigKeys.COLOR_SCORE_NOTE));
 			getConfig().setValue(TGConfigKeys.COLOR_TAB_NOTE, getDefaults().getValue(TGConfigKeys.COLOR_TAB_NOTE));
 			getConfig().setValue(TGConfigKeys.COLOR_PLAY_NOTE, getDefaults().getValue(TGConfigKeys.COLOR_PLAY_NOTE));
+			getConfig().setValue(TGConfigKeys.COLOR_BACKGROUND_PLAYING, getDefaults().getValue(TGConfigKeys.COLOR_BACKGROUND_PLAYING));
 			getConfig().setValue(TGConfigKeys.COLOR_SELECTION, getDefaults().getValue(TGConfigKeys.COLOR_SELECTION));
 			getConfig().setValue(TGConfigKeys.COLOR_LINE, getDefaults().getValue(TGConfigKeys.COLOR_LINE));
 		}


### PR DESCRIPTION
2 fixes: 
- size of rectangle around played beat: consider lowest note when tablature is not displayed
- restore background color to default when "Default" button of "Tools/Settings" dialog is clicked