### PR TITLE
Separated default gmChannels for gpx

### DIFF
--- a/common/TuxGuitar-gpx/src/org/herac/tuxguitar/io/gpx/GPXDocumentReader.java
+++ b/common/TuxGuitar-gpx/src/org/herac/tuxguitar/io/gpx/GPXDocumentReader.java
@@ -122,14 +122,14 @@ public class GPXDocumentReader {
 						Node gmNode = getChildNode(trackNode, "GeneralMidi");
 						if( gmNode != null ){
 							track.setGmProgram(getChildNodeIntegerContent(gmNode, "Program"));
-							track.setGmChannel1(getChildNodeIntegerContent(gmNode, "PrimaryChannel"));
-							track.setGmChannel2(getChildNodeIntegerContent(gmNode, "SecondaryChannel"));
+							track.setGmChannel1(getChildNodeIntegerContent(gmNode, "PrimaryChannel", this.getFreeGmChannel(null)));
+							track.setGmChannel2(getChildNodeIntegerContent(gmNode, "SecondaryChannel", this.getFreeGmChannel(track)));
 						}
 					} else if (this.version == GP7) {
 						Node midiConnectionNode = getChildNode(trackNode, "MidiConnection");
 						if( midiConnectionNode != null ){
-							track.setGmChannel1(getChildNodeIntegerContent(midiConnectionNode, "PrimaryChannel"));
-							track.setGmChannel2(getChildNodeIntegerContent(midiConnectionNode, "SecondaryChannel"));
+							track.setGmChannel1(getChildNodeIntegerContent(midiConnectionNode, "PrimaryChannel", this.getFreeGmChannel(null)));
+							track.setGmChannel2(getChildNodeIntegerContent(midiConnectionNode, "SecondaryChannel", this.getFreeGmChannel(track)));
 						}
 						NodeList soundsNodes = getChildNodeList(trackNode, "Sounds");
 						if( soundsNodes != null ){
@@ -569,5 +569,21 @@ public class GPXDocumentReader {
 	
 	private int[] getChildNodeIntegerContentArray(Node node, String name ){
 		return getChildNodeIntegerContentArray(node, name, (" ") );
+	}
+
+	private int getFreeGmChannel(GPXTrack trackToCheck) {
+		int gmChannel = 0;
+
+		boolean isGmChannelUsed;
+		do {
+			gmChannel += 1;
+
+			isGmChannelUsed = trackToCheck != null && ((trackToCheck.getGmChannel1() == gmChannel) || (trackToCheck.getGmChannel2() == gmChannel));
+			for (GPXTrack track : this.gpxDocument.getTracks()) {
+				isGmChannelUsed |= ((track.getGmChannel1() == gmChannel) || (track.getGmChannel2() == gmChannel));
+			}
+		} while (isGmChannelUsed);
+
+		return gmChannel;
 	}
 }


### PR DESCRIPTION
Recently I've found some `.gp` files which work fine in GuitarPro but don't in TuxGuitar. Instruments of all tracks were replaced by one of the first track.

I've discovered that they are in GP7 format without specified general midi channels at `MidiConnection` element in `score.gpif` file in them. 

![empty tags](https://github.com/helge17/tuxguitar/assets/57191063/d334bb87-9539-4b16-a3ed-3705d70125ac)

In that case TuxGuitar reads default value `0` as midi channels. The same midi channel in all tracks causes all channels but the first one skip their initialization.

I made sure that the default channel value was one that had not yet been used.