### PR TITLE
fix null pointer exception

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/errors/TGMeasureErrorDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/errors/TGMeasureErrorDialog.java
@@ -169,7 +169,9 @@ public class TGMeasureErrorDialog implements TGEventListener {
 			@Override
 			public void onSelect(UISelectionEvent event) {
 				TGMeasureError err = TGMeasureErrorDialog.this.errTable.getSelectedValue();
-				TGMeasureErrorDialog.this.moveToError(err);
+				if (err != null) {
+					TGMeasureErrorDialog.this.moveToError(err);
+				}
 			}
 		});
 		errListLayout.set(errTable, UITableLayout.PACKED_HEIGHT, 120f);


### PR DESCRIPTION
when clicking in first item of measure error dialog, if caret is in a valid measure
see #723