### PR TITLE
revert 27502a6ecd264637887ecc4df20ea0ab89dbea0e (continued)

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/io/tg/TGStream.java
+++ b/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/io/tg/TGStream.java
@@ -15,6 +15,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.io.IOUtils;
 import org.herac.tuxguitar.io.base.TGFileFormat;
 import org.herac.tuxguitar.io.base.TGFileFormatException;
 import org.herac.tuxguitar.song.models.TGMeasure;
@@ -333,11 +334,7 @@ public class TGStream {
 				if (zipEntry.getName().equals(fileNames[i])) {
 					ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 					BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream);
-					byte[] bytes = new byte[1024];
-					int len;
-					while ((len = zipInputStream.read(bytes)) >= 0) {
-						bufferedOutputStream.write(bytes, 0, len);
-					}
+					IOUtils.copy(zipInputStream, bufferedOutputStream);
 					bufferedOutputStream.flush();
 					byte buffer[] = outputStream.toByteArray();
 					streams[i] = new ByteArrayInputStream(buffer);


### PR DESCRIPTION
modification was introduced to bypass an Android build issue no more needed after android dependencies update
see discussion in 462f2224401f7eedb5e23bac1fef1526af234080