### PR TITLE
fix measure error selection when several errors in one single measure

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/helpers/TGMeasureError.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/helpers/TGMeasureError.java
@@ -28,5 +28,12 @@ public class TGMeasureError {
 	public boolean canBeFixed() {
 		return ((this.errCode == TGMeasureManager.VOICE_TOO_LONG) || (this.errCode == TGMeasureManager.VOICE_TOO_SHORT));
 	}
+
+	public boolean isEqualTo(TGMeasureError err) {
+		if (err == null) return false;
+		return ( this.measure.equals(err.getMeasure())
+				&& (this.voiceIndex == err.getVoiceIndex())
+				&& (this.errCode == err.getErrCode()) );
+	}
 	
 }


### PR DESCRIPTION
see #723
e.g. errors in both voices 1 and 2

also:
- automatically activate voice corresponding to error when selected
- when moving caret to measure, select with higher priority the measure error associated to caret voice