### PR TITLE
bug fixes, free edition mode

### DIFF
--- a/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGDeleteNoteOrRestAction.java
+++ b/common/TuxGuitar-editor-utils/src/org/herac/tuxguitar/editor/action/note/TGDeleteNoteOrRestAction.java
@@ -45,7 +45,11 @@ public class TGDeleteNoteOrRestAction extends TGActionBase {
 		if (beat.isTextBeat() && beat.isRestBeat()) {
 			songManager.getMeasureManager().removeText(beat);
 		} else if (voice.isRestVoice()) {
-			songManager.getMeasureManager().removeVoice(voice, true);
+			if (songManager.isFreeEditionMode(measure)) {
+				songManager.getMeasureManager().removeVoiceWithoutControl(voice);
+			} else {
+				songManager.getMeasureManager().removeVoice(voice, true);
+			}
 		} else {
 			songManager.getMeasureManager().removeNote(measure, beat.getStart(), voice.getIndex(), string);
 		}

--- a/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/song/managers/TGMeasureManager.java
+++ b/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/song/managers/TGMeasureManager.java
@@ -816,10 +816,14 @@ public class TGMeasureManager {
 
 	public void moveAllBeats(TGMeasure measure,long theMove){
 		moveBeats(measure.getBeats(),theMove);
+		// refresh precise start
+		this.updateBeatsPreciseStart(measure);
 	}
 
 	public void moveBeats(TGMeasure measure, long start, long theMove){
 		moveBeats(getBeatsBeforeEnd(measure.getBeats(), start),theMove);
+		// refresh precise start
+		this.updateBeatsPreciseStart(measure);
 	}
 
 	/**
@@ -848,8 +852,6 @@ public class TGMeasureManager {
 		long start = beat.getStart();
 		//define new (approximative) start
 		beat.setStart(start + theMove);
-		// refresh precise start
-		this.updateBeatPreciseStart(beat);
 	}
 	private void moveBeatPrecise(TGBeat beat,long thePreciseMove){
 		long preciseStart = beat.getPreciseStart();
@@ -1730,6 +1732,11 @@ public class TGMeasureManager {
 		this.removeBeat(beat);
 	}
 
+	public void removeVoiceWithoutControl(TGVoice voice){
+		removeVoice(voice);
+		this.updateBeatsPreciseStart(voice.getBeat().getMeasure());
+	}
+	
 	public void removeVoice(TGVoice voice,boolean moveNextVoices){
 		removeVoice(voice);
 		if(moveNextVoices){
@@ -1822,6 +1829,9 @@ public class TGMeasureManager {
 			}else{
 				beat.getVoice(voiceIndex).getDuration().copyFrom( oldDuration );
 			}
+		}
+		if (getSongManager().isFreeEditionMode(measure)) {
+			this.updateBeatsPreciseStart(measure);
 		}
 	}
 

--- a/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/song/models/TGBeat.java
+++ b/common/TuxGuitar-lib/src/main/java/org/herac/tuxguitar/song/models/TGBeat.java
@@ -202,7 +202,7 @@ public abstract class TGBeat implements Comparable<TGBeat> {
 	@Override
 	public int compareTo(TGBeat beat) {
 		if (beat == null) return 1;
-		if ((this.preciseStart != null) && (beat.getPreciseStart() >= 0)) {
+		if ((this.preciseStart != null) && (beat.getPreciseStart()!= null)) {
 			return Long.valueOf(this.preciseStart).compareTo(Long.valueOf(beat.getPreciseStart()));
 		}
 		return (Long.valueOf(this.getStart()).compareTo(Long.valueOf(beat.getStart())));


### PR DESCRIPTION
see #579

TGBeat: forgot to update one test after .preciseStart defaults to null

TGMeasureManager.moveBeat: avoid concurrent modification of beats
  precise start, was throwing an exception with copy/paste measure action

TGMeasureManager.removeVoice: need to refresh beats preciseStart if action
  is done in free edition mode

TGDeleteNoteOrRestAction/TGMeasureManager.removeVoiceWithoutControl:
  specific behavior of free edition mode when deleting a rest