### PR TITLE
Restore scrollbars when playing, performance optimization

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayout.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/TGLayout.java
@@ -279,6 +279,8 @@ public abstract class TGLayout {
 	public void paintPlayMode(UIPainter painter, TGMeasureImpl measure, TGBeatImpl beat){
 		this.playModeEnabled = true;
 		
+		measure.paintMeasure(this, painter);
+		
 		//pinto el pulso
 		if( beat != null ){
 			beat.paint(this,painter,measure.getPosX()  + measure.getHeaderImpl().getLeftSpacing(this),


### PR DESCRIPTION
To sum up, in SWT configuration:
- on Linux, scrollbars are semi-transparent, overlap the canvas content, and appear/disappear dynamically
- on Windows, scrollbars are solid and occupy a fixed area in canvas

Dynamic appearance/disappearance of tablature scrollbars created a serious performance issue on Linux following an SWT update. It was fixed by hiding scrollbars when playing (20ae8bee2671e52678c0372bc076487eb4b3f95f).
This fix created another issue on Windows: when player starts or stops, hiding/showing scrollbars changes the size of the available area to paint tablature. This provokes an update of layout, moving measures around in some cases.

This commit targets a solution compatible with both OSes:
- restore scrollbar(s) when playing, to fix Windows issue
- aggressive performance optimization, to fix Linux issue: reduce what is repainted when a tablature repaint event occurs if player is playing

references:
- Linux issue: https://github.com/helge17/tuxguitar/issues/403
- Windows issue: https://github.com/helge17/tuxguitar/issues/554