### PR TITLE
Fix #432

### DIFF
--- a/desktop/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/menu/JFXMenuCheckableItem.java
+++ b/desktop/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/menu/JFXMenuCheckableItem.java
@@ -18,8 +18,5 @@ public class JFXMenuCheckableItem extends JFXMenuActionItem implements UIMenuChe
 		((CheckMenuItem) this.getControl()).setSelected(checked);
 	}
 
-	public boolean hasSelectionListener() {
-		return (!this.selectionListener.isEmpty());
-	}
 	
 }

--- a/desktop/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/menu/JFXMenuRadioItem.java
+++ b/desktop/TuxGuitar-ui-toolkit-jfx/src/org/herac/tuxguitar/ui/jfx/menu/JFXMenuRadioItem.java
@@ -18,8 +18,5 @@ public class JFXMenuRadioItem extends JFXMenuActionItem implements UIMenuCheckab
 		((RadioMenuItem) this.getControl()).setSelected(checked);
 	}
 	
-	public boolean hasSelectionListener() {
-		return (!this.selectionListener.isEmpty());
-	}
 
 }

--- a/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/event/SWTSelectionListenerManager.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/event/SWTSelectionListenerManager.java
@@ -2,6 +2,8 @@ package org.herac.tuxguitar.ui.swt.event;
 
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MenuItem;
 import org.herac.tuxguitar.ui.event.UISelectionEvent;
 import org.herac.tuxguitar.ui.event.UISelectionListenerManager;
 import org.herac.tuxguitar.ui.swt.widget.SWTEventReceiver;
@@ -20,7 +22,15 @@ public class SWTSelectionListenerManager extends UISelectionListenerManager impl
 	
 	public void widgetSelected(SelectionEvent e) {
 		if(!this.control.isIgnoreEvents()) {
-			this.onSelect(new UISelectionEvent(this.control));
+			// warning, when a SWT radio button is selected, if another radio button was selected it gets unselected and also generates an event
+			// only consider the selected radio button
+			boolean doIt = true;
+			if ((e.widget instanceof MenuItem) && ((e.widget.getStyle() & SWT.RADIO) != 0)) {
+				doIt = ((MenuItem)e.widget).getSelection();
+			}
+			if (doIt) {
+				this.onSelect(new UISelectionEvent(this.control));
+			}
 		}
 	}
 	

--- a/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/menu/SWTMenuCheckableItem.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/org/herac/tuxguitar/ui/swt/menu/SWTMenuCheckableItem.java
@@ -17,7 +17,4 @@ public class SWTMenuCheckableItem extends SWTMenuActionItem implements UIMenuChe
 		this.getControl().setSelection(checked);
 	}
 
-	public boolean hasSelectionListener() {
-		return (!this.selectionListener.isEmpty());
-	}
 }

--- a/desktop/TuxGuitar-ui-toolkit/src/org/herac/tuxguitar/ui/menu/UIMenuCheckableItem.java
+++ b/desktop/TuxGuitar-ui-toolkit/src/org/herac/tuxguitar/ui/menu/UIMenuCheckableItem.java
@@ -6,5 +6,4 @@ public interface UIMenuCheckableItem extends UIMenuActionItem {
 
 	void setChecked(boolean checked);
 	
-	boolean hasSelectionListener();
 }

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/DivisionMenuItem.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/DivisionMenuItem.java
@@ -34,7 +34,7 @@ public class DivisionMenuItem extends TGMenuItem {
 
 		for (int i = 0; i < TGDivisionType.DIVISION_TYPES.length; i++) {
 			final int j = i;
-			this.divisionTypeMenuItems[j] = this.divisionMenuItem.getMenu().createCheckItem();
+			this.divisionTypeMenuItems[j] = this.divisionMenuItem.getMenu().createRadioItem();
 			this.divisionTypeMenuItems[j].addSelectionListener(new UISelectionListener() {
 				public void onSelect(UISelectionEvent event) {
 					DivisionMenuItem.this.createDivisionTypeAction(DivisionMenuItem.this.createDivisionType(TGDivisionType.DIVISION_TYPES[j])).process();

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/DivisionMenuItem.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/menu/impl/DivisionMenuItem.java
@@ -2,7 +2,6 @@ package org.herac.tuxguitar.app.view.menu.impl;
 
 import org.herac.tuxguitar.app.TuxGuitar;
 import org.herac.tuxguitar.app.action.TGActionProcessorListener;
-import org.herac.tuxguitar.app.view.component.tab.TablatureEditor;
 import org.herac.tuxguitar.app.view.menu.TGMenuItem;
 import org.herac.tuxguitar.document.TGDocumentManager;
 import org.herac.tuxguitar.editor.action.duration.TGSetDivisionTypeDurationAction;
@@ -13,7 +12,6 @@ import org.herac.tuxguitar.ui.event.UISelectionEvent;
 import org.herac.tuxguitar.ui.event.UISelectionListener;
 import org.herac.tuxguitar.ui.menu.UIMenu;
 import org.herac.tuxguitar.ui.menu.UIMenuCheckableItem;
-import org.herac.tuxguitar.ui.menu.UIMenuActionItem;
 import org.herac.tuxguitar.ui.menu.UIMenuSubMenuItem;
 
 public class DivisionMenuItem extends TGMenuItem {

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/toolbar/edit/TGEditToolBarSectionDuration.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/toolbar/edit/TGEditToolBarSectionDuration.java
@@ -46,7 +46,6 @@ public class TGEditToolBarSectionDuration extends TGEditToolBarSection {
 	
 	private List<UIToolCheckableItem> durationToolItems;
 	private List<UIMenuCheckableItem> divisionTypeMenuItems;
-	private List<TGActionProcessorListener> divisionTypeProcessors;
 	
 	private Map<Integer, String> durationNameKeys;
 	private Map<Integer, String> durationActions;
@@ -88,10 +87,10 @@ public class TGEditToolBarSectionDuration extends TGEditToolBarSection {
 		});
 		
 		this.divisionTypeMenuItems = new ArrayList<UIMenuCheckableItem>();
-		this.divisionTypeProcessors = new ArrayList<TGActionProcessorListener>();
 		for( int i = 0 ; i < TGDivisionType.DIVISION_TYPES.length ; i ++ ){
-			this.divisionTypeMenuItems.add(this.createDivisionTypeMenuItem(TGDivisionType.DIVISION_TYPES[i]));
-			this.divisionTypeProcessors.add(this.createDivisionTypeAction(TGDivisionType.DIVISION_TYPES[i]));
+			UIMenuCheckableItem item = this.createDivisionTypeMenuItem(TGDivisionType.DIVISION_TYPES[i]);
+			this.divisionTypeMenuItems.add(item);
+			item.addSelectionListener(this.createDivisionTypeAction(TGDivisionType.DIVISION_TYPES[i]));
 		}
 	}
 	
@@ -230,25 +229,12 @@ public class TGEditToolBarSectionDuration extends TGEditToolBarSection {
 		return uiMenuItem;
 	}
 	
-	/* radio buttons generate events both when they are selected AND unselected (at least in SWT configuration)
-	 * the only relevant event is when radio button is selected by user
-	 * so, only keep selectionListener defined for non-selected radio buttons
-	 */
+
 	private void updateDivisionTypeMenuItems(TGDivisionType selection, boolean running) {
 		for(int i=0; i< this.divisionTypeMenuItems.size(); i++) {
 			UIMenuCheckableItem uiMenuItem = this.divisionTypeMenuItems.get(i);
 			TGDivisionType divisionType = uiMenuItem.getData(TGDivisionType.class.getName());
-			if (divisionType.isEqual(selection)) {
-				uiMenuItem.setChecked(true);
-				if (uiMenuItem.hasSelectionListener()) {
-					uiMenuItem.removeSelectionListener(this.divisionTypeProcessors.get(i));
-				}
-			} else {
-				uiMenuItem.setChecked(false);
-				if (!uiMenuItem.hasSelectionListener()) {
-					uiMenuItem.addSelectionListener(this.divisionTypeProcessors.get(i));
-				}
-			}
+			uiMenuItem.setChecked(divisionType.isEqual(selection));
 		}
 		this.divisionTypeItem.setImage(this.getIconManager().getDivisionType(selection.getEnters()));
 	}


### PR DESCRIPTION
A bit surprising such an issue could be present since so long
see description/analysis in #432 

global solution applied to all groups of radio buttons for SWT.
Therefore, implementation of edit toolbar for division type is also simplified