### PR TITLE
fix one scrolling issue

### DIFF
--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
@@ -199,6 +199,7 @@ public class TGControl {
 			}
 		} else {
 			this.hScroll.setVisible(false);
+			this.scrollX = 0;
 		}
 		int vMax = Math.max(Math.round(this.height - bounds.getHeight()), 0);
 		int vThumb = Math.round(bounds.getHeight());
@@ -212,6 +213,7 @@ public class TGControl {
 			}
 		} else {
 			this.vScroll.setVisible(false);
+			this.scrollY = 0;
 		}
 	}
 

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Tablature.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/Tablature.java
@@ -74,8 +74,10 @@ public class Tablature implements TGController {
 	}
 	
 	public void updateMeasures(List<Integer> numbers){
-		this.getViewLayout().updateMeasureNumbers(numbers);
-		this.getCaret().update();
+		if (!numbers.isEmpty()) {
+			this.getViewLayout().updateMeasureNumbers(numbers);
+			this.getCaret().update();
+		}
 		this.disposeUnregisteredResources.process();
 	}
 	


### PR DESCRIPTION
this one was pretty tricky (#534)
(bug present since at least TG 1.5.6, not tested before)

test scenario to reproduce issue:
- multitrack song, edition mode active
- click in track1
- scroll down several tracks with scrollbar, until caret is no more visible
- move mouse into tab => this scrolls back to track1 unexpectedly

root cause:
TGMouseMoveAction and/or TGMouseExitAction are triggered at end of test scenario (because edition mode active).
After action is processed, TGUpdateListener.processPostExecution is called, this triggers an update of cached buffer: TGUpdateBuffer.apply, then it calls TGUpdateBuffer.applyUpdateMeasures
at this stage, the list of measures to update is empty, because it was cleared by TGUpdateListener.processPreExecution, and no measure changed since.
This ends up in Tablature.updateMeasures, with an empty list of measures to update.
This method called Caret.update, provoking a scroll back to track1, where caret is since beginning of test scenario.

Fix:
- don't update caret in Tablature.updateMeasures if list of measures to update is empty
unexpected side effect: linear layout, open a song with many tracks, click in last one, then close song.
It comes back to "Untitled.tg", but does not scroll back to track1. So nothing is visible on the screen.
So:
- TGControl: when cannot scroll (scrollbar hidden), force scroll to zero

Not 100% sure this will not have any side effect...