### PR TITLE
play grace notes for percussion tracks (flams)

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/player/base/MidiSequenceParser.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/player/base/MidiSequenceParser.java
@@ -191,8 +191,8 @@ public class MidiSequenceParser {
 						addFadeIn(sh,track.getNumber(), start, duration, tgChannel.getVolume(), channel);
 					}
 					//---Grace---
-					if(note.getEffect().isGrace() && !percussionChannel ){
-						bendMode = true;
+					if(note.getEffect().isGrace()) {
+						bendMode = !percussionChannel;
 						int graceKey = track.getOffset() + note.getEffect().getGrace().getFret() + ((TGString)track.getStrings().get(note.getString() - 1)).getValue();
 						int graceLength = note.getEffect().getGrace().getDurationTime();
 						int graceVelocity = note.getEffect().getGrace().getDynamic();


### PR DESCRIPTION
see #573 
After some more tests it seems OK. And for non-percussion tracks the code is exactly equivalent to previous behavior. Risk of regression is evaluated low (subjectively) 