### PR TITLE
add note effects to ascii export

### DIFF
--- a/common/TuxGuitar-ascii/src/org/herac/tuxguitar/io/ascii/ASCIIOutputStream.java
+++ b/common/TuxGuitar-ascii/src/org/herac/tuxguitar/io/ascii/ASCIIOutputStream.java
@@ -2,6 +2,8 @@ package org.herac.tuxguitar.io.ascii;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import org.herac.tuxguitar.song.models.TGNote;
+import org.herac.tuxguitar.song.models.effects.TGEffectBend;
 
 public class ASCIIOutputStream {
 	private PrintWriter writer;
@@ -12,17 +14,66 @@ public class ASCIIOutputStream {
 		this.writer = new PrintWriter(stream);
 	}
 	
-	public void drawNote(int fret, boolean isDeadNote){
-		movePoint(getPosX() + ((fret >=10 )?2:1),getPosY());
-		if (isDeadNote) {
-			this.writer.print("X");
-		} else {
-			this.writer.print(fret);
+	public int drawNote(TGNote note, TGNote nextNote, boolean printNote){
+		int printWidth=0;
+		if (note!=null) {
+			StringBuffer noteString=new StringBuffer();
+			int fret=note.getValue();
+			if (note.getEffect().isDeadNote()) {
+				noteString.append("X");
+				printWidth+=1;
+			} else {
+				noteString.append(fret);
+				printWidth+=(fret >=10 )?2:1;
+			}
+			if (note.getEffect().isHammer() && (nextNote !=null)) {
+				if (nextNote.getValue()>fret) {
+					noteString.append("h");
+				} else {
+					noteString.append("p");			
+				}
+				++printWidth;
+			}
+			if (note.getEffect().isSlide() && (nextNote !=null)) {
+				if (nextNote.getValue()>fret) {
+					noteString.append("/");
+				} else {
+					noteString.append("\\");			
+				}
+				++printWidth;
+			}
+			if (note.getEffect().isBend()) {
+				TGEffectBend bend=note.getEffect().getBend();
+				// bend.getMovements().size()==0 means hold bend, not handled yet
+				if (bend.getMovements().size()>0) {
+					int movement=bend.getMovements().get(0);
+					int bendNote=fret+Math.abs(movement)/2;
+					if (movement<0) {
+						movement=-movement;
+						noteString.insert(0, "r");
+						noteString.insert(0, bendNote);
+					} else {
+						noteString.append("b");
+						noteString.append(bendNote);
+					}
+					++printWidth;
+					printWidth+=(bendNote >=10 )?2:1;
+				}
+			}
+
+			if (printNote) {
+				this.writer.print(noteString.toString());
+				movePoint(getPosX() + printWidth,getPosY());					
+			}
 		}
+		return printWidth;
 	}
 	
 	public void drawStringSegments(int count){
-		movePoint(getPosX() + count,getPosY());
+		if (count<0) {
+			count=0;
+		}
+		movePoint(getPosX() + count,getPosY());		
 		for(int i = 0; i < count;i ++){
 			this.writer.print("-");
 		}

--- a/common/TuxGuitar-ascii/src/org/herac/tuxguitar/io/ascii/ASCIIOutputStream.java
+++ b/common/TuxGuitar-ascii/src/org/herac/tuxguitar/io/ascii/ASCIIOutputStream.java
@@ -15,16 +15,15 @@ public class ASCIIOutputStream {
 	}
 
 	public int drawNote(TGNote note, TGNote nextNote, boolean printNote){
-		int printWidth=0;
+		StringBuffer noteString=new StringBuffer();
 		if (note!=null) {
-			StringBuffer noteString=new StringBuffer();
 			int fret=note.getValue();
 			if (note.getEffect().isDeadNote()) {
 				noteString.append("X");
-				++printWidth;
+			} else if (note.getEffect().isBend() && (note.getEffect().getBend().getMovements().size()==0)) { // bend.getMovements().size()==0 means hold bend
+				noteString.append("H");
 			} else {
 				noteString.append(fret);
-				printWidth+=(fret >=10 )?2:1;
 			}
 			if (note.getEffect().isHammer() && (nextNote !=null)) {
 				if (nextNote.getValue()>fret) {
@@ -32,7 +31,6 @@ public class ASCIIOutputStream {
 				} else {
 					noteString.append("p");
 				}
-				++printWidth;
 			}
 			if (note.getEffect().isSlide() && (nextNote !=null)) {
 				if (nextNote.getValue()>fret) {
@@ -40,11 +38,10 @@ public class ASCIIOutputStream {
 				} else {
 					noteString.append("\\");
 				}
-				++printWidth;
 			}
 			if (note.getEffect().isBend()) {
 				TGEffectBend bend=note.getEffect().getBend();
-				// bend.getMovements().size()==0 means hold bend, not handled yet
+				// bend.getMovements().size()==0 means hold bend and is handled above
 				if (bend.getMovements().size()>0) {
 					int movement=bend.getMovements().get(0);
 					// rounding of division by 2 is intentional to avoid fractional frets like 12b12.5 in the ASCII notation
@@ -56,17 +53,16 @@ public class ASCIIOutputStream {
 						noteString.append("b");
 						noteString.append(bendNote);
 					}
-					++printWidth;
-					printWidth+=(bendNote >=10 )?2:1;
 				}
 			}
 
 			if (printNote) {
 				this.writer.print(noteString.toString());
-				movePoint(getPosX() + printWidth,getPosY());
+				movePoint(getPosX() + noteString.length(),getPosY());
 			}
 		}
-		return printWidth;
+
+		return noteString.length();
 	}
 
 	public void drawStringSegments(int count){

--- a/common/TuxGuitar-ascii/src/org/herac/tuxguitar/io/ascii/ASCIIOutputStream.java
+++ b/common/TuxGuitar-ascii/src/org/herac/tuxguitar/io/ascii/ASCIIOutputStream.java
@@ -9,11 +9,11 @@ public class ASCIIOutputStream {
 	private PrintWriter writer;
 	private int x;
 	private int y;
-	
+
 	public ASCIIOutputStream(PrintStream stream){
 		this.writer = new PrintWriter(stream);
 	}
-	
+
 	public int drawNote(TGNote note, TGNote nextNote, boolean printNote){
 		int printWidth=0;
 		if (note!=null) {
@@ -21,7 +21,7 @@ public class ASCIIOutputStream {
 			int fret=note.getValue();
 			if (note.getEffect().isDeadNote()) {
 				noteString.append("X");
-				printWidth+=1;
+				++printWidth;
 			} else {
 				noteString.append(fret);
 				printWidth+=(fret >=10 )?2:1;
@@ -30,7 +30,7 @@ public class ASCIIOutputStream {
 				if (nextNote.getValue()>fret) {
 					noteString.append("h");
 				} else {
-					noteString.append("p");			
+					noteString.append("p");
 				}
 				++printWidth;
 			}
@@ -38,7 +38,7 @@ public class ASCIIOutputStream {
 				if (nextNote.getValue()>fret) {
 					noteString.append("/");
 				} else {
-					noteString.append("\\");			
+					noteString.append("\\");
 				}
 				++printWidth;
 			}
@@ -47,9 +47,9 @@ public class ASCIIOutputStream {
 				// bend.getMovements().size()==0 means hold bend, not handled yet
 				if (bend.getMovements().size()>0) {
 					int movement=bend.getMovements().get(0);
+					// rounding of division by 2 is intentional to avoid fractional frets like 12b12.5 in the ASCII notation
 					int bendNote=fret+Math.abs(movement)/2;
 					if (movement<0) {
-						movement=-movement;
 						noteString.insert(0, "r");
 						noteString.insert(0, bendNote);
 					} else {
@@ -63,22 +63,22 @@ public class ASCIIOutputStream {
 
 			if (printNote) {
 				this.writer.print(noteString.toString());
-				movePoint(getPosX() + printWidth,getPosY());					
+				movePoint(getPosX() + printWidth,getPosY());
 			}
 		}
 		return printWidth;
 	}
-	
+
 	public void drawStringSegments(int count){
 		if (count<0) {
 			count=0;
 		}
-		movePoint(getPosX() + count,getPosY());		
+		movePoint(getPosX() + count,getPosY());
 		for(int i = 0; i < count;i ++){
 			this.writer.print("-");
 		}
 	}
-	
+
 	public void drawTuneSegment(String tune,int maxLength){
 		for(int i = tune.length();i < maxLength;i ++){
 			drawSpace();
@@ -86,44 +86,44 @@ public class ASCIIOutputStream {
 		movePoint(getPosX() + tune.length(),getPosY());
 		this.writer.print(tune);
 	}
-	
+
 	public void drawBarSegment(){
 		movePoint(getPosX() + 1,getPosY());
 		this.writer.print("|");
 	}
-	
+
 	public void nextLine(){
 		movePoint(0,getPosY() + 1);
 		this.writer.println("");
 	}
-	
+
 	public void drawStringLine(String s){
 		movePoint(0,getPosY() + 1);
 		this.writer.println(s);
 	}
-	
+
 	public void drawSpace(){
 		movePoint(getPosX() + 1,getPosY());
 		this.writer.print(" ");
 	}
-	
+
 	private void movePoint(int x,int y){
 		this.x = x;
 		this.y = y;
 	}
-	
+
 	public int getPosX(){
 		return this.x;
 	}
-	
+
 	public int getPosY(){
 		return this.y;
 	}
-	
+
 	public void flush(){
 		this.writer.flush();
 	}
-	
+
 	public void close(){
 		this.writer.close();
 	}

--- a/common/TuxGuitar-ascii/src/org/herac/tuxguitar/io/ascii/ASCIITabOutputStream.java
+++ b/common/TuxGuitar-ascii/src/org/herac/tuxguitar/io/ascii/ASCIITabOutputStream.java
@@ -118,7 +118,6 @@ public class ASCIITabOutputStream {
 			TGBeat nextBeat = this.manager.getMeasureManager().getNextBeat( measure.getBeats() , beat);
 			TGNote nextNote=(nextBeat != null ? this.manager.getMeasureManager().getNote(nextBeat, currentString+1) : null);
 
-			//Si hay una nota en la misma cuerda, la dibujo
 			TGNote note = this.manager.getMeasureManager().getNote(beat, currentString+1);
 			outLength=this.out.drawNote(note, nextNote, true);
 			for(int checkedString = 0; checkedString < stringCount;checkedString++){


### PR DESCRIPTION

I extended the tuxguitar ascii export.

The ascii export includes now the additional note effects

- hammer on
- pull off
- slide up
- slide down
- bend up
- release bend

The note effect for dead notes was already included.

The notation is according to [ASCII Tab](https://en.wikipedia.org/wiki/ASCII_tab).

| Symbol | Technique      |
|--------|----------------|
| h      | hammer on      |
| p      | pull off       |
| b      | bend string up |
| r      | release bend   |
| /      | slide up       |
| \      | slide down     |
| X      | dead note      |

The test environment was

- Ubuntu 24.04.1 LTS
- eclipse-java-2023-12-R-linux-gtk-x86_64

The attached `ascii-effects.tg` file demonstrates the export, see [ascii-effects.zip](https://github.com/user-attachments/files/18640555/ascii-effects.zip) .

![2025-02-03T095833](https://github.com/user-attachments/assets/281aad97-deec-4332-a551-d9ff45c75bec)

ASCII export in `ascii-effects.tab`:

```console
E|-12h-15------12----------------0------15b18----------15r12-|-X-----|
B|-12----------13-------9--15\-3-6------------12-19r17-------|-X-----|
G|-------------14-5/-12-10-----3-7--2------------------------|-X-----|
D|--------5p-4-14-5--5-----------8---------------------------|-X-----|
A|-----------4-16----------------9---------------------------|-X-----|
E|-------------17----------------10-2b4-4--------------------|-X-----|
```