### PR TITLE
fix audio export

### DIFF
--- a/desktop/TuxGuitar-synth-export/src/org/herac/tuxguitar/io/synth/TGSynthSongWriter.java
+++ b/desktop/TuxGuitar-synth-export/src/org/herac/tuxguitar/io/synth/TGSynthSongWriter.java
@@ -55,7 +55,6 @@ public class TGSynthSongWriter implements TGSongWriter {
 			TGSynthSequenceHandler midiSequenceHandler = new TGSynthSequenceHandler(tgSong.countTracks());
 			midiSequenceParser.parse(midiSequenceHandler);
 			if(!midiSequenceHandler.getEvents().isEmpty()) {
-				
 				TGSynthModel synthModel = new TGSynthModel(this.context);
 				TGAudioBufferProcessor audioProcessor = new TGAudioBufferProcessor(synthModel);
 				ByteArrayOutputStream audioBuffer = new ByteArrayOutputStream();
@@ -64,17 +63,15 @@ public class TGSynthSongWriter implements TGSongWriter {
 				this.loadSynthPrograms(synthModel, tgSong);
 				
 				sequence.start();
+				long duration = 0;
 				while(!sequence.isEnded()) {
 					sequence.dispatchEvents();
 					
 					audioProcessor.process();
 					audioBuffer.write(audioProcessor.getBuffer().getBuffer(), 0, audioProcessor.getBuffer().getLength());
-					
+					duration += audioProcessor.getBuffer().getLength();
 					sequence.forward();
 				}
-				
-				long duration = (long) (TGAudioLine.AUDIO_FORMAT.getFrameRate() * ((sequence.getLength() / 1000.00)));
-				
 				ByteArrayInputStream byteBuffer = new ByteArrayInputStream(audioBuffer.toByteArray());
 				AudioInputStream sourceStream = new AudioInputStream(byteBuffer, TGAudioLine.AUDIO_FORMAT, duration);
 				AudioInputStream targetStream = AudioSystem.getAudioInputStream(settings.getFormat(), sourceStream);


### PR DESCRIPTION
computation of audio file duration was erroneous
when too high, this had no audible consequence
when too low, output file was truncated

see #431