### PR TITLE
Add song details to exported PDF & SVG file

### DIFF
--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
@@ -16,6 +16,7 @@ import org.herac.tuxguitar.ui.resource.UIFont;
 import org.herac.tuxguitar.ui.resource.UIPainter;
 import org.herac.tuxguitar.ui.resource.UIRectangle;
 import org.herac.tuxguitar.ui.resource.UIResourceFactory;
+import org.herac.tuxguitar.util.TGMessagesManager;
 
 public class TGPrintLayout extends TGLayout {
 	
@@ -135,70 +136,96 @@ public class TGPrintLayout extends TGLayout {
 			if( songName != null && songName.length() > 0 ){
 				painter.setFont(getSongNameFont());
 				painter.drawString(songName,(x + getCenter(painter,songName)), (fmTopLine + y));
-				
 				headerOffset += (20.0f * getScale());
 			}
 			
-			if( artistName != null && artistName.length() > 0 ) {
+			if (artistName != null && artistName.length() > 0) {
+
 				painter.setFont(getArtistFont());
-				painter.drawString(artistName,(x + getCenter(painter, artistName)), (fmTopLine + y + Math.round(headerOffset)));
-				
-				headerOffset += (10.0f * getScale());
+				painter.drawString(
+					artistName,
+					x + getCenter(painter, artistName),
+					fmTopLine + y + Math.round(headerOffset)
+				);
+				headerOffset += 10.0f * getScale();
 			}
 
-			if( (albumName != null && albumName.length() > 0) || 
-					(releaseYear != null && releaseYear.length() > 0) ) {
+			if ((albumName != null && albumName.length() > 0) || 
+				(releaseYear != null && releaseYear.length() > 0)) {
+
 				String albumNameReleaseYear = "";
-				
-				if( albumName != null && albumName.length() > 0)
-					albumNameReleaseYear += "Recorded on " + albumName + " ";
-				
-				if( releaseYear != null && releaseYear.length() > 0)
+				if( albumName != null && albumName.length() > 0 )
+					albumNameReleaseYear += TGMessagesManager.getProperty("composition.album") + " " + albumName + " ";
+				if( releaseYear != null && releaseYear.length() > 0 )
 					albumNameReleaseYear += "(" + releaseYear + ")";
 
 				painter.setFont(getAlbumNameYearFont());
-				painter.drawString(albumNameReleaseYear, (x + getCenter(painter, albumNameReleaseYear)), (fmTopLine + y + Math.round(headerOffset)));
-				
-				headerOffset += (20.0f * getScale());
+				painter.drawString(
+					albumNameReleaseYear,
+					x + getCenter(painter, albumNameReleaseYear),
+					fmTopLine + y + Math.round(headerOffset)
+				);
+				headerOffset += 20.0f * getScale();
 			}
 			
-			if( trackName != null && trackName.length() > 0 ) {
-				trackName = "(track " + trackName + ")";
+			if (trackName != null && trackName.length() > 0) {
+
+				trackName = TGMessagesManager.getProperty("track") + " " + trackName;
 				painter.setFont(getTrackNameFont());
-				painter.drawString(trackName,(x + getCenter(painter,trackName)),(fmTopLine + y + Math.round(headerOffset)));
-				
-				headerOffset += (20.0f * getScale());
+				painter.drawString(
+					trackName,
+					x + getCenter(painter,trackName),
+					fmTopLine + y + Math.round(headerOffset)
+				);
+				headerOffset += 20.0f * getScale();
 			}
 			
-			if( songAuthor != null && songAuthor.length() > 0 ){
+			if (songAuthor != null && songAuthor.length() > 0) {
+
+				songAuthor = TGMessagesManager.getProperty("composition.author") + " " + songAuthor;
 				painter.setFont(getSongAuthorFont());
-				painter.drawString(songAuthor,(x + getRight(painter, songAuthor)),(fmTopLine + y + Math.round(headerOffset)));
-				
-				headerOffset += (10.0f * getScale());
+				painter.drawString(
+					songAuthor,
+					x + getRight(painter, songAuthor),
+					fmTopLine + y + Math.round(headerOffset)
+				);
+				headerOffset += 10.0f * getScale();
 			}
 
-			if( copyright != null && copyright.length() > 0) {
-				copyright = "Copyrighted by " + copyright;
+			if (copyright != null && copyright.length() > 0) {
+
+				copyright = TGMessagesManager.getProperty("composition.copyright") + " " + copyright;
 				painter.setFont(getSongAuthorFont());
-				painter.drawString(copyright, (x + getRight(painter, copyright)),(fmTopLine + y + Math.round(headerOffset)));
-				
-				headerOffset += (10.0f * getScale());
+				painter.drawString(
+					copyright,
+					x + getRight(painter, copyright),
+					fmTopLine + y + Math.round(headerOffset)
+				);
+				headerOffset += 10.0f * getScale();
 			}
 			
-			if( transcriber != null && transcriber.length() > 0) {
-				transcriber = "Transcribed by " + transcriber;
+			if (transcriber != null && transcriber.length() > 0) {
+
+				transcriber = TGMessagesManager.getProperty("composition.transcriber") + " " + transcriber;
 				painter.setFont(getSongAuthorFont());
-				painter.drawString(transcriber, (x + getRight(painter, transcriber)),(fmTopLine + y + Math.round(headerOffset)));
-				
-				headerOffset += (10.0f * getScale());
+				painter.drawString(
+					transcriber,
+					x + getRight(painter, transcriber),
+					fmTopLine + y + Math.round(headerOffset)
+				);
+				headerOffset += 10.0f * getScale();
 			}
 
-			if( tabCreator != null && tabCreator.length() > 0) {
-				tabCreator = "Created by " + tabCreator;
+			if( tabCreator != null && tabCreator.length() > 0 ){
+
+				tabCreator = TGMessagesManager.getProperty("composition.writer") + " " + tabCreator;
 				painter.setFont(getSongAuthorFont());
-				painter.drawString(tabCreator, (x + getRight(painter, tabCreator)),(fmTopLine + y + Math.round(headerOffset)));
-				
-				headerOffset += (20.0f * getScale());
+				painter.drawString(
+					tabCreator,
+					x + getRight(painter, tabCreator),
+					fmTopLine + y + Math.round(headerOffset)
+				);
+				headerOffset += 20.0f * getScale();
 			}
 		}
 		return headerOffset;
@@ -372,8 +399,15 @@ public class TGPrintLayout extends TGLayout {
 	
 	public UIFont getSongAuthorFont() {
 		UIResourceFactory factory = this.getComponent().getResourceFactory();
-		if( factory != null && ( this.songAuthorFont == null || this.songAuthorFont.isDisposed() ) ){
-			this.songAuthorFont = factory.createFont(this.getResources().getDefaultFont().getName(), (8.0f * getFontScale()), true, false);
+
+		if( factory != null && 
+			(this.songAuthorFont == null || this.songAuthorFont.isDisposed()) ){
+
+			this.songAuthorFont = factory.createFont(
+				this.getResources().getDefaultFont().getName(), 
+				8.0f * getFontScale(),
+				true, false
+			);
 		}
 		return this.songAuthorFont;
 	}
@@ -389,8 +423,14 @@ public class TGPrintLayout extends TGLayout {
 	public UIFont getArtistFont() {
 		UIResourceFactory factory = this.getComponent().getResourceFactory();
 		
-		if( factory != null && ( this.artistFont == null || this.artistFont.isDisposed() ) ) {
-			this.artistFont = factory.createFont(this.getResources().getDefaultFont().getName(), (12.0f * getFontScale()), true, false);
+		if( factory != null && 
+			(this.artistFont == null || this.artistFont.isDisposed()) ){
+
+			this.artistFont = factory.createFont(
+				this.getResources().getDefaultFont().getName(),
+				12.0f * getFontScale(),
+				true, false
+			);
 		}
 		
 		return this.artistFont;
@@ -399,8 +439,14 @@ public class TGPrintLayout extends TGLayout {
 	public UIFont getAlbumNameYearFont() {
 		UIResourceFactory factory = this.getComponent().getResourceFactory();
 		
-		if( factory != null && ( this.albumNameYearFont == null || this.albumNameYearFont.isDisposed() ) ) {
-			this.albumNameYearFont = factory.createFont(this.getResources().getDefaultFont().getName(), (10.0f * getFontScale()), true, false);
+		if( factory != null && 
+			(this.albumNameYearFont == null || this.albumNameYearFont.isDisposed()) ){
+
+			this.albumNameYearFont = factory.createFont(
+				this.getResources().getDefaultFont().getName(),
+				10.0f * getFontScale(),
+				true, false
+			);
 		}
 		
 		return this.albumNameYearFont;
@@ -420,7 +466,9 @@ public class TGPrintLayout extends TGLayout {
 		if( this.artistFont != null && !this.artistFont.isDisposed() ){
 			this.artistFont.dispose();
 		}
-		if( this.albumNameYearFont != null && !this.albumNameYearFont.isDisposed() ){
+		if( this.albumNameYearFont != null && 
+			!this.albumNameYearFont.isDisposed() ){
+
 			this.albumNameYearFont.dispose();
 		}
 	}

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
@@ -147,7 +147,7 @@ public class TGPrintLayout extends TGLayout {
 					x + getCenter(painter, artistName),
 					fmTopLine + y + Math.round(headerOffset)
 				);
-				headerOffset += 10.0f * getScale();
+				headerOffset += 20.0f * getScale();
 			}
 
 			if ((albumName != null && albumName.length() > 0) || 

--- a/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
+++ b/common/TuxGuitar-lib/src/org/herac/tuxguitar/graphics/control/print/TGPrintLayout.java
@@ -26,6 +26,8 @@ public class TGPrintLayout extends TGLayout {
 	private UIFont songNameFont;
 	private UIFont trackNameFont;
 	private UIFont songAuthorFont;
+	private UIFont artistFont;
+	private UIFont albumNameYearFont;
 	
 	public TGPrintLayout(TGController controller, TGPrintSettings settings){
 		super(controller, settings.getStyle());
@@ -122,17 +124,46 @@ public class TGPrintLayout extends TGLayout {
 			float fmTopLine = painter.getFMTopLine();
 			String songName = getSong().getName();
 			String songAuthor = getSong().getAuthor();
+			String artistName = getSong().getArtist();
+			String albumName = getSong().getAlbum();
+			String releaseYear = getSong().getDate();
+			String copyright = getSong().getCopyright();
+			String transcriber = getSong().getTranscriber();
+			String tabCreator = getSong().getWriter();
 			String trackName = track.getName();
 			
 			if( songName != null && songName.length() > 0 ){
 				painter.setFont(getSongNameFont());
 				painter.drawString(songName,(x + getCenter(painter,songName)), (fmTopLine + y));
 				
-				headerOffset += (30.0f * getScale());
+				headerOffset += (20.0f * getScale());
+			}
+			
+			if( artistName != null && artistName.length() > 0 ) {
+				painter.setFont(getArtistFont());
+				painter.drawString(artistName,(x + getCenter(painter, artistName)), (fmTopLine + y + Math.round(headerOffset)));
+				
+				headerOffset += (10.0f * getScale());
+			}
+
+			if( (albumName != null && albumName.length() > 0) || 
+					(releaseYear != null && releaseYear.length() > 0) ) {
+				String albumNameReleaseYear = "";
+				
+				if( albumName != null && albumName.length() > 0)
+					albumNameReleaseYear += "Recorded on " + albumName + " ";
+				
+				if( releaseYear != null && releaseYear.length() > 0)
+					albumNameReleaseYear += "(" + releaseYear + ")";
+
+				painter.setFont(getAlbumNameYearFont());
+				painter.drawString(albumNameReleaseYear, (x + getCenter(painter, albumNameReleaseYear)), (fmTopLine + y + Math.round(headerOffset)));
+				
+				headerOffset += (20.0f * getScale());
 			}
 			
 			if( trackName != null && trackName.length() > 0 ) {
-				trackName = "(" + trackName + ")";
+				trackName = "(track " + trackName + ")";
 				painter.setFont(getTrackNameFont());
 				painter.drawString(trackName,(x + getCenter(painter,trackName)),(fmTopLine + y + Math.round(headerOffset)));
 				
@@ -141,7 +172,31 @@ public class TGPrintLayout extends TGLayout {
 			
 			if( songAuthor != null && songAuthor.length() > 0 ){
 				painter.setFont(getSongAuthorFont());
-				painter.drawString(songAuthor,(x + getRight(painter,songAuthor)),(fmTopLine + y + Math.round(headerOffset)));
+				painter.drawString(songAuthor,(x + getRight(painter, songAuthor)),(fmTopLine + y + Math.round(headerOffset)));
+				
+				headerOffset += (10.0f * getScale());
+			}
+
+			if( copyright != null && copyright.length() > 0) {
+				copyright = "Copyrighted by " + copyright;
+				painter.setFont(getSongAuthorFont());
+				painter.drawString(copyright, (x + getRight(painter, copyright)),(fmTopLine + y + Math.round(headerOffset)));
+				
+				headerOffset += (10.0f * getScale());
+			}
+			
+			if( transcriber != null && transcriber.length() > 0) {
+				transcriber = "Transcribed by " + transcriber;
+				painter.setFont(getSongAuthorFont());
+				painter.drawString(transcriber, (x + getRight(painter, transcriber)),(fmTopLine + y + Math.round(headerOffset)));
+				
+				headerOffset += (10.0f * getScale());
+			}
+
+			if( tabCreator != null && tabCreator.length() > 0) {
+				tabCreator = "Created by " + tabCreator;
+				painter.setFont(getSongAuthorFont());
+				painter.drawString(tabCreator, (x + getRight(painter, tabCreator)),(fmTopLine + y + Math.round(headerOffset)));
 				
 				headerOffset += (20.0f * getScale());
 			}
@@ -331,6 +386,26 @@ public class TGPrintLayout extends TGLayout {
 		return this.trackNameFont;
 	}
 	
+	public UIFont getArtistFont() {
+		UIResourceFactory factory = this.getComponent().getResourceFactory();
+		
+		if( factory != null && ( this.artistFont == null || this.artistFont.isDisposed() ) ) {
+			this.artistFont = factory.createFont(this.getResources().getDefaultFont().getName(), (12.0f * getFontScale()), true, false);
+		}
+		
+		return this.artistFont;
+	}
+
+	public UIFont getAlbumNameYearFont() {
+		UIResourceFactory factory = this.getComponent().getResourceFactory();
+		
+		if( factory != null && ( this.albumNameYearFont == null || this.albumNameYearFont.isDisposed() ) ) {
+			this.albumNameYearFont = factory.createFont(this.getResources().getDefaultFont().getName(), (10.0f * getFontScale()), true, false);
+		}
+		
+		return this.albumNameYearFont;
+	}
+	
 	public void disposeLayout(){
 		super.disposeLayout();
 		if( this.songNameFont != null && !this.songNameFont.isDisposed() ){
@@ -341,6 +416,12 @@ public class TGPrintLayout extends TGLayout {
 		}
 		if( this.trackNameFont != null && !this.trackNameFont.isDisposed() ){
 			this.trackNameFont.dispose();
+		}
+		if( this.artistFont != null && !this.artistFont.isDisposed() ){
+			this.artistFont.dispose();
+		}
+		if( this.albumNameYearFont != null && !this.albumNameYearFont.isDisposed() ){
+			this.albumNameYearFont.dispose();
 		}
 	}
 	


### PR DESCRIPTION
Addressing #609 

Add song details such as song name, artist, author, album, release year, transcriber, tab creator to the top of exported file.

For SVG export, to maintain consistency with PDF printing (where paintHeader() exists in TGPrintLayout), we could implement paintHeader() within TGLayoutVertical. However, this would directly impact the main program by displaying song details on top of the tab.

Alternatively, we can create a new subclass of TGLayout (called TGSvgLayout for example). This subclass would largely mirror TGLayoutVertical but include the necessary paintHeader() implementation specifically for SVG export, minimizing unintended side effects on the main program.