### PR TITLE
fix for scales notes display on fretboard

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/song/models/TGScale.java
+++ b/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/song/models/TGScale.java
@@ -1,20 +1,42 @@
 package org.herac.tuxguitar.song.models;
 
+import org.herac.tuxguitar.util.TGMusicKeyUtils;
+
 public abstract class TGScale {
 	private final boolean[] notes = new boolean[12];
 	
 	private int key;
+	private int alteration;
 	
 	public TGScale(){
 		this.clear();
 	}
 	
-	public void setKey(int key){
-		this.key = key;
+	public void setKeyName(String name){
+		String shortName = name.substring(0,1);
+		this.key = 0;
+		for (int i=0; i<TGMusicKeyUtils.sharpKeyNames.length; i++) {
+			if (shortName.equals(TGMusicKeyUtils.sharpKeyNames[i])) {
+				this.key = i;
+			}
+		}
+		this.alteration = TGMusicKeyUtils.NONE;
+		if (name.contains("#")) {
+			this.key += 1;
+			this.alteration = TGMusicKeyUtils.SHARP;
+		}
+		else if (name.contains("b")) {
+			this.key -= 1;
+			this.alteration = TGMusicKeyUtils.FLAT;
+		}
 	}
 	
 	public int getKey(){
 		return this.key;
+	}
+	
+	public int getAlteration(){
+		return this.alteration;
 	}
 	
 	public void setNote(int note,boolean on){
@@ -26,7 +48,7 @@ public abstract class TGScale {
 	}
 	
 	public void clear(){
-		this.setKey(0);
+		this.setKeyName("C");
 		for(int i = 0; i < this.notes.length; i++){
 			this.setNote(i,false);
 		}

--- a/common/TuxGuitar-lib/src/test/java/org/herac/tuxguitar/util/TestMusicKeyUtils.java
+++ b/common/TuxGuitar-lib/src/test/java/org/herac/tuxguitar/util/TestMusicKeyUtils.java
@@ -8,6 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.herac.tuxguitar.song.factory.TGFactory;
+import org.herac.tuxguitar.song.models.TGScale;
+
 public class TestMusicKeyUtils {
 
 	@Test
@@ -411,6 +414,52 @@ public class TestMusicKeyUtils {
 				}
 			}
 		}
+	}
+	
+	@Test
+	public void testScaleKeySignature() {
+		TGFactory factory = new TGFactory();
+		// major scale
+		TGScale scale = factory.newScale();
+		scale.setNote(0, true);
+		scale.setNote(2, true);
+		scale.setNote(4, true);
+		scale.setNote(5, true);
+		scale.setNote(7, true);
+		scale.setNote(9, true);
+		scale.setNote(11, true);
+		
+		scale.setKeyName("C");
+		assertEquals(0, TGMusicKeyUtils.getKeySignature(scale));
+
+		scale.setKeyName("D");
+		assertEquals(2, TGMusicKeyUtils.getKeySignature(scale));
+		
+		scale.setKeyName("Eb");
+		assertEquals(7 + 3, TGMusicKeyUtils.getKeySignature(scale));
+
+		scale.setKeyName("F");
+		assertEquals(7 + 1, TGMusicKeyUtils.getKeySignature(scale));
+		
+		scale.setKeyName("C#");
+		assertEquals(7, TGMusicKeyUtils.getKeySignature(scale));
+		
+		// minor scale
+		scale.clear();
+		scale.setNote(0, true);
+		scale.setNote(2, true);
+		scale.setNote(3, true);
+		scale.setNote(5, true);
+		scale.setNote(7, true);
+		scale.setNote(8, true);
+		scale.setNote(10, true);
+		
+		scale.setKeyName("A");
+		assertEquals(0, TGMusicKeyUtils.getKeySignature(scale));
+		
+		scale.setKeyName("C");
+		assertEquals(7+3, TGMusicKeyUtils.getKeySignature(scale));
+
 	}
 
 }

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/tools/scale/ScaleManager.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/tools/scale/ScaleManager.java
@@ -10,14 +10,13 @@ import org.herac.tuxguitar.event.TGEventManager;
 import org.herac.tuxguitar.resource.TGResourceManager;
 import org.herac.tuxguitar.song.models.TGScale;
 import org.herac.tuxguitar.util.TGContext;
-import org.herac.tuxguitar.util.TGMusicKeyUtils;
 import org.herac.tuxguitar.util.error.TGErrorManager;
 import org.herac.tuxguitar.util.singleton.TGSingletonFactory;
 import org.herac.tuxguitar.util.singleton.TGSingletonUtil;
 
 public class ScaleManager {
 	
-	private static final String[] KEY_NAMES = TGMusicKeyUtils.sharpKeyNames;
+	private static final String[] KEY_NAMES = new String[]    {"C", "C#", "Db", "D", "D#", "Eb", "E", "F", "F#", "Gb", "G", "G#", "Ab", "A",  "A#", "Bb", "B"};
 	
 	private static final String KEY_SEPARATOR = ",";
 	
@@ -29,16 +28,16 @@ public class ScaleManager {
 	
 	private TGScale scale;
 	
-	private int selectionIndex;
+	private int scaleIndex;
 	
-	private int selectionKey;
+	private int selectionKeyIndex;
 	
 	private ScaleManager(TGContext context){
 		this.context = context;
 		this.scales = new ArrayList<ScaleInfo>();
 		this.scale = TuxGuitar.getInstance().getSongManager().getFactory().newScale();
-		this.selectionKey = 0;
-		this.selectionIndex = NONE_SELECTION;
+		this.selectionKeyIndex = 0;
+		this.scaleIndex = NONE_SELECTION;
 		this.loadScales();
 	}
 	
@@ -54,13 +53,13 @@ public class ScaleManager {
 		TGEventManager.getInstance(this.context).fireEvent(new ScaleEvent());
 	}
 	
-	public void selectScale(int index, int key){
-		if( index == NONE_SELECTION ){
+	public void selectScale(int scaleIndex, int keyIndex){
+		if( scaleIndex == NONE_SELECTION ){
 			getScale().clear();
 		}
-		else if(index >= 0 && index < this.scales.size()){
+		else if(scaleIndex >= 0 && scaleIndex < this.scales.size()){
 			getScale().clear();
-			ScaleInfo info = (ScaleInfo)this.scales.get(index);
+			ScaleInfo info = (ScaleInfo)this.scales.get(scaleIndex);
 			String[] keys = info.getKeys().split(KEY_SEPARATOR);
 			for (int i = 0; i < keys.length; i ++){
 				int note = (Integer.parseInt(keys[i]) - 1);
@@ -68,10 +67,10 @@ public class ScaleManager {
 					getScale().setNote(note,true);
 				}
 			}
-			getScale().setKey(key);
+			getScale().setKeyName(KEY_NAMES[keyIndex]);
 		}
-		this.selectionIndex = index;
-		this.selectionKey = key;
+		this.scaleIndex = scaleIndex;
+		this.selectionKeyIndex = keyIndex;
 		this.fireListeners();
 	}
 	
@@ -117,12 +116,12 @@ public class ScaleManager {
 		return KEY_NAMES;
 	}
 	
-	public int getSelectionIndex() {
-		return this.selectionIndex;
+	public int getScaleIndex() {
+		return this.scaleIndex;
 	}
 	
-	public int getSelectionKey() {
-		return this.selectionKey;
+	public int getSelectionKeyIndex() {
+		return this.selectionKeyIndex;
 	}
 	
 	private void loadScales(){

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/fretboard/TGFretBoard.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/fretboard/TGFretBoard.java
@@ -27,6 +27,7 @@ import org.herac.tuxguitar.player.base.MidiPlayer;
 import org.herac.tuxguitar.song.models.TGBeat;
 import org.herac.tuxguitar.song.models.TGMeasure;
 import org.herac.tuxguitar.song.models.TGNote;
+import org.herac.tuxguitar.song.models.TGScale;
 import org.herac.tuxguitar.song.models.TGString;
 import org.herac.tuxguitar.song.models.TGTrack;
 import org.herac.tuxguitar.song.models.TGVoice;
@@ -271,9 +272,9 @@ public class TGFretBoard {
 	}
 	
 	private void loadScaleName() {
-		int scaleKey = TuxGuitar.getInstance().getScaleManager().getSelectionKey();
-		int scaleIndex = TuxGuitar.getInstance().getScaleManager().getSelectionIndex();
-		String key = TuxGuitar.getInstance().getScaleManager().getKeyName( scaleKey );
+		int scaleKeyIndex = TuxGuitar.getInstance().getScaleManager().getSelectionKeyIndex();
+		int scaleIndex = TuxGuitar.getInstance().getScaleManager().getScaleIndex();
+		String key = TuxGuitar.getInstance().getScaleManager().getKeyName( scaleKeyIndex );
 		String name = TuxGuitar.getInstance().getScaleManager().getScaleName( scaleIndex );
 		this.scaleName.setText( ( key != null && name != null ) ? ( key + " - " + name ) : "" );
 	}
@@ -439,13 +440,15 @@ public class TGFretBoard {
 	
 	private void paintScale(UIPainter painter) {
 		TGTrack track = getTrack();
+		TGScale scale = TuxGuitar.getInstance().getScaleManager().getScale();
+		int keySignature = TGMusicKeyUtils.getKeySignature(scale);
 		
 		for (int i = 0; i < this.strings.length; i++) {
 			TGString string = track.getString(i + 1);
 			for (int j = 0; j < this.frets.length; j++) {
 				
 				int noteValue = string.getValue() + j;
-				if(TuxGuitar.getInstance().getScaleManager().getScale().getNote(noteValue)){
+				if(scale.getNote(noteValue)){
 					int x = this.frets[j];
 					if(j > 0){
 						x -= ((x - this.frets[j - 1]) / 2);
@@ -453,7 +456,8 @@ public class TGFretBoard {
 					int y = this.strings[i];
 					
 					if( (this.config.getStyle() & TGFretBoardConfig.DISPLAY_TEXT_SCALE) != 0 ){
-						paintKeyText(painter,this.config.getColorScaleText(), this.config.getColorScale(),x,y,TGMusicKeyUtils.sharpNoteName(noteValue));
+						String noteName = TGMusicKeyUtils.noteName(noteValue, keySignature);
+						paintKeyText(painter,this.config.getColorScaleText(), this.config.getColorScale(),x,y,noteName);
 					}
 					else{
 						paintKeyOval(painter,this.config.getColorScale(),x,y);

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/piano/TGPiano.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/piano/TGPiano.java
@@ -195,9 +195,9 @@ public class TGPiano {
 	}
 	
 	private void loadScaleName() {
-		int scaleKey = TuxGuitar.getInstance().getScaleManager().getSelectionKey();
-		int scaleIndex = TuxGuitar.getInstance().getScaleManager().getSelectionIndex();
-		String key = TuxGuitar.getInstance().getScaleManager().getKeyName( scaleKey );
+		int scaleKeyIndex = TuxGuitar.getInstance().getScaleManager().getSelectionKeyIndex();
+		int scaleIndex = TuxGuitar.getInstance().getScaleManager().getScaleIndex();
+		String key = TuxGuitar.getInstance().getScaleManager().getKeyName( scaleKeyIndex );
 		String name = TuxGuitar.getInstance().getScaleManager().getScaleName( scaleIndex );
 		this.scaleName.setText( ( key != null && name != null ) ? ( key + " - " + name ) : "" );
 	}

--- a/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/scale/TGScaleDialog.java
+++ b/desktop/TuxGuitar/src/org/herac/tuxguitar/app/view/dialog/scale/TGScaleDialog.java
@@ -41,7 +41,7 @@ public class TGScaleDialog {
 		for(int i = 0;i < keyNames.length;i ++){
 			keys.addItem(new UISelectItem<Integer>(keyNames[i], i));
 		}
-		keys.setSelectedValue(scaleManager.getSelectionKey());
+		keys.setSelectedValue(scaleManager.getSelectionKeyIndex());
 		compositeLayout.set(keys, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false);
 		compositeLayout.set(keys, UITableLayout.PACKED_HEIGHT, 200f);
 		
@@ -51,7 +51,7 @@ public class TGScaleDialog {
 		for(int i = 0;i < scaleNames.length;i ++){
 			scales.addItem(new UISelectItem<Integer>(scaleNames[i], i));
 		}
-		scales.setSelectedValue(scaleManager.getSelectionIndex());
+		scales.setSelectedValue(scaleManager.getScaleIndex());
 		
 		compositeLayout.set(scales, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, false);
 		compositeLayout.set(scales, UITableLayout.PACKED_HEIGHT, 200f);


### PR DESCRIPTION
fixes #204, at least partially: scales with flat base notes can be displayed, and result should be ok for many common scales.
Not a perfect solution though. It can't be correct in all cases, as there are no double-sharp / double-flat concepts in TuxGuitar currently. E.g. D# major scale is displayed with 3 sharps (in an incorrect order) instead of 5 sharps + 2 double-sharps.
Intentionally, E#, Fb, B# and Cb scales are not accessible.