### PR TITLE
Export trill beats

### DIFF
--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -765,8 +765,17 @@ public class MusicXMLWriter{
 		if (note.getEffect().isTrill()){
 			Node trillNode = this.addNode(ornamentsNode, "trill-mark");
 
-			int trillBeats = note.getEffect().getTrill().getDuration().getValue() / note.getVoice().getDuration().getValue();
-			this.addAttribute(trillNode, "beats", Integer.toString(trillBeats));
+			TGDuration noteDuration = note.getVoice().getDuration();
+			int trillBeats = note.getEffect().getTrill().getDuration().getValue() / noteDuration.getValue();
+			if (noteDuration.isDotted()){
+				trillBeats = trillBeats * 3 / 2;
+			}
+			if (noteDuration.isDoubleDotted()){
+				trillBeats = trillBeats * 7 / 4;
+			}
+			if (trillBeats > 1){
+				this.addAttribute(trillNode, "beats", Integer.toString(trillBeats));
+			}
 
 			// Default case of unison. As MusicXML only supports the following.
 			// half, unison, whole

--- a/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
+++ b/desktop/TuxGuitar-musicxml/src/app/tuxguitar/io/musicxml/MusicXMLWriter.java
@@ -765,6 +765,9 @@ public class MusicXMLWriter{
 		if (note.getEffect().isTrill()){
 			Node trillNode = this.addNode(ornamentsNode, "trill-mark");
 
+			int trillBeats = note.getEffect().getTrill().getDuration().getValue() / note.getVoice().getDuration().getValue();
+			this.addAttribute(trillNode, "beats", Integer.toString(trillBeats));
+
 			// Default case of unison. As MusicXML only supports the following.
 			// half, unison, whole
 			// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/trill-step/


### PR DESCRIPTION
This PR adds the `beats` attribute to trills in the MusicXML export.