### PR TITLE
fix crash when selecting an invalid measure

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/Selector.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/Selector.java
@@ -42,16 +42,21 @@ public class Selector {
 		if (initial == null || beat == null) {
 			initializeSelection(beat);
 		} else {
-			active = true;
-			if (initial.getMeasure().getNumber() < beat.getMeasure().getNumber()
-					|| initialIsEarlierInTheSameMeasure(beat)) {
-				start = initial;
-				end = beat;
-			} else {
-				start = beat;
-				end = initial;
+			if (this.beatsOrderIsConsistent(beat)) {
+				active = true;
+				if (initial.getMeasure().getNumber() < beat.getMeasure().getNumber()
+						|| initialIsEarlierInTheSameMeasure(beat)) {
+					start = initial;
+					end = beat;
+				} else {
+					start = beat;
+					end = initial;
+				}
+				this.saveState();
 			}
-			this.saveState();
+			else {
+				active = false;
+			}
 		}
 	}
 
@@ -62,6 +67,18 @@ public class Selector {
 	private boolean initialIsEarlierInTheSameMeasure(TGBeat beat) {
 		return initial.getMeasure().getNumber() == beat.getMeasure().getNumber()
 				&& initial.getStart() < beat.getStart();
+	}
+
+	private boolean beatsOrderIsConsistent(TGBeat beatToSelect) {
+		// in free edition mode, some measures may be invalid, e.g. too long
+		// in this case, some beats in a measure may have a start attribute bigger than notes in the next measure!
+		// in other words: whenever one measure is too long, the order of beats shown on score/tab is not
+		// consistent with their .start attribute
+		if ( (beatToSelect.getMeasure().getNumber() < initial.getMeasure().getNumber())
+				&& (beatToSelect.getStart() >= initial.getStart()) ) return false;
+		if ( (beatToSelect.getMeasure().getNumber() > end.getMeasure().getNumber())
+				&& (beatToSelect.getStart() <= end.getStart()) ) return false;
+		return true;
 	}
 
 	public TGBeat getInitialBeat() {


### PR DESCRIPTION
to reproduce bug:
- create a way too long measure in free edition mode
- select with click & drag from right to left, starting in the measure following the invalid one

Selection needs the beats to be ordered correctly according to their .start attribute. This is not always the case when a measure is too long

fix #733