### PR TITLE
fix audio export duration

### DIFF
--- a/desktop/TuxGuitar-synth-export/src/org/herac/tuxguitar/io/synth/TGSynthSongWriter.java
+++ b/desktop/TuxGuitar-synth-export/src/org/herac/tuxguitar/io/synth/TGSynthSongWriter.java
@@ -12,6 +12,7 @@ import org.herac.tuxguitar.io.base.TGFileFormat;
 import org.herac.tuxguitar.io.base.TGFileFormatException;
 import org.herac.tuxguitar.io.base.TGSongWriter;
 import org.herac.tuxguitar.io.base.TGSongWriterHandle;
+import org.herac.tuxguitar.midi.synth.TGAudioBuffer;
 import org.herac.tuxguitar.midi.synth.TGAudioBufferProcessor;
 import org.herac.tuxguitar.midi.synth.TGAudioLine;
 import org.herac.tuxguitar.midi.synth.TGSynthModel;
@@ -72,6 +73,7 @@ public class TGSynthSongWriter implements TGSongWriter {
 					duration += audioProcessor.getBuffer().getLength();
 					sequence.forward();
 				}
+				duration = duration / TGAudioBuffer.CHANNELS;
 				ByteArrayInputStream byteBuffer = new ByteArrayInputStream(audioBuffer.toByteArray());
 				AudioInputStream sourceStream = new AudioInputStream(byteBuffer, TGAudioLine.AUDIO_FORMAT, duration);
 				AudioInputStream targetStream = AudioSystem.getAudioInputStream(settings.getFormat(), sourceStream);


### PR DESCRIPTION
correction of 1e2268d5092dc247b72c9d9ce0b7621e113a5cfe
forgot a factor 2 in duration computation (nb of channels)
see #431 