### PR TITLE
duration of grace note, cleanup and fix

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/song/models/effects/TGEffectGrace.java
+++ b/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/song/models/effects/TGEffectGrace.java
@@ -14,10 +14,10 @@ public abstract class TGEffectGrace {
 	
 	public static final int TRANSITION_HAMMER = 3;
 
+	// grace duration: do NOT change these values
+	// this encoding is implicitly used by several file formats, including external (GP)
 	public static final int DURATION_SIXTY_FOURTH = 1;
-
 	public static final int DURATION_THIRTY_SECOND = 2;
-
 	public static final int DURATION_SIXTEENTH = 3;
 	
 	private int fret;
@@ -85,8 +85,14 @@ public abstract class TGEffectGrace {
 	}
 	
 	public int getDurationTime(){
-		//return (int)(((float)TGDuration.QUARTER_TIME / 16.00 ) * (float)getDuration());
-		return (int)((TGDuration.QUARTER_TIME / 16.00 ) * getDuration());
+		if (getDuration() == DURATION_SIXTEENTH) {
+			return (int)(TGDuration.QUARTER_TIME / 4);
+		}
+		if (getDuration() == DURATION_THIRTY_SECOND) {
+			return (int)(TGDuration.QUARTER_TIME / 8);
+		}
+		// default: 64th
+		return (int)(TGDuration.QUARTER_TIME / 16);
 	}
 	
 	public TGEffectGrace clone(TGFactory factory){

--- a/common/TuxGuitar-lilypond/src/org/herac/tuxguitar/io/lilypond/LilypondOutputStream.java
+++ b/common/TuxGuitar-lilypond/src/org/herac/tuxguitar/io/lilypond/LilypondOutputStream.java
@@ -725,11 +725,11 @@ public class LilypondOutputStream {
 				TGString string = measure.getTrack().getString(note.getString());
 				TGEffectGrace grace = note.getEffect().getGrace();
 
-				if( duration < TGDuration.SIXTY_FOURTH && grace.getDuration() == 1 ){
+				if( duration < TGDuration.SIXTY_FOURTH && grace.getDuration() == TGEffectGrace.DURATION_SIXTY_FOURTH ){
 					duration = TGDuration.SIXTY_FOURTH;
-				}else if( duration < TGDuration.THIRTY_SECOND && grace.getDuration() == 2 ){
+				}else if( duration < TGDuration.THIRTY_SECOND && grace.getDuration() == TGEffectGrace.DURATION_THIRTY_SECOND ){
 					duration = TGDuration.THIRTY_SECOND;
-				}else if( duration < TGDuration.SIXTEENTH && grace.getDuration() == 3 ){
+				}else if( duration < TGDuration.SIXTEENTH && grace.getDuration() == TGEffectGrace.DURATION_SIXTEENTH ){
 					duration = TGDuration.SIXTEENTH;
 				}
 				if( i > 0 ){


### PR DESCRIPTION
cleanup: follow-up of 99aaa9c36889ea85a4875bdb26c39d19d5b47145

fix: computed durationTime was erroneous for 16th
QUARTER_TIME/16*getDuration() returned 3*QUARTER_TIME/16 instead of 4*QUARTER_TIME/16==QUARTER_TIME/4
(very small difference though...)