### PR TITLE
Missing colons in the Measure menu

### DIFF
--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/measure/TGMeasureCleanDialog.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/measure/TGMeasureCleanDialog.java
@@ -50,7 +50,7 @@ public class TGMeasureCleanDialog {
 		int measureCount = song.countMeasureHeaders();
 		
 		UILabel fromLabel = uiFactory.createLabel(range);
-		fromLabel.setText(TuxGuitar.getProperty("edit.from"));
+		fromLabel.setText(TuxGuitar.getProperty("edit.from") + ":");
 		rangeLayout.set(fromLabel, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, false, true);
 		
 		int from;
@@ -70,7 +70,7 @@ public class TGMeasureCleanDialog {
 		rangeLayout.set(fromSpinner, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 180f, null, null);
 		
 		UILabel toLabel = uiFactory.createLabel(range);
-		toLabel.setText(TuxGuitar.getProperty("edit.to"));
+		toLabel.setText(TuxGuitar.getProperty("edit.to") + ":");
 		rangeLayout.set(toLabel, 2, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, false, true);
 		
 		final UISpinner toSpinner = uiFactory.createSpinner(range);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/measure/TGMeasurePasteDialog.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/measure/TGMeasurePasteDialog.java
@@ -38,7 +38,7 @@ public class TGMeasurePasteDialog {
 		dialogLayout.set(group, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
 		
 		UILabel countLabel = uiFactory.createLabel(group);
-		countLabel.setText(TuxGuitar.getProperty("edit.paste.count"));
+		countLabel.setText(TuxGuitar.getProperty("edit.paste.count") + ":");
 		groupLayout.set(countLabel, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, false, true);
 		
 		final UISpinner countSpinner = uiFactory.createSpinner(group);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/measure/TGMeasureRemoveDialog.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/measure/TGMeasureRemoveDialog.java
@@ -60,7 +60,7 @@ public class TGMeasureRemoveDialog {
 		}
 		
 		UILabel fromLabel = uiFactory.createLabel(range);
-		fromLabel.setText(TuxGuitar.getProperty("edit.from"));
+		fromLabel.setText(TuxGuitar.getProperty("edit.from") + ":");
 		rangeLayout.set(fromLabel, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, false, true);
 		
 		final UISpinner fromSpinner = uiFactory.createSpinner(range);
@@ -70,7 +70,7 @@ public class TGMeasureRemoveDialog {
 		rangeLayout.set(fromSpinner, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 180f, null, null);
 		
 		UILabel toLabel = uiFactory.createLabel(range);
-		toLabel.setText(TuxGuitar.getProperty("edit.to"));
+		toLabel.setText(TuxGuitar.getProperty("edit.to") + ":");
 		rangeLayout.set(toLabel, 2, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, false, true);
 		
 		final UISpinner toSpinner = uiFactory.createSpinner(range);


### PR DESCRIPTION
This fix added a missing colon after "Paste Count" in the menu: Measure -> Paste Measure, like in the menu: Measure -> Add Measure -> "Add Count:".

Greetings,
Gootector