### PR TITLE
[MusicXML] export dead note

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -232,3 +232,7 @@ Taehun Yun
 Alejandro6626
     * Spanish translation
     * Contact: https://github.com/alejandro6626
+
+Klaus Rettinghaus
+    * MusicXML export
+    * Contact: https://github.com/rettinghaus

--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -512,7 +512,6 @@ public class MusicXMLWriter{
 						this.writeDirection(parent, note);
 					}
 
-
 					Node noteNode = this.addNode(parent, "note");
 
 					int stringValue = beat.getMeasure().getTrack().getString(note.getString()).getValue();
@@ -546,6 +545,8 @@ public class MusicXMLWriter{
 					if (note.getEffect().isGhostNote()){
 						Node noteheadNode = this.addNode(noteNode, "notehead", "normal");
 						this.addAttribute(noteheadNode, "parentheses", "yes");
+					} else if (!isTablature && note.getEffect().isDeadNote()){
+						Node noteheadNode = this.addNode(noteNode, "notehead", "x");
 					}
 
 					this.addNode(noteNode, "staff", isTablature ? "2" : "1");

--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -557,7 +557,8 @@ public class MusicXMLWriter{
 					if (note.getEffect().isGhostNote()){
 						Node noteheadNode = this.addNode(noteNode, "notehead", "normal");
 						this.addAttribute(noteheadNode, "parentheses", "yes");
-					} else if (!isTablature && note.getEffect().isDeadNote()){
+					}
+					else if (!isTablature && note.getEffect().isDeadNote()){
 						Node noteheadNode = this.addNode(noteNode, "notehead", "x");
 					}
 

--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -301,6 +301,10 @@ public class MusicXMLWriter{
 			if(timeSignatureChanges){
 				this.writeTimeSignature(measureAttributes,measure.getTimeSignature());
 			}
+
+			this.addNode(measureAttributes, "staves", "2");
+			this.addNode(measureAttributes, "part-symbol", "none");
+
 			if(clefChanges){
 				this.writeClef(measureAttributes,measure.getClef(), isPercussion);
 			}

--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -519,6 +519,7 @@ public class MusicXMLWriter{
 					// write palm mute symbol as text
 					if (!isTablature && note.getEffect().isPalmMute()) {
 						Node direction = this.addAttribute(this.addNode(parent, "direction"), "placement", "above");
+						this.addAttribute(direction, "placement", "below");
 						Node directionType = this.addNode(direction, "direction-type");
 						Node words = this.addNode(directionType, "words", "P.M.");	
 					}

--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -419,7 +419,7 @@ public class MusicXMLWriter{
 		}
 	}
 
-	private void writeDirection(Node parent, TGNote note){
+	private void writeDynamics(Node parent, TGNote note){
 		Node direction = this.addAttribute(this.addNode(parent, "direction"), "placement", "above");
 		Node directionType = this.addNode(direction, "direction-type");
 		Node dynamics = this.addNode(directionType, "dynamics");
@@ -513,7 +513,14 @@ public class MusicXMLWriter{
 					int noteVelocity = note.getVelocity();
 					if (noteVelocity != lastVelocity){
 						lastVelocity = noteVelocity;
-						this.writeDirection(parent, note);
+						this.writeDynamics(parent, note);
+					}
+
+					// write palm mute symbol as text
+					if (!isTablature && note.getEffect().isPalmMute()) {
+						Node direction = this.addAttribute(this.addNode(parent, "direction"), "placement", "above");
+						Node directionType = this.addNode(direction, "direction-type");
+						Node words = this.addNode(directionType, "words", "P.M.");	
 					}
 
 					Node noteNode = this.addNode(parent, "note");

--- a/desktop/TuxGuitar/share/help/about.html
+++ b/desktop/TuxGuitar/share/help/about.html
@@ -351,6 +351,11 @@
       <li>Spanish translation</li>
       <li>Contact:&nbsp;https://github.com/alejandro6626</li>
     </ul>
+    <h4>Klaus Rettinghaus</h4>
+    <ul>
+      <li>MusicXML export</li>
+      <li>Contact:&nbsp;https://github.com/rettinghaus</li>
+    </ul>
   </section>
 </body>
 </html>


### PR DESCRIPTION
This adds export of the correct notehead for dead notes (in standard notation) and the palm mute symbol. 
Furthermore it makes the number of staves and the absence of a part symbol explicit.