### PR TITLE
warn user when saving under foreign format

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/io/base/TGFileFormatManager.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/io/base/TGFileFormatManager.java
@@ -8,6 +8,7 @@ import org.herac.tuxguitar.event.TGEventManager;
 import org.herac.tuxguitar.io.tg.TGFileFormatDetectorImpl;
 import org.herac.tuxguitar.io.tg.TGSongReaderImpl;
 import org.herac.tuxguitar.io.tg.TGSongWriterImpl;
+import org.herac.tuxguitar.io.tg.TGStream;
 import org.herac.tuxguitar.util.TGContext;
 import org.herac.tuxguitar.util.singleton.TGSingletonFactory;
 import org.herac.tuxguitar.util.singleton.TGSingletonUtil;
@@ -318,6 +319,15 @@ public class TGFileFormatManager {
 				if (supportedFormatCode.equals(formatCode)) {
 					return true;
 				}
+			}
+		}
+		return false;
+	}
+	
+	public boolean isNativeWriteFileFormat(String formatCode) {
+		for (String supportedFormatCode : TGStream.TG_FORMAT.getSupportedFormats()) {
+			if (supportedFormatCode.equals(formatCode)) {
+				return true;
 			}
 		}
 		return false;

--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -196,6 +196,7 @@ file.save-as=Save As
 file.save.default-name=Untitled
 file.save-changes-question=The song has unsaved changes.\nDo you want to save the changes?
 file.overwrite-question=This file already exists. Do you want to overwrite it?
+file.confirm-foreign-format=This file format may not be able to store all song details correctly.\nIt is recommended to use TuxGuitar file format.\nContinue?
 file.import=Import
 file.export=Export
 file.supported-formats=All Supported Formats

--- a/common/resources/lang/messages_bg.properties
+++ b/common/resources/lang/messages_bg.properties
@@ -52,6 +52,7 @@ file.save-as=Запазване като
 file.save.default-name=Неозаглавено
 file.save-changes-question=Песента има незапазени промени.\nЖелаете ли да ги запазите?
 file.overwrite-question=Такъв файл вече съществува. Желаете ли да го презапишете?
+# file.confirm-foreign-format=
 file.import=Внасяне
 file.export=Изнасяне
 # file.supported-formats=

--- a/common/resources/lang/messages_ca.properties
+++ b/common/resources/lang/messages_ca.properties
@@ -52,6 +52,7 @@ file.save-as=Desa com a
 file.save.default-name=Sense títol
 file.save-changes-question=L'arxiu té canvis sense desar.\nVoleu desar els canvis?
 file.overwrite-question=L'arxiu ja existeix, desitgeu sobreescriure'l?
+# file.confirm-foreign-format=
 file.import=Importa
 file.export=Exportar
 # file.supported-formats=

--- a/common/resources/lang/messages_cs.properties
+++ b/common/resources/lang/messages_cs.properties
@@ -52,6 +52,7 @@ file.save-as=Uložit jako...
 file.save.default-name=Bez názvu
 # file.save-changes-question=
 file.overwrite-question=Tento soubor již existuje, opravdu ho chcete přepsat??
+# file.confirm-foreign-format=
 file.import=Importovat
 file.export=Exportovat
 # file.supported-formats=

--- a/common/resources/lang/messages_de.properties
+++ b/common/resources/lang/messages_de.properties
@@ -52,6 +52,7 @@ file.save-as=Speichern unter
 file.save.default-name=Unbenannt
 file.save-changes-question=Das Lied wurde seit dem letzten Speichern verändert.\nWollen Sie die Änderungen vor dem Beenden speichern?
 file.overwrite-question=Diese Datei existiert bereits. Soll sie überschrieben werden?
+# file.confirm-foreign-format=
 file.import=Importieren als
 file.export=Exportieren als
 file.supported-formats=Alle unterstützten Formate

--- a/common/resources/lang/messages_el.properties
+++ b/common/resources/lang/messages_el.properties
@@ -52,6 +52,7 @@ file.save-as=Αποθήκευση Ως
 file.save.default-name=Χωρίς τίτλο
 file.save-changes-question=Το τραγούδι περιέχει μη αποθηκευμένες αλλαγές.\nΕπιθυμείτε να αποθηκεύσετε τις αλλαγές;
 file.overwrite-question=Αυτός ο φάκελος υπάρχει ήδη. Επιθυμείτε να τον αντικαταστήσετε;
+# file.confirm-foreign-format=
 file.import=Εισαγωγή
 file.export=Εξαγωγή
 # file.supported-formats=

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -52,6 +52,7 @@ file.save-as=Guardar Como
 file.save.default-name=Sin Título
 file.save-changes-question=El archivo tiene cambios sin guardar.\n¿Desea guardar los cambios?
 file.overwrite-question=El archivo ya existe, ¿desea reemplazarlo?
+# file.confirm-foreign-format=
 file.import=Importar
 file.export=Exportar
 # file.supported-formats=

--- a/common/resources/lang/messages_eu.properties
+++ b/common/resources/lang/messages_eu.properties
@@ -52,6 +52,7 @@ file.save-as=Gorde beste izenarekin
 file.save.default-name=Izenburu gabea
 file.save-changes-question=Fitxategia aldaketak ditu, Gorde nahi al dituzu?
 file.overwrite-question=Badago Fitxategi bat izen honekin, Ordezkatu nahi duzu?
+# file.confirm-foreign-format=
 file.import=Importatu
 file.export=Exportatu
 # file.supported-formats=

--- a/common/resources/lang/messages_fi.properties
+++ b/common/resources/lang/messages_fi.properties
@@ -52,6 +52,7 @@ file.save-as=Tallenna nimellä
 file.save.default-name=Nimetön
 file.save-changes-question=Kappaleessa on tallentamattomia muutoksia. \nHaluatko tallentaa muutokset?
 file.overwrite-question=Tämä tiedosto on jo olemassa. Haluatko korvata sen?
+# file.confirm-foreign-format=
 file.import=Tuo
 file.export=Vie
 # file.supported-formats=

--- a/common/resources/lang/messages_fr.properties
+++ b/common/resources/lang/messages_fr.properties
@@ -52,6 +52,7 @@ file.save-as=Enregistrer sous...
 file.save.default-name=Sans titre
 file.save-changes-question=Le morceau a été modifié.\nVoulez-vous enregistrer les modifications ?
 file.overwrite-question=Ce fichier existe déjà. Voulez-vous le remplacer ?
+file.confirm-foreign-format=Utiliser ce format de fichier pourrait provoquer une perte d'information.\nIl est recommandé d'utiliser le format TuxGuitar.\nContinuer?
 file.import=Importer
 file.export=Exporter
 file.supported-formats=Tous les formats pris en charge

--- a/common/resources/lang/messages_hu.properties
+++ b/common/resources/lang/messages_hu.properties
@@ -52,6 +52,7 @@ file.save-as=Mentés másként...
 file.save.default-name=Nincs cím
 # file.save-changes-question=
 file.overwrite-question=A fájl már létezik, felülírod ???
+# file.confirm-foreign-format=
 file.import=Importálás
 file.export=Exportálás
 # file.supported-formats=

--- a/common/resources/lang/messages_it.properties
+++ b/common/resources/lang/messages_it.properties
@@ -52,6 +52,7 @@ file.save-as=Salva come
 file.save.default-name=Senza titolo
 file.save-changes-question=La canzone è stata modificata.\nVuoi salvare le modifiche?
 file.overwrite-question=Questo file esiste già, vuoi sovrascriverlo??
+# file.confirm-foreign-format=
 file.import=Importa
 file.export=Esporta
 file.supported-formats=Tutti i formati supportati

--- a/common/resources/lang/messages_ja.properties
+++ b/common/resources/lang/messages_ja.properties
@@ -52,6 +52,7 @@ file.save-as=別名保存
 # file.save.default-name=
 file.save-changes-question=ファイルが変更されています.\n変更を保存しますか?
 file.overwrite-question=同名のファイルが存在します.\n上書きしますか?
+# file.confirm-foreign-format=
 file.import=インポート
 file.export=エクスポート
 # file.supported-formats=

--- a/common/resources/lang/messages_ko.properties
+++ b/common/resources/lang/messages_ko.properties
@@ -52,6 +52,7 @@ file.save-as=다른 이름으로 저장
 # file.save.default-name=
 file.save-changes-question=저장되지 않은 변경사항이 있습니다.\n변경 내용을 저장할까요?
 file.overwrite-question=파일이 이미 존재합니다. 덮어쓸까요?
+# file.confirm-foreign-format=
 file.import=불러오기
 file.export=내보내기
 # file.supported-formats=

--- a/common/resources/lang/messages_lt.properties
+++ b/common/resources/lang/messages_lt.properties
@@ -52,6 +52,7 @@ file.save-as=Įrašyti taip
 file.save.default-name=Be pavadinimo
 file.save-changes-question=Kūrinyje yra neįrašytų pakeitimų.\nAr dabar juos įrašyti?
 file.overwrite-question=Toks failas jau yra. Ar jį perrašyti?
+# file.confirm-foreign-format=
 file.import=Importuoti
 file.export=Eksportuoti
 # file.supported-formats=

--- a/common/resources/lang/messages_nl.properties
+++ b/common/resources/lang/messages_nl.properties
@@ -52,6 +52,7 @@ file.save-as=Opslaan Als
 file.save.default-name=Naamloos
 file.save-changes-question=De track heeft niet opgeslagen wijzigingen.\nWilt u dit alsnog opslaan?
 file.overwrite-question=Dit bestand bestaat al, wilt u dit overschrijven?
+# file.confirm-foreign-format=
 file.import=Importeren
 file.export=Exporteren
 # file.supported-formats=

--- a/common/resources/lang/messages_pl.properties
+++ b/common/resources/lang/messages_pl.properties
@@ -52,6 +52,7 @@ file.save-as=Zapisz jako
 file.save.default-name=Bez nazwy
 file.save-changes-question=Utwór ma niezapisane zmiany.\nChcesz zapisać zmiany?
 file.overwrite-question=Plik już istnieje. Chcesz go zastąpić?
+# file.confirm-foreign-format=
 file.import=Importuj
 file.export=Eksportuj
 file.supported-formats=Wszystkie obsługiwane formaty

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -52,6 +52,7 @@ file.save-as=Salvar Como
 # file.save.default-name=
 file.save-changes-question=A música tem alterações não salvas.\nDeseja salvar as mudanças?
 file.overwrite-question=Este arquivo já existe, você deseja salvar sobre ele??
+# file.confirm-foreign-format=
 file.import=Importar
 file.export=Exportar
 # file.supported-formats=

--- a/common/resources/lang/messages_ru.properties
+++ b/common/resources/lang/messages_ru.properties
@@ -52,6 +52,7 @@ file.save-as=Сохранить как
 file.save.default-name=Без названия
 file.save-changes-question=В композиции были сделаны изменения.\nСохранить их?
 file.overwrite-question=Такой файл уже существует. Заменить его?
+# file.confirm-foreign-format=
 file.import=Импорт
 file.export=Экспорт
 # file.supported-formats=

--- a/common/resources/lang/messages_sr.properties
+++ b/common/resources/lang/messages_sr.properties
@@ -52,6 +52,7 @@ file.save-as=Snimi kao
 file.save.default-name=Nema_ime
 file.save-changes-question=Izmene koje ste izvršili nisu snimljene.\nŽelite li da ih snimite?
 file.overwrite-question=Navedena datoteka već postoji, da li želite da je prepišete??
+# file.confirm-foreign-format=
 # file.import=
 file.export=Eksportuj
 # file.supported-formats=

--- a/common/resources/lang/messages_sv.properties
+++ b/common/resources/lang/messages_sv.properties
@@ -52,6 +52,7 @@ file.save-as=Spara som
 file.save.default-name=Utan titel
 file.save-changes-question=Sången har osparade ändringar.\nVill du spara ändringarna?
 file.overwrite-question=Denna fil finns redan. Vill du skriva över den?
+# file.confirm-foreign-format=
 file.import=Importera
 file.export=Exportera
 # file.supported-formats=

--- a/common/resources/lang/messages_uk.properties
+++ b/common/resources/lang/messages_uk.properties
@@ -52,6 +52,7 @@ file.save-as=Зберегти як
 file.save.default-name=Неназвана
 file.save-changes-question=Зміни до пісні не збережені.\nЗберегти?
 file.overwrite-question=Цей файл вже існує, перезаписати?
+# file.confirm-foreign-format=
 file.import=Імпортувати
 file.export=Експортувати
 # file.supported-formats=

--- a/common/resources/lang/messages_vi.properties
+++ b/common/resources/lang/messages_vi.properties
@@ -52,6 +52,7 @@ file.save-as=Lưu dạng
 file.save.default-name=Vô đề
 file.save-changes-question=Có nhiều thay đổi chưa lưu, bạn có muốn thoát mà không lưu chúng lại không?
 file.overwrite-question=Tập tin này có rồi, Bạn có muốn ghi đè lên nó không??
+# file.confirm-foreign-format=
 file.import=Nhập
 file.export=Xuất
 # file.supported-formats=

--- a/common/resources/lang/messages_zh.properties
+++ b/common/resources/lang/messages_zh.properties
@@ -52,6 +52,7 @@ file.save-as=另存为
 file.save.default-name=未命名
 file.save-changes-question=曲谱还未保存。\n是否要保存更改?
 file.overwrite-question=文件已存在！是否覆盖现有文件?
+# file.confirm-foreign-format=
 file.import=导入
 file.export=导出
 # file.supported-formats=

--- a/common/resources/lang/messages_zh_GB.properties
+++ b/common/resources/lang/messages_zh_GB.properties
@@ -52,6 +52,7 @@ file.save-as=另存为
 file.save.default-name=未命名
 file.save-changes-question=曲谱还未保存.\n希望保存所做修改吗?
 file.overwrite-question=文件已存在.是否覆盖现有文件?
+# file.confirm-foreign-format=
 file.import=导入
 file.export=导出
 # file.supported-formats=

--- a/common/resources/lang/messages_zh_TW.properties
+++ b/common/resources/lang/messages_zh_TW.properties
@@ -52,6 +52,7 @@ file.save-as=另存新檔
 file.save.default-name=未命名
 file.save-changes-question=這首曲子有尚未儲存的修改.\n你要儲存這些改變嗎?
 file.overwrite-question=檔案已存在，是否覆寫？
+# file.confirm-foreign-format=
 file.import=輸入
 file.export=輸出
 # file.supported-formats=

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/file/TGWriteFileAction.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/file/TGWriteFileAction.java
@@ -7,10 +7,19 @@ import java.io.FileOutputStream;
 import org.herac.tuxguitar.action.TGActionContext;
 import org.herac.tuxguitar.action.TGActionException;
 import org.herac.tuxguitar.action.TGActionManager;
+import org.herac.tuxguitar.app.TuxGuitar;
+import org.herac.tuxguitar.app.action.impl.view.TGOpenViewAction;
+import org.herac.tuxguitar.app.document.TGDocument;
+import org.herac.tuxguitar.app.document.TGDocumentListManager;
+import org.herac.tuxguitar.app.view.dialog.confirm.TGConfirmDialog;
+import org.herac.tuxguitar.app.view.dialog.confirm.TGConfirmDialogController;
+import org.herac.tuxguitar.document.TGDocumentContextAttributes;
 import org.herac.tuxguitar.editor.action.TGActionBase;
+import org.herac.tuxguitar.editor.action.TGActionProcessor;
 import org.herac.tuxguitar.editor.action.file.TGWriteSongAction;
 import org.herac.tuxguitar.io.base.TGFileFormatManager;
 import org.herac.tuxguitar.io.base.TGFileFormatUtils;
+import org.herac.tuxguitar.song.models.TGSong;
 import org.herac.tuxguitar.util.TGContext;
 
 public class TGWriteFileAction extends TGActionBase {
@@ -27,15 +36,47 @@ public class TGWriteFileAction extends TGActionBase {
 	
 	protected void processAction(TGActionContext context){
 		try {
+			TGFileFormatManager fileFormatManager = TGFileFormatManager.getInstance(getContext());
+			
 			String fileName = context.getAttribute(ATTRIBUTE_FILE_NAME);
 			
 			context.setAttribute(TGWriteSongAction.ATTRIBUTE_OUTPUT_STREAM, new FileOutputStream(new File(fileName)));
 			String formatCode = TGFileFormatUtils.getFileFormatCode(fileName);
 			context.setAttribute(TGWriteSongAction.ATTRIBUTE_FORMAT_CODE, formatCode);
-			context.setAttribute(ATTRIBUTE_FILE_EXPORT, !TGFileFormatManager.getInstance(getContext()).isCommonWriteFileFormat(formatCode));
+			context.setAttribute(ATTRIBUTE_FILE_EXPORT, !fileFormatManager.isCommonWriteFileFormat(formatCode));
 			
-			TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
-			tgActionManager.execute(TGWriteSongAction.NAME, context);
+			TGSong song = context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SONG);
+			TGDocument document = TGDocumentListManager.getInstance(getContext()).findDocument(song);
+			if (!fileFormatManager.isNativeWriteFileFormat(formatCode) && (!document.isForeignFormatConfirmed())) {
+				// foreign format, not explicitly accepted by user: issue a warning
+				TGActionProcessor tgActionProcessor = new TGActionProcessor(getContext(), TGOpenViewAction.NAME);
+				tgActionProcessor.setAttribute(TGOpenViewAction.ATTRIBUTE_CONTROLLER, new TGConfirmDialogController());
+				tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_MESSAGE, TuxGuitar.getProperty("file.confirm-foreign-format"));
+				tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_STYLE, TGConfirmDialog.BUTTON_YES | TGConfirmDialog.BUTTON_CANCEL);
+				tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_DEFAULT_BUTTON, TGConfirmDialog.BUTTON_CANCEL);
+				tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_RUNNABLE_YES, new Runnable() {
+					// user confirmed use of foreign format, store preference and save file
+					@Override
+					public void run() {
+						document.confirmForeignFormat();
+						TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
+						tgActionManager.execute(TGWriteSongAction.NAME, context);
+					}});
+				tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_RUNNABLE_CANCEL, new Runnable() {
+					// user canceled use of foreign format, open "save as"
+					@Override
+					public void run() {
+						TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
+						tgActionManager.execute(TGSaveAsFileAction.NAME, context);
+					}});
+				tgActionProcessor.process();
+			}
+			else {
+				// no warning required, write song
+				TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
+				tgActionManager.execute(TGWriteSongAction.NAME, context);
+			}
+			
 		} catch (FileNotFoundException e) {
 			throw new TGActionException(e);
 		}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/document/TGDocument.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/document/TGDocument.java
@@ -13,6 +13,7 @@ public class TGDocument {
 	private TGUndoableBuffer undoableBuffer;
 	private boolean unsaved;
 	private boolean unwanted;
+	private boolean foreignFormatConfirmed;
 	private TGBeat caretBeat;
 	private int caretString;
 	private TGBeat selectionStart;
@@ -92,6 +93,14 @@ public class TGDocument {
 
 	public void setSelectionEnd(TGBeat selectionEnd) {
 		this.selectionEnd = selectionEnd;
+	}
+	
+	public boolean isForeignFormatConfirmed() {
+		return foreignFormatConfirmed;
+	}
+	
+	public void confirmForeignFormat() {
+		this.foreignFormatConfirmed = true;
 	}
 
 }


### PR DESCRIPTION
@helge17: I would like your opinion about this PR before merging

The idea is to avoid silent data loss (#462), **but** it conflicts with your [recommendation](https://github.com/helge17/tuxguitar/discussions/41#discussioncomment-8572347) to issue a warning when we change file format.
We won't be able to issue 2 inconsistent warnings:
- warning, latest file format is not backward compatible, use with care
- warning, please use latest file format or you may loose data

In any case, these 2 sentences will be relevant, and it will be difficult for user to choose.

Possible way out: use new extension ".tg2" when we change file format, and rewrite warning message created in this PR.
