### PR TITLE
Add tempo change / ending / repeat TEF v2 support

### DIFF
--- a/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/TEInputStream.java
+++ b/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/TEInputStream.java
@@ -5,7 +5,9 @@ import java.io.InputStream;
 
 import org.herac.tuxguitar.io.tef.base.TEChord;
 import org.herac.tuxguitar.io.tef.base.TEComponentChord;
+import org.herac.tuxguitar.io.tef.base.TEComponentEnding;
 import org.herac.tuxguitar.io.tef.base.TEComponentNote;
+import org.herac.tuxguitar.io.tef.base.TEComponentTempoChange;
 import org.herac.tuxguitar.io.tef.base.TEInfo;
 import org.herac.tuxguitar.io.tef.base.TEPercussion;
 import org.herac.tuxguitar.io.tef.base.TERepeat;
@@ -251,9 +253,22 @@ public class TEInputStream {
 			else if( ((data[2] & 0xff) & 0x1f) == 29 ){
 				//SCALE DIAGRAM | SPECIAL CHAR | SYNCOPATION CHANGE
 			}
-			else if( ((data[2] & 0xff) & 0x1f) == 30 ){
-				//TEMPO CHANGE | VOICE CHANGE | DRUM EVENT | CRESCENDO ACCENT | REPEAT/ENDING
+			else if ((data[2] & 0xff) == 0xFE) {
+				// TEMPO CHANGE
+				int bpm = (data[4] << 8) | (data[3] & 0xff);
+				this.song.getComponents().add( new TEComponentTempoChange(position, measure, string, bpm));
 			}
+			else if ((data[2] & 0xff) == 0x5E) {
+				// REPEAT/ENDING
+				boolean isOpenBracket = (data[4] & 0x40) > 0;
+				boolean isCloseBracket = (data[4] & 0x80) > 0;
+				int endingNumber = data[4] & 0x7;
+				this.song.getComponents().add( new TEComponentEnding(position, measure, string, isOpenBracket, isCloseBracket, endingNumber));
+			}
+			else if( ((data[2] & 0xff) & 0x1f) == 30 ){
+				// VOICE CHANGE | DRUM EVENT | CRESCENDO ACCENT
+			}
+
 			mIndex = measure;
 		}
 	}

--- a/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/TESongParser.java
+++ b/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/TESongParser.java
@@ -7,7 +7,9 @@ import java.util.Iterator;
 import org.herac.tuxguitar.io.tef.base.TEChord;
 import org.herac.tuxguitar.io.tef.base.TEComponent;
 import org.herac.tuxguitar.io.tef.base.TEComponentChord;
+import org.herac.tuxguitar.io.tef.base.TEComponentEnding;
 import org.herac.tuxguitar.io.tef.base.TEComponentNote;
+import org.herac.tuxguitar.io.tef.base.TEComponentTempoChange;
 import org.herac.tuxguitar.io.tef.base.TESong;
 import org.herac.tuxguitar.io.tef.base.TETimeSignature;
 import org.herac.tuxguitar.io.tef.base.TETrack;
@@ -24,6 +26,7 @@ import org.herac.tuxguitar.song.models.TGNote;
 import org.herac.tuxguitar.song.models.TGSong;
 import org.herac.tuxguitar.song.models.TGString;
 import org.herac.tuxguitar.song.models.TGTimeSignature;
+import org.herac.tuxguitar.song.models.TGTempo;
 import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.song.models.TGVelocities;
 import org.herac.tuxguitar.song.models.effects.TGEffectBend;
@@ -127,6 +130,12 @@ public class TESongParser {
 						}
 						else if(component instanceof TEComponentChord){
 							addChord(song.getChords(),(TEComponentChord)component,tgTrack,tgMeasure);
+						}
+						else if (component instanceof TEComponentTempoChange){
+							addTempoChange((TEComponentTempoChange)component, tgSong, tgMeasure);
+						}
+						else if (component instanceof TEComponentEnding){
+							addEnding((TEComponentEnding)component, tgMeasure);
 						}
 					}
 					offset += strings;
@@ -440,6 +449,30 @@ public class TESongParser {
 				TGBeat tgBeat = getBeat(tgMeasure, getStart(null, tgMeasure, component.getPosition()));
 				tgBeat.setChord(tgChord);
 			}
+		}
+	}
+
+	private void addTempoChange(TEComponentTempoChange tempoChange,TGSong tgSong, TGMeasure tgMeasure){
+		TGTempo newTempoEvent = this.manager.getFactory().newTempo();
+		newTempoEvent.copyFrom(tgMeasure.getTempo());
+		newTempoEvent.setValue(tempoChange.getBpm());
+
+		this.manager.changeTempos(tgSong, tgMeasure.getHeader(), newTempoEvent, true);
+	}
+
+	private void addEnding(TEComponentEnding ending,TGMeasure tgMeasure){
+		TGMeasureHeader measureHeader = tgMeasure.getHeader();
+
+		if (ending.getIsOpenBracket()) {
+			measureHeader.setRepeatOpen(true);
+		}
+
+		int endingNumber = ending.getEndingNumber();
+
+		if (ending.getIsCloseBracket() && endingNumber >= 2) {
+			measureHeader.setRepeatClose(endingNumber - 1);
+		} else if (measureHeader.getRepeatClose() == 0 && endingNumber != 0) {
+			measureHeader.setRepeatAlternative(1 << (endingNumber - 1));
 		}
 	}
 	

--- a/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/TESongReader.java
+++ b/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/TESongReader.java
@@ -12,9 +12,11 @@ public class TESongReader implements TGSongReader {
 	public TESongReader(){
 		super();
 	}
+
+	public static final TGFileFormat FILE_FORMAT = new TGFileFormat("TablEdit v2", "application/x-tef", new String[]{"tef"});
 	
 	public TGFileFormat getFileFormat() {
-		return new TGFileFormat("TablEdit", "application/x-tef", new String[]{"tef"});
+		return FILE_FORMAT;
 	}
 	
 	public void read(TGSongReaderHandle handle) throws TGFileFormatException {

--- a/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/base/TEComponentEnding.java
+++ b/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/base/TEComponentEnding.java
@@ -1,0 +1,27 @@
+package org.herac.tuxguitar.io.tef.base;
+
+public class TEComponentEnding extends TEComponent {
+    private boolean isOpenBracket;
+    private boolean isCloseBracket;
+    private int endingNumber;
+
+    public TEComponentEnding(int position,int measure, int string, boolean isOpenBracket, boolean isCloseBracket, int endingNumber) {
+        super(position, measure, string);
+
+        this.isOpenBracket = isOpenBracket;
+        this.isCloseBracket = isCloseBracket;
+        this.endingNumber = endingNumber;
+    }
+
+    public boolean getIsOpenBracket() {
+        return this.isOpenBracket;
+    }
+
+    public boolean getIsCloseBracket() {
+        return this.isCloseBracket;
+    }
+
+    public int getEndingNumber() {
+        return this.endingNumber;
+    }
+}

--- a/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/base/TEComponentTempoChange.java
+++ b/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef/base/TEComponentTempoChange.java
@@ -1,0 +1,15 @@
+package org.herac.tuxguitar.io.tef.base;
+
+public class TEComponentTempoChange extends TEComponent {
+    private int bpm;
+
+    public TEComponentTempoChange(int position,int measure, int string, int bpm) {
+        super(position, measure, string);
+
+        this.bpm = bpm;
+    }
+
+    public int getBpm() {
+        return this.bpm;
+    }
+}


### PR DESCRIPTION
Adds support for tempo changes, alternative endings, and repeats components in the TEF v2 import process.

This PR re-uses implementation done initially in PR #600
(splitting tef v2 and tef v3 into different PRs)