### PR TITLE
fix paste selection issue

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGStoredBeatList.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/helpers/TGStoredBeatList.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 public class TGStoredBeatList {
 	private List<TGBeat> beats;
-	private long length = 0;
 	private List<Integer> stringValues;
 	private boolean isPercussionTrack;
 	
@@ -23,7 +22,6 @@ public class TGStoredBeatList {
 			beat = beat.clone(factory);
 			beat.setStart(beat.getStart() - first);
 			beat.setMeasure(null);
-			this.length += beat.getVoice(0).getDuration().getTime();
 			this.beats.add(beat);
 		}
 		this.stringValues = new ArrayList<Integer>();
@@ -37,9 +35,6 @@ public class TGStoredBeatList {
 	
 	public List<TGBeat> getBeats() {
 		return beats;
-	}
-	public long getLength() {
-		return length;
 	}
 	
 	public List<Integer> getStringValues() {

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/managers/TGMeasureManager.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/managers/TGMeasureManager.java
@@ -2095,4 +2095,21 @@ public class TGMeasureManager {
 		}
 		return value;
 	}
+	
+	public void removeOverlappingRestBeats(TGMeasure measure) {
+		List<TGBeat> beatsToRemove = new ArrayList<TGBeat>();
+		for (TGBeat refBeat : measure.getBeats()) {
+			for (TGBeat beat : measure.getBeats()) {
+				if (beat.isRestBeat() && !refBeat.isRestBeat() && (!beatsToRemove.contains(beat)) 
+					&& (beat.getEnd() > refBeat.getStart()) && (beat.getStart() < refBeat.getEnd())) {
+						beatsToRemove.add(beat);
+				}
+			}
+		}
+		while (beatsToRemove.size()>0) {
+			this.removeBeat(beatsToRemove.get(0));
+			beatsToRemove.remove(0);
+		}
+
+	}
 }

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGBeat.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/song/models/TGBeat.java
@@ -115,19 +115,55 @@ public abstract class TGBeat {
 		return true;
 	}
 	
+	// duration (time) of shortest voice
+	public long getShortestVoiceDurationTime() {
+		long time = -1;
+		for (int v=0; v<this.countVoices(); v++) {
+			TGVoice voice = this.getVoice(v);
+			if (!voice.isEmpty()) {
+				if ((time<0) || (voice.getDuration().getTime()<time)) {
+					time = voice.getDuration().getTime();
+				}
+			}
+		}
+		return time;
+	}
+	
+	// duration (time) of longest voice
+	public long getDurationTime() {
+		long time = 0;
+		for (int v=0; v<this.countVoices(); v++) {
+			TGVoice voice = this.getVoice(v);
+			if (!voice.isEmpty()) {
+				if (voice.getDuration().getTime() > time) {
+					time = voice.getDuration().getTime();
+				}
+			}
+		}
+		return time;
+	}
+	
+	public long getEnd() {
+		return this.getStart() + this.getDurationTime();
+	}
+	
+	public void copyFrom(TGBeat beat, TGFactory factory) {
+		this.setStart(beat.getStart());
+		this.getStroke().copyFrom(beat.getStroke());
+		for( int i = 0 ; i < beat.voices.length ; i ++ ){
+			this.setVoice(i, beat.voices[i].clone(factory));
+		}
+		if(beat.chord != null){
+			this.setChord( beat.chord.clone(factory));
+		}
+		if(beat.text != null){
+			this.setText( beat.text.clone(factory));
+		}
+	}
+	
 	public TGBeat clone(TGFactory factory){
 		TGBeat beat = factory.newBeat();
-		beat.setStart(getStart());
-		beat.getStroke().copyFrom(getStroke());
-		for( int i = 0 ; i < this.voices.length ; i ++ ){
-			beat.setVoice(i, this.voices[i].clone(factory));
-		}
-		if(this.chord != null){
-			beat.setChord( this.chord.clone(factory));
-		}
-		if(this.text != null){
-			beat.setText( this.text.clone(factory));
-		}
+		beat.copyFrom(this, factory);
 		return beat;
 	}
 }


### PR DESCRIPTION
see #545

preceding implementation of "paste selection" was imported from 2.0beta fork, and was too simplistic:
- remove beats from song
- insert beats to paste

Several issues:
- did not consider multiple voices, this led to invalid measures in some cases
- when removing beats, everything is shifted left, this can modify following measures in the whole song, typically splitting long notes in 2 (over measures boundaries)
  quite painful: damaged measures may be very far, even off-screen, so the consequence of this bug may be seen a long time after it occurred

Note that this new implementation is much more complex
Some bugs in corner cases are still possible. Anyway it this occurs it should be local