### PR TITLE
add chords to ascii export

### DIFF
--- a/common/TuxGuitar-ascii/src/app/tuxguitar/io/ascii/ASCIIOutputStream.java
+++ b/common/TuxGuitar-ascii/src/app/tuxguitar/io/ascii/ASCIIOutputStream.java
@@ -2,6 +2,7 @@ package app.tuxguitar.io.ascii;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import app.tuxguitar.song.models.TGChord;
 import app.tuxguitar.song.models.TGNote;
 import app.tuxguitar.song.models.effects.TGEffectBend;
 
@@ -12,6 +13,13 @@ public class ASCIIOutputStream {
 
 	public ASCIIOutputStream(PrintStream stream){
 		this.writer = new PrintWriter(stream);
+	}
+
+	public int drawChord(TGChord chord) {
+		String chordName=(chord!=null ? chord.getName() : "");
+		this.writer.print(chordName);
+		movePoint(getPosX() + chordName.length(),getPosY());
+		return chordName.length();
 	}
 
 	public int drawNote(TGNote note, TGNote nextNote, boolean printNote){
@@ -98,9 +106,15 @@ public class ASCIIOutputStream {
 		this.writer.println(s);
 	}
 
+	public void drawSpace(int numSpaces){
+		movePoint(getPosX() + numSpaces,getPosY());
+		for (int i = 0; i < numSpaces; i++) {
+			this.writer.print(' ');
+		}
+	}
+
 	public void drawSpace(){
-		movePoint(getPosX() + 1,getPosY());
-		this.writer.print(" ");
+		drawSpace(1);
 	}
 
 	private void movePoint(int x,int y){


### PR DESCRIPTION
I further extended the tuxguitar ascii export.

The ascii export includes now chord names.

The attached file [ascii-chords.zip](https://github.com/user-attachments/files/19244555/ascii-chords.zip) demonstrates the export.

The implementation has the side effect, that for multiline tabs there is an additional empty line between tabs if there are no chords at all.

The test environment was

- Ubuntu 24.04.2 LTS
- eclipse-java-2023-12-R-linux-gtk-x86_64

![2025-03-14T091622](https://github.com/user-attachments/assets/6aa5a373-200c-4cd1-a60c-929b596c57fe)

```console
   Cmaj7   Ebm6add9/5- \Gb D#m C7sus2
E|-12----|-13-------------------------|
B|-12----|-13------------------11-----|
G|-12----|-14--------------11--15-----|
D|-14----|-13--------------8---12-----|
A|-15----|-15--------------9---15-----|
E|-------|-14--------------11---------|
```
