### PR TITLE
don't change current doc uri when exporting song

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/io/base/TGFileFormatManager.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/io/base/TGFileFormatManager.java
@@ -312,6 +312,17 @@ public class TGFileFormatManager {
 		return this.commonWriteFileFormats.contains(fileFormat);
 	}
 	
+	public boolean isCommonWriteFileFormat(String formatCode){
+		for (TGFileFormat fileFormat : this.commonWriteFileFormats) {
+			for (String supportedFormatCode : fileFormat.getSupportedFormats()) {
+				if (supportedFormatCode.equals(formatCode)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+	
 	public void fireFileFormatAvailabilityEvent(){
 		TGEventManager.getInstance(this.context).fireEvent(new TGFileFormatAvailabilityEvent());
 	}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/file/TGWriteFileAction.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/file/TGWriteFileAction.java
@@ -9,6 +9,7 @@ import org.herac.tuxguitar.action.TGActionException;
 import org.herac.tuxguitar.action.TGActionManager;
 import org.herac.tuxguitar.editor.action.TGActionBase;
 import org.herac.tuxguitar.editor.action.file.TGWriteSongAction;
+import org.herac.tuxguitar.io.base.TGFileFormatManager;
 import org.herac.tuxguitar.io.base.TGFileFormatUtils;
 import org.herac.tuxguitar.util.TGContext;
 
@@ -17,6 +18,8 @@ public class TGWriteFileAction extends TGActionBase {
 	public static final String NAME = "action.file.write";
 	
 	public static final String ATTRIBUTE_FILE_NAME = "fileName";
+	// file export: boolean attribute, set to true if writing to a non commonFileFormat
+	public static final String ATTRIBUTE_FILE_EXPORT = "fileExport";
 	
 	public TGWriteFileAction(TGContext context) {
 		super(context, NAME);
@@ -27,7 +30,9 @@ public class TGWriteFileAction extends TGActionBase {
 			String fileName = context.getAttribute(ATTRIBUTE_FILE_NAME);
 			
 			context.setAttribute(TGWriteSongAction.ATTRIBUTE_OUTPUT_STREAM, new FileOutputStream(new File(fileName)));
-			context.setAttribute(TGWriteSongAction.ATTRIBUTE_FORMAT_CODE, TGFileFormatUtils.getFileFormatCode(fileName));
+			String formatCode = TGFileFormatUtils.getFileFormatCode(fileName);
+			context.setAttribute(TGWriteSongAction.ATTRIBUTE_FORMAT_CODE, formatCode);
+			context.setAttribute(ATTRIBUTE_FILE_EXPORT, !TGFileFormatManager.getInstance(getContext()).isCommonWriteFileFormat(formatCode));
 			
 			TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
 			tgActionManager.execute(TGWriteSongAction.NAME, context);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateSavedSongController.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateSavedSongController.java
@@ -1,6 +1,7 @@
 package org.herac.tuxguitar.app.action.listener.cache.controller;
 
 import org.herac.tuxguitar.action.TGActionContext;
+import org.herac.tuxguitar.app.action.impl.file.TGWriteFileAction;
 import org.herac.tuxguitar.app.document.TGDocument;
 import org.herac.tuxguitar.app.document.TGDocumentListManager;
 import org.herac.tuxguitar.app.helper.TGFileHistory;
@@ -22,7 +23,9 @@ public class TGUpdateSavedSongController extends TGUpdateItemsController {
 		
 		TGDocument tgDocument = TGDocumentListManager.getInstance(context).findCurrentDocument();
 		tgDocument.setUnwanted(false);
-		tgDocument.setUnsaved(false);
+		if (!Boolean.TRUE.equals(actionContext.getAttribute(TGWriteFileAction.ATTRIBUTE_FILE_EXPORT) )) {
+			tgDocument.setUnsaved(false);
+		}
 		
 		TGFileHistory tgFileHistory = TGFileHistory.getInstance(context);
 		tgFileHistory.reset(null);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateWrittenFileController.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/listener/cache/controller/TGUpdateWrittenFileController.java
@@ -22,7 +22,8 @@ public class TGUpdateWrittenFileController extends TGUpdateItemsController {
 	public void update(TGContext context, TGActionContext actionContext) {
 		try {
 			String fileName = actionContext.getAttribute(TGWriteFileAction.ATTRIBUTE_FILE_NAME);
-			if( fileName != null ) {
+			// update document uri only if file was "saved", not "exported"
+			if( (fileName != null) && !Boolean.TRUE.equals(actionContext.getAttribute(TGWriteFileAction.ATTRIBUTE_FILE_EXPORT)) ) {
 				URI uri = new File(fileName).toURI();
 				URL url = uri.toURL();
 				


### PR DESCRIPTION
see #462

use case:
- open myFile.tg file
- "File/Export" (e.g. pdf, lilypond, musicxml or whatever) this exports correctly myFile.xxx, but current active document now remains myFile.tg
also don't change attribute "unsaved"

File/Save (or Save As) correctly updates doc uri and unsaved attributes