### PR TITLE
Update Mac Workflow for aarch64

### DIFF
--- a/.github/workflows/macos-maven.yml
+++ b/.github/workflows/macos-maven.yml
@@ -39,6 +39,8 @@ jobs:
       run: mkdir swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }} && cd swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }} && unzip ../swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }}.zip && mvn install:install-file -Dfile=swt.jar -DgroupId=org.eclipse.swt -DartifactId=org.eclipse.swt.cocoa.macosx -Dpackaging=jar -Dversion=${{ env.SWT_VERSION }}
     - name: Build with Maven
       run: cd desktop/build-scripts/tuxguitar-macosx-swt-cocoa && mvn -e clean verify
+    - name: Rename app depending of arch
+      run: mv desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target/tuxguitar-9.99-SNAPSHOT-macosx-swt-cocoa.app desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target/tuxguitar-9.99-SNAPSHOT-macosx-${{ env.TUX_ARCH }}-swt-cocoa.app
     - uses: actions/upload-artifact@v4
       with:
         name: Package-MacOS-${{ matrix.os }}

--- a/.github/workflows/macos-maven.yml
+++ b/.github/workflows/macos-maven.yml
@@ -19,26 +19,30 @@ jobs:
   build-macOS:
     strategy:
       matrix:
-          os: [macos-13]
+          os: [macos-13,macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 21
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
+    - name : Set value of TUX_ARCH
+      run:  echo "TUX_ARCH=`uname -m | sed 's/arm64/aarch64/'`" >> "$GITHUB_ENV"
+    - name : Set value of SWT_VERSION
+      run:  echo "SWT_VERSION=4.33" >> "$GITHUB_ENV"
     - name : Download SWT
-      run: curl -o swt-4.33-cocoa-macosx-`uname -m`.zip https://archive.eclipse.org/eclipse/downloads/drops4/R-4.33-202409030240/swt-4.33-cocoa-macosx-`uname -m`.zip
+      run: curl -o swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }}.zip https://archive.eclipse.org/eclipse/downloads/drops4/R-4.33-202409030240/swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }}.zip
     - name : install SWT
-      run: mkdir swt-4.33-cocoa-macosx-`uname -m` && cd swt-4.33-cocoa-macosx-`uname -m` && unzip ../swt-4.33-cocoa-macosx-`uname -m`.zip && mvn install:install-file -Dfile=swt.jar -DgroupId=org.eclipse.swt -DartifactId=org.eclipse.swt.cocoa.macosx -Dpackaging=jar -Dversion=4.33
+      run: mkdir swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }} && cd swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }} && unzip ../swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }}.zip && mvn install:install-file -Dfile=swt.jar -DgroupId=org.eclipse.swt -DartifactId=org.eclipse.swt.cocoa.macosx -Dpackaging=jar -Dversion=${{ env.SWT_VERSION }}
     - name: Build with Maven
       run: cd desktop/build-scripts/tuxguitar-macosx-swt-cocoa && mvn -e clean verify
     - uses: actions/upload-artifact@v4
       with:
         name: Package-MacOS-${{ matrix.os }}
-        path: desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target/tuxguitar-9.99-SNAPSHOT-macosx-swt-cocoa.app
+        path: desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target/tuxguitar-9.99-SNAPSHOT-macosx-${{ env.TUX_ARCH }}-swt-cocoa.app
 
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive


### PR DESCRIPTION
Add support to Mac workflow to support aarch64.
Generated package test on my M3 Mac. Adding into JRE from brew openjdk works well:
$ cp -R /opt/homebrew/opt/openjdk/ Contents/MacOS/jre

Warning, launching the .app directly does not work (it ask for rosetta) but in cmd line ./tuxguitar.sh start perfectly.

I will look for the previous warning, but I prefer to publish now as it can help other searching for an aarch64 version.