### PR TITLE
fixed scrolling issues (again)

### DIFF
--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/component/tab/TGControl.java
@@ -156,10 +156,18 @@ public class TGControl {
 					|| (canvasWidth!=this.lastCanvasWidth) || (canvasHeight!=this.lastCanvasHeight)
 					|| (scale != this.lastScale) || (this.tablature.getViewLayout().getStyle() != this.lastLayoutStyle)
 					|| (this.tablature.getViewLayout().getMode() != this.lastLayoutMode)) {
+				int lastWidth = this.width;
+				int lastHeight = this.height;
 				this.tablature.paintTablature(painter, this.canvas.getBounds(), -this.scrollX, -this.scrollY);
 				this.width = Math.round(this.tablature.getViewLayout().getWidth());
 				this.height = Math.round(this.tablature.getViewLayout().getHeight());
 				this.lastPaintedPlayedMeasure = playedMeasure;
+				// if measure position changed AND scale or size changed, need to reconsider measure position (can only be done *after* tablature is updated)
+				if (moved && (scale != this.lastScale) || (lastWidth != this.width) || (lastHeight != this.height)) {
+					// move to caret measure and redraw a second time
+					this.moveTo(this.tablature.getCaret().getMeasure());
+					this.tablature.paintTablature(painter, this.canvas.getBounds(), -this.scrollX, -this.scrollY);
+				}
 			}
 			
 			// highlight played beat


### PR DESCRIPTION
- when zooming in/out (#568)
- when changing track (click in track table)

This restores part of behavior implemented before first perf optimization (20ae8bee2671e52678c0372bc076487eb4b3f95f): in some cases, tablature is redrawn twice (only when not playing).
Because dimensions are re-computed when redrawing. In some cases, after redrawing tab shall scroll to display caret. So it needs to be redrawn. This could be probably optimized, by separating computation from effective display.