### PR TITLE
don't link tied note to a rest graphically

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
@@ -585,7 +585,10 @@ public class TGNoteImpl extends TGNote {
 		for (int i = getMeasureImpl().countBeats() - 1; i >= 0; i--) {
 			TGBeat beat = getMeasureImpl().getBeat(i);
 			TGVoice voice = beat.getVoice( getVoice().getIndex() );
-			if (beat.getStart() < getBeatImpl().getStart() && !voice.isRestVoice()) {
+			if (beat.getStart() < getBeatImpl().getStart()) {
+				if (voice.isRestVoice()) {
+					return null;
+				}
 				Iterator<TGNote> it = voice.getNotes().iterator();
 				while(it.hasNext()){
 					TGNoteImpl note = (TGNoteImpl)it.next();


### PR DESCRIPTION
when one note in beat n is tied and beat n-1 is a rest, then the player does not consider note is tied to any note in beat n-2 graphically, a tie to beat n-2 was drawn
now, graphical representation is consistent with player behavior
see #698