### PR TITLE
[MusicXML] export velocity instead of visual dynamics

### DIFF
--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -510,12 +510,6 @@ public class MusicXMLWriter{
 					TGNote note = voice.getNote( n );
 					TGNote previousNoteOnString = previousNotesOnAllStrings.get(note.getString());
 
-					int noteVelocity = note.getVelocity();
-					if (noteVelocity != lastVelocity){
-						lastVelocity = noteVelocity;
-						this.writeDynamics(parent, note);
-					}
-
 					// write palm mute symbol as text
 					if (!isTablature && note.getEffect().isPalmMute()) {
 						Node direction = this.addAttribute(this.addNode(parent, "direction"), "placement", "above");
@@ -525,6 +519,8 @@ public class MusicXMLWriter{
 					}
 
 					Node noteNode = this.addNode(parent, "note");
+					float noteVelocity = note.getVelocity() / TGVelocities.DEFAULT * 100;
+					this.addAttribute(noteNode, "dynamics", Float.toString(noteVelocity));
 
 					int stringValue = beat.getMeasure().getTrack().getString(note.getString()).getValue();
 					int noteValue = note.getValue();

--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -519,7 +519,7 @@ public class MusicXMLWriter{
 					}
 
 					Node noteNode = this.addNode(parent, "note");
-					float noteVelocity = note.getVelocity() / TGVelocities.DEFAULT * 100;
+					float noteVelocity = (float) note.getVelocity() / TGVelocities.DEFAULT * 100;
 					this.addAttribute(noteNode, "dynamics", Float.toString(noteVelocity));
 
 					int stringValue = beat.getMeasure().getTrack().getString(note.getString()).getValue();


### PR DESCRIPTION
As dynamics are not "real dynamics" (see #588), they should not be exported as such. Especially because every velocity is written before every note, which doesn't make any sense within chords, and results in all dynamic symbols put on top of each other:

<img width="159" alt="imported with MuseScore" src="https://github.com/user-attachments/assets/262091fd-d894-43cb-a0d4-2470ac6b1128" />

This changes the exporter to write the velocity for every note instead of writing dynamic symols.

NB: I left the function for writing dynamics there for the case #588 will be addressed.
