### PR TITLE
associate "tef" file format to tef v3

### DIFF
--- a/desktop/TuxGuitar-tef/share/META-INF/services/org.herac.tuxguitar.util.plugin.TGPlugin
+++ b/desktop/TuxGuitar-tef/share/META-INF/services/org.herac.tuxguitar.util.plugin.TGPlugin
@@ -1,2 +1,4 @@
+# make sure tef2 is defined BEFORE tef3
+# as tef3 files are recognized by file content, but tef2 files can only be recognized by file extension
 org.herac.tuxguitar.io.tef2.TESongReaderPlugin
 org.herac.tuxguitar.io.tef3.TESongReaderPlugin

--- a/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef3/TESongReader.java
+++ b/desktop/TuxGuitar-tef/src/org/herac/tuxguitar/io/tef3/TESongReader.java
@@ -13,10 +13,7 @@ public class TESongReader implements TGSongReader {
 		super();
 	}
 
-	// do not associate a file extension (.tef) here:
-	// since tef v2 files can only be identified by extension and not by content, make sure ".tef" is only associated to tef v2
-	// tef v3 should be identified by file content (thanks to TEFileFormatDetector)
-	public static final TGFileFormat FILE_FORMAT = new TGFileFormat("TablEdit v3", "application/x-tef", new String[] {});
+	public static final TGFileFormat FILE_FORMAT = new TGFileFormat("TablEdit v3", "application/x-tef", new String[] {"tef"});
 	
 	public TGFileFormat getFileFormat() {
 		return FILE_FORMAT;


### PR DESCRIPTION
see #636

tef v3 files are recognized by file content.
tef v2 files are recognized by file extension "tef".

As file readers for tef v2 AND v3 are associated to the same "tef" extension, it is important that tef v2 plugin is registered BEFORE tef v3

See explicit comment added in services file