### PR TITLE
move ".tef" from File/Import to File/Open

### DIFF
--- a/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/TESongReaderPlugin.java
+++ b/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/TESongReaderPlugin.java
@@ -11,7 +11,7 @@ public class TESongReaderPlugin extends TGSongReaderPlugin {
 	public static final String MODULE_ID = "tuxguitar-tef";
 	
 	public TESongReaderPlugin() {
-		super(false);
+		super(true);
 	}
 	
 	public String getModuleId(){

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/file/TGWriteFileAction.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/action/impl/file/TGWriteFileAction.java
@@ -32,7 +32,7 @@ public class TGWriteFileAction extends TGActionBase {
 			context.setAttribute(TGWriteSongAction.ATTRIBUTE_OUTPUT_STREAM, new FileOutputStream(new File(fileName)));
 			String formatCode = TGFileFormatUtils.getFileFormatCode(fileName);
 			context.setAttribute(TGWriteSongAction.ATTRIBUTE_FORMAT_CODE, formatCode);
-			context.setAttribute(ATTRIBUTE_FILE_EXPORT, !TGFileFormatManager.getInstance(getContext()).isNativeWriteFileFormat(formatCode));
+			context.setAttribute(ATTRIBUTE_FILE_EXPORT, !TGFileFormatManager.getInstance(getContext()).isNativeFileFormat(formatCode));
 			
 			TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
 			tgActionManager.execute(TGWriteSongAction.NAME, context);


### PR DESCRIPTION
see [this comment](https://github.com/helge17/tuxguitar/pull/481#issuecomment-2262278439) in PR481

This PR moves ".tef" files from File/Import to File/Open menu. I am clearly hesitating for midi files.
Looking at all file formats TuxGuitar can read: TablEdit, PowerTab, GuitarPro and TuxGuitar all produce *tablature* files. Basically, the same *nature* of data encoded differently. For these, I think File/Open makes sense.
Midi files contain data of a fundamentally different *nature*. The imported data is significantly transformed when TG opens a midi file. So I think it makes sense to keep it in File/Import menu. It makes more clear to users the data is "imported", hence "modified".

By the way, I have to fix something: following 340f89993c8a9206ff4030c87ed4fc37d1faefa3, old TG file formats don't appear any more in File/Open (as expected), but they are now visible in File/Import (unexpected).

User doc also needs to be updated