### PR TITLE
Add more song details to exported SVG file

### DIFF
--- a/desktop/TuxGuitar-svg/src/org/herac/tuxguitar/io/svg/SVGController.java
+++ b/desktop/TuxGuitar-svg/src/org/herac/tuxguitar/io/svg/SVGController.java
@@ -12,9 +12,11 @@ import org.herac.tuxguitar.song.models.TGMeasure;
 import org.herac.tuxguitar.song.models.TGMeasureHeader;
 import org.herac.tuxguitar.song.models.TGSong;
 import org.herac.tuxguitar.ui.resource.UIColor;
+import org.herac.tuxguitar.ui.resource.UIFont;
 import org.herac.tuxguitar.ui.resource.UIPainter;
 import org.herac.tuxguitar.ui.resource.UIRectangle;
 import org.herac.tuxguitar.ui.resource.UIResourceFactory;
+import org.herac.tuxguitar.util.TGMessagesManager;
 
 public class SVGController implements TGController {
 	
@@ -59,6 +61,7 @@ public class SVGController implements TGController {
 	
 	public void write(StringBuffer svgBuffer) throws Throwable {		
 		if( this.tgSong != null ){
+			
 			// Do a paint to calculate the document height.
 			UIRectangle svgBounds = new UIRectangle(0, 0, 960, 0 );
 			UIPainter svgPainter = new SVGPainter(new StringBuffer());
@@ -80,8 +83,12 @@ public class SVGController implements TGController {
 			svgPainter.closePath();
 			svgBackground.dispose();
 			
+			// Paint header with song info first
+			float headerOffset = 0f;
+			headerOffset += this.paintHeader(svgPainter, svgBounds, 0f, 10f);
+			
 			// Paint the TGSong
-			this.tgLayout.paint(svgPainter, svgBounds, 0, 0);
+			this.tgLayout.paint(svgPainter, svgBounds, 0, headerOffset);
 			
 			// Closes the painter
 			svgPainter.dispose();
@@ -92,6 +99,137 @@ public class SVGController implements TGController {
 		}
 	}
 	
+	public float paintHeader(
+		UIPainter svgPainter, 
+		UIRectangle svgBounds,
+		float startX, float startY
+	) {
+		float headerOffset = 0f;
+		float marginLeft = this.tgLayout.getFirstMeasureSpacing();
+		float marginRight = 5f;
+		float widthMinusMargin = 
+				svgBounds.getWidth() - (marginLeft + marginRight);
+		float fmTopLine = Math.round(svgPainter.getFMTopLine());
+
+		String songName = getSong().getName();
+		String songAuthor = getSong().getAuthor();
+		String artistName = getSong().getArtist();
+		String albumName = getSong().getAlbum();
+		String releaseYear = getSong().getDate();
+		String copyright = getSong().getCopyright();
+		String transcriber = getSong().getTranscriber();
+		String tabCreator = getSong().getWriter();
+		
+		if( songName != null && songName.length() > 0 ){
+			svgPainter.setFont(getSongNameFont());
+			
+			((SVGPainter) svgPainter).drawString(
+				songName, 
+				widthMinusMargin / 2,
+				fmTopLine + startY + Math.round(headerOffset),
+				"middle"
+			);
+			
+			headerOffset += 20.0f * tgLayout.getScale();
+		}
+
+		if( artistName != null && artistName.length() > 0 ){
+			svgPainter.setFont(getArtistFont());
+			
+			((SVGPainter) svgPainter).drawString(
+				artistName, 
+				widthMinusMargin / 2,
+				fmTopLine + startY + Math.round(headerOffset),
+				"middle"
+			);
+			
+			headerOffset += 20.0f * tgLayout.getScale();
+		}
+		
+		if( (albumName != null && albumName.length() > 0) ||
+			(releaseYear != null && releaseYear.length() > 0) ){
+			
+			String albumNameReleaseYear = "";
+			if( albumName != null && albumName.length() > 0 )
+				albumNameReleaseYear += TGMessagesManager.getProperty("composition.album") + " " + albumName + " ";
+			if( releaseYear != null && releaseYear.length() > 0 )
+				albumNameReleaseYear += "(" + releaseYear + ")";
+		
+			svgPainter.setFont(getAlbumNameYearFont());
+			
+			((SVGPainter) svgPainter).drawString(
+				albumNameReleaseYear,
+				widthMinusMargin / 2,
+				startY + fmTopLine + Math.round(headerOffset),
+				"middle"
+			);
+			
+			headerOffset += 20.0f * tgLayout.getScale();
+		}
+		
+		if( songAuthor != null && songAuthor.length() > 0 ){
+			
+			songAuthor = TGMessagesManager.getProperty("composition.author") + " " + songAuthor;
+			svgPainter.setFont(getSongAuthorFont());
+			
+			((SVGPainter) svgPainter).drawString(
+				songAuthor,
+				widthMinusMargin,
+				fmTopLine + startY + Math.round(headerOffset),
+				"end"
+			);
+			
+			headerOffset += 10.0f * tgLayout.getScale();
+		}
+
+		if( copyright != null && copyright.length() > 0 ){
+
+			copyright = TGMessagesManager.getProperty("composition.copyright") + " " + copyright;
+			svgPainter.setFont(getSongAuthorFont());
+			
+			((SVGPainter) svgPainter).drawString(
+				copyright,
+				widthMinusMargin,
+				fmTopLine + startY + Math.round(headerOffset),
+				"end"
+			);
+			
+			headerOffset += 10.0f * tgLayout.getScale();
+		}
+		
+		if( transcriber != null && transcriber.length() > 0 ){
+
+			transcriber = TGMessagesManager.getProperty("composition.transcriber") + " " + transcriber;
+			svgPainter.setFont(getSongAuthorFont());
+			
+			((SVGPainter) svgPainter).drawString(
+				transcriber,
+				widthMinusMargin,
+				fmTopLine + startY + Math.round(headerOffset),
+				"end"
+			);
+			
+			headerOffset += 10.0f * tgLayout.getScale();
+		}
+
+		if( tabCreator != null && tabCreator.length() > 0 ){
+
+			tabCreator = TGMessagesManager.getProperty("composition.writer") + " " + tabCreator;
+			svgPainter.setFont(getSongAuthorFont());
+			
+			((SVGPainter) svgPainter).drawString(
+				tabCreator,
+				widthMinusMargin,
+				fmTopLine + startY + Math.round(headerOffset),
+				"end"
+			);
+			
+			headerOffset += 20.0f * tgLayout.getScale();
+		}
+
+		return headerOffset;
+	}
+
 	public TGLayoutStyles getStyles() {
 		return this.tgStyles.getStyles();
 	}
@@ -115,4 +253,53 @@ public class SVGController implements TGController {
 	public boolean isLoopEHeader(TGMeasureHeader measureHeader) {
 		return false;
 	}
+	
+	private UIFont getSongNameFont() {
+		String textFont = this.tgStyles.getStyles().getTextFont().getName();
+
+		UIFont songNameFont = this.tgResourceFactory.createFont(
+			textFont,
+			16.0f * this.tgLayout.getFontScale(), 
+			true, false
+		);
+
+		return songNameFont;
+	}
+
+	private UIFont getArtistFont() {
+		String textFont = this.tgStyles.getStyles().getTextFont().getName();
+
+		UIFont artistFont = this.tgResourceFactory.createFont(
+			textFont,
+			12.0f * this.tgLayout.getFontScale(), 
+			true, false
+		);
+
+		return artistFont;
+	}
+
+	private UIFont getAlbumNameYearFont() {
+		String textFont = this.tgStyles.getStyles().getTextFont().getName();
+		
+		UIFont albumNameYearFont = this.tgResourceFactory.createFont(
+			textFont,
+			10.0f * this.tgLayout.getFontScale(),
+			true, false
+		);
+
+		return albumNameYearFont;
+	}
+
+	private UIFont getSongAuthorFont() {
+		String textFont = this.tgStyles.getStyles().getTextFont().getName();
+		
+		UIFont songAuthorFont = this.tgResourceFactory.createFont(
+			textFont,
+			8.0f * this.tgLayout.getFontScale(),
+			true, false
+		);
+
+		return songAuthorFont;
+	}
+
 }

--- a/desktop/TuxGuitar-svg/src/org/herac/tuxguitar/io/svg/SVGPainter.java
+++ b/desktop/TuxGuitar-svg/src/org/herac/tuxguitar/io/svg/SVGPainter.java
@@ -65,15 +65,36 @@ public class SVGPainter extends SVGResourceFactory implements UIPainter {
 	}
 	
 	public void drawString(String string, float x, float y) {
+		this.drawString(string, x, y, "start");
+	}
+	
+	public void drawString(String string, float x, float y, String textAnchor) {
 		this.setAdvanced(false);
 		this.svgBuffer.append("\r\n");
 		this.svgBuffer.append("<text ");
 		this.svgBuffer.append("x='" + x + "' ");
 		this.svgBuffer.append("y='" + y + "' ");
+		this.svgBuffer.append("text-anchor=\"" + textAnchor + "\" ");
 		this.svgBuffer.append("font-family=\""+ this.svgFont.getName() + "\" ");
 		this.svgBuffer.append("font-size=\"" + this.svgFont.getHeight() + "\" ");
 		this.svgBuffer.append("fill=\"" + this.svgForeground.toHexString() +"\" ");
 		this.svgBuffer.append(">");
+
+		/** 
+		 * Escape XML special characters before print
+		 * 
+		 * & - &amp;
+		 * < - &lt;
+		 * > - &gt;
+		 * " - &quot;
+		 * ' - &apos;
+		 */
+		string = string.replaceAll("[&]", "&amp;");
+		string = string.replaceAll("[<]", "&lt;");
+		string = string.replaceAll("[>]", "&gt;");
+		string = string.replaceAll("[\"]", "&quot;");
+		string = string.replaceAll("[']", "&apos;");
+		
 		this.svgBuffer.append( string );
 		this.svgBuffer.append("</text>");
 	}


### PR DESCRIPTION
I have to use attribute `text-anchor` on svg file in order to make the text aligned correctly. The old way of calculating X-coordinate to paintString() doesn't work.

![test609_2_2](https://github.com/user-attachments/assets/6e91625f-b980-4a1f-8af8-f7beee1a7a98)
