### PR TITLE
Perf optimization, update SWT for Linux to 4.26

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,11 +37,11 @@ In order for Asian characters to be displayed correctly, you may also need to in
 ### Download and install SWT for Linux
 
 ```sh
-$ wget https://archive.eclipse.org/eclipse/downloads/drops4/R-4.21-202109060500/swt-4.21-gtk-linux-`uname -m`.zip
-$ mkdir swt-4.21-gtk-linux-`uname -m`
-$ cd swt-4.21-gtk-linux-`uname -m`
-$ unzip ../swt-4.21-gtk-linux-`uname -m`.zip
-$ mvn install:install-file -Dfile=swt.jar -DgroupId=org.eclipse.swt -DartifactId=org.eclipse.swt.gtk.linux -Dpackaging=jar -Dversion=4.21
+$ wget https://archive.eclipse.org/eclipse/downloads/drops4/R-4.26-202211231800/swt-4.26-gtk-linux-`uname -m`.zip
+$ mkdir swt-4.26-gtk-linux-`uname -m`
+$ cd swt-4.26-gtk-linux-`uname -m`
+$ unzip ../swt-4.26-gtk-linux-`uname -m`.zip
+$ mvn install:install-file -Dfile=swt.jar -DgroupId=org.eclipse.swt -DartifactId=org.eclipse.swt.gtk.linux -Dpackaging=jar -Dversion=4.26
 $ cd ..
 ```
 

--- a/desktop/TuxGuitar-test/pom.xml
+++ b/desktop/TuxGuitar-test/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>${org.eclipse.swt.groupId}</groupId>
 			<artifactId>org.eclipse.swt.gtk.linux</artifactId>
-			<version>4.21</version>
+			<version>4.26</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/desktop/TuxGuitar-ui-toolkit/src/org/herac/tuxguitar/ui/widget/UIScrollBar.java
+++ b/desktop/TuxGuitar-ui-toolkit/src/org/herac/tuxguitar/ui/widget/UIScrollBar.java
@@ -31,4 +31,6 @@ public interface UIScrollBar extends UIComponent {
 	void addSelectionListener(UISelectionListener listener);
 	
 	void removeSelectionListener(UISelectionListener listener);
+	
+	void setVisible(boolean visible);
 }

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -139,6 +139,7 @@ public class TGConfigDefaults{
 
 		loadProperty(properties, TGConfigKeys.HOMEPAGE_URL, "https://tuxguitar.app");
 		loadProperty(properties, TGConfigKeys.CONFIG_APP_VERSION, "");
+		loadProperty(properties, TGConfigKeys.HIDE_SCROLLBARS_WHEN_PLAYING, false);
 	}
 
 	public static List<String> getKeys() {

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/system/config/TGConfigKeys.java
@@ -112,4 +112,5 @@ public class TGConfigKeys {
 
 	public static final String HOMEPAGE_URL = "homepage.url";
 	public static final String CONFIG_APP_VERSION = "config.app.version";
+	public static final String HIDE_SCROLLBARS_WHEN_PLAYING = "view.hide-scrollbars-when-playing";
 }

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
@@ -168,13 +168,35 @@ public class TGControl {
 		}
 	}
 	
+	/* Warning: only update scrollbars if at least one attribute has changed
+	 * else it creates a significant performance issue in Linux/SWT configuration:
+	 * - updating scrollbar generates a SWT event to repaint this.canvas, because scrollbars are transparent
+	 * - it calls this.paintTablature
+	 * - which in turn call this.updateScroll
+	 * if scrollbars are updated here, it creates a recursive loop: paintTablature -> updateScroll -> paintTablature -> ...
+	 * this leads to repainting the tab about 60 times per second, creating a significant CPU load
+	 * see https://github.com/helge17/tuxguitar/issues/403
+	 */
 	public void updateScroll(){
 		UIRectangle bounds = this.canvas.getBounds();
 		
-		this.hScroll.setMaximum(Math.max(Math.round(this.width - bounds.getWidth()), 0));
-		this.vScroll.setMaximum(Math.max(Math.round(this.height - bounds.getHeight()), 0));
-		this.hScroll.setThumb(Math.round(bounds.getWidth()));
-		this.vScroll.setThumb(Math.round(bounds.getHeight()));
+		int value;
+		value = Math.max(Math.round(this.width - bounds.getWidth()), 0);
+		if (this.hScroll.getMaximum() != value) {
+			this.hScroll.setMaximum(value);
+		}
+		value = Math.max(Math.round(this.height - bounds.getHeight()), 0);
+		if (this.vScroll.getMaximum() != value) {
+			this.vScroll.setMaximum(value);
+		}
+		value = Math.round(bounds.getWidth());
+		if (this.hScroll.getThumb() != value) {
+			this.hScroll.setThumb(value);
+		}
+		value = Math.round(bounds.getHeight());
+		if (this.vScroll.getThumb() != value) {
+			this.vScroll.setThumb(value);
+		}
 	}
 	
 	public void moveScrollTo(TGMeasureImpl measure){

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
@@ -1,6 +1,7 @@
 package org.herac.tuxguitar.app.view.component.tab;
 
 import org.herac.tuxguitar.app.TuxGuitar;
+import org.herac.tuxguitar.app.system.config.TGConfigKeys;
 import org.herac.tuxguitar.app.system.keybindings.KeyBindingActionManager;
 import org.herac.tuxguitar.app.transport.TGTransport;
 import org.herac.tuxguitar.app.ui.TGApplication;
@@ -45,10 +46,12 @@ public class TGControl {
 	protected long lastHScrollTime;
 	
 	private boolean painting;
+	private boolean hideScrollbarsWhenPlaying;
 	
 	public TGControl(TGContext context, UIContainer parent) {
 		this.context = context;
 		this.tablature = TablatureEditor.getInstance(this.context).getTablature();
+		this.hideScrollbarsWhenPlaying = TuxGuitar.getInstance().getConfig().getBooleanValue(TGConfigKeys.HIDE_SCROLLBARS_WHEN_PLAYING);
 		this.initialize(parent);
 	}
 	
@@ -106,8 +109,10 @@ public class TGControl {
 		this.setPainting(true);
 		try{
 			boolean isPlaying = MidiPlayer.getInstance(this.context).isRunning();
-			this.hScroll.setVisible(!isPlaying);
-			this.vScroll.setVisible(!isPlaying);
+			if (hideScrollbarsWhenPlaying) {
+				this.hScroll.setVisible(!isPlaying);
+				this.vScroll.setVisible(!isPlaying);
+			}
 			this.checkScroll();
 			
 			int oldWidth = this.width;

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
@@ -105,6 +105,9 @@ public class TGControl {
 	public void paintTablature(UIPainter painter) {
 		this.setPainting(true);
 		try{
+			boolean isPlaying = MidiPlayer.getInstance(this.context).isRunning();
+			this.hScroll.setVisible(!isPlaying);
+			this.vScroll.setVisible(!isPlaying);
 			this.checkScroll();
 			
 			int oldWidth = this.width;
@@ -122,7 +125,7 @@ public class TGControl {
 			
 			this.updateScroll();
 			
-			if( MidiPlayer.getInstance(this.context).isRunning()){
+			if( isPlaying ){
 				this.paintTablaturePlayMode(painter);
 			}
 			// Si no estoy reproduciendo y hay cambios

--- a/desktop/build-scripts/common-resources/common-freebsd/dist/tuxguitar.cfg
+++ b/desktop/build-scripts/common-resources/common-freebsd/dist/tuxguitar.cfg
@@ -1,1 +1,2 @@
 # Non-default settings for FreeBSD
+view.hide-scrollbars-when-playing=true

--- a/desktop/build-scripts/common-resources/common-linux/dist/tuxguitar.cfg
+++ b/desktop/build-scripts/common-resources/common-linux/dist/tuxguitar.cfg
@@ -1,2 +1,3 @@
 # Non-default settings for Linux
 midi.port=Gervill
+view.hide-scrollbars-when-playing=true

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -295,7 +295,7 @@
 			<dependency>
 				<groupId>${org.eclipse.swt.groupId}</groupId>
 				<artifactId>org.eclipse.swt.gtk.linux</artifactId>
-				<version>4.21</version>
+				<version>4.26</version>
 			</dependency>
 			<dependency>
 				<groupId>${org.eclipse.swt.groupId}</groupId>

--- a/doc/contribute.md
+++ b/doc/contribute.md
@@ -146,11 +146,11 @@ To have all foreign packages in your Eclipse workspace, create a folder named "e
 eclipse-workspace$ sudo apt install maven
 eclipse-workspace$ mkdir externals
 eclipse-workspace$ cd externals
-eclipse-workspace$ wget https://archive.eclipse.org/eclipse/downloads/drops4/R-4.21-202109060500/swt-4.21-gtk-linux-x86_64.zip
-eclipse-workspace/externals$ mkdir swt-4.21-gtk-linux-x86_64
-eclipse-workspace/externals$ cd swt-4.21-gtk-linux-x86_64
-eclipse-workspace/externals$ unzip ../swt-4.21-gtk-linux-x86_64.zip
-eclipse-workspace/externals$ mvn install:install-file -Dfile=swt.jar -DgroupId=org.eclipse.swt -DartifactId=org.eclipse.swt.gtk.linux -Dpackaging=jar -Dversion=4.21
+eclipse-workspace$ wget https://archive.eclipse.org/eclipse/downloads/drops4/R-4.26-202211231800/swt-4.26-gtk-linux-x86_64.zip
+eclipse-workspace/externals$ mkdir swt-4.26-gtk-linux-x86_64
+eclipse-workspace/externals$ cd swt-4.26-gtk-linux-x86_64
+eclipse-workspace/externals$ unzip ../swt-4.26-gtk-linux-x86_64.zip
+eclipse-workspace/externals$ mvn install:install-file -Dfile=swt.jar -DgroupId=org.eclipse.swt -DartifactId=org.eclipse.swt.gtk.linux -Dpackaging=jar -Dversion=4.26
 ```
 
 #### Define run configuration

--- a/misc/build_tuxguitar_from_source.sh
+++ b/misc/build_tuxguitar_from_source.sh
@@ -636,8 +636,8 @@ fi
 # Linux
 if [ $build_linux ]; then
   # SWT version in Debian 12
-  SWT_VERSION=4.21
-  SWT_DATE=202109060500
+  SWT_VERSION=4.26
+  SWT_DATE=202211231800
   SWT_PLATFORM=gtk-linux
   [ `uname` == Linux ] && build_tg_for_linux
 fi


### PR DESCRIPTION
See #403 

@helge17 , I would appreciate your feedback before merging this PR, especially:
- not tested on macOS
- ~~not tested on FreeBSD (I've got some issues in my VM, need to spend some time on it)~~ I could finally test on FreeBSD, it's OK. Better apply the same optimization as for Linux, as it uses the same gtk flavour of SWT
- I reverted 429c42f159f4e07a3c6dded9dabc363be2478a7f: it modified `build_tuxguitar_from_source.sh` (untested)

on macOS and Windows, behavior should be unchanged.
on Linux and FreeBSD, the only visible modification is that scrollbars are now hidden when playing.
no impact on Android.

I think we shall try to update SWT for Linux quite soon, to leave us some time to detect possible issues. Now, if someone wants to package 1.6.3 for debian 12, performance issue #403 will be present.
