### PR TITLE
Re-introduce TGDivisionType.NORMAL as an alias for DIVISION_TYPES[0]

### DIFF
--- a/common/TuxGuitar-gtp/src/org/herac/tuxguitar/io/gtp/GP3OutputStream.java
+++ b/common/TuxGuitar-gtp/src/org/herac/tuxguitar/io/gtp/GP3OutputStream.java
@@ -217,7 +217,7 @@ public class GP3OutputStream extends GTPOutputStream {
 		if (duration.isDotted() || duration.isDoubleDotted() ) {
 			flags |= 0x01;
 		}
-		if (!duration.getDivision().isEqual(TGDivisionType.DIVISION_TYPES[0])) {
+		if (!duration.getDivision().isEqual(TGDivisionType.NORMAL)) {
 			flags |= 0x20;
 		}
 		if(beat.isTextBeat()){

--- a/common/TuxGuitar-gtp/src/org/herac/tuxguitar/io/gtp/GP4OutputStream.java
+++ b/common/TuxGuitar-gtp/src/org/herac/tuxguitar/io/gtp/GP4OutputStream.java
@@ -290,7 +290,7 @@ public class GP4OutputStream extends GTPOutputStream{
 		else if (effect.isTremoloBar() || effect.isTapping() || effect.isSlapping() || effect.isPopping() || effect.isFadeIn()) {
 			flags |= 0x08;
 		}
-		if (!duration.getDivision().isEqual(TGDivisionType.DIVISION_TYPES[0])) {
+		if (!duration.getDivision().isEqual(TGDivisionType.NORMAL)) {
 			flags |= 0x20;
 		}
 		if (changeTempo) {

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/io/tg/TGSongReaderImpl.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/io/tg/TGSongReaderImpl.java
@@ -484,7 +484,7 @@ public class TGSongReaderImpl extends TGStream implements TGSongReader {
 			readDivisionType(duration.getDivision());
 		}
 		else{
-			duration.getDivision().copyFrom(TGDivisionType.DIVISION_TYPES[0]);
+			duration.getDivision().copyFrom(TGDivisionType.NORMAL);
 		}
 	}
 	


### PR DESCRIPTION
for better code readability

see 372283d391bf910e9ac04120a94ea9744108b6e8