### PR TITLE
Free edition mode, simplify multi-voices

### DIFF
--- a/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/note/TGDeleteNoteOrRestAction.java
+++ b/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/note/TGDeleteNoteOrRestAction.java
@@ -3,6 +3,7 @@ package app.tuxguitar.editor.action.note;
 import app.tuxguitar.action.TGActionContext;
 import app.tuxguitar.document.TGDocumentContextAttributes;
 import app.tuxguitar.editor.action.TGActionBase;
+import app.tuxguitar.song.managers.TGMeasureManager;
 import app.tuxguitar.song.managers.TGSongManager;
 import app.tuxguitar.song.models.TGBeat;
 import app.tuxguitar.song.models.TGMeasure;
@@ -49,12 +50,21 @@ public class TGDeleteNoteOrRestAction extends TGActionBase {
 	}
 	private void removeNote(TGActionContext context, TGMeasure measure, TGBeat beat, TGVoice voice, int string) {
 		TGSongManager songManager = getSongManager(context);
+		TGMeasureManager measureManager = songManager.getMeasureManager();
 		if (beat.isTextBeat() && beat.isRestBeat()) {
-			songManager.getMeasureManager().removeText(beat);
+			measureManager.removeText(beat);
 		} else if (voice.isRestVoice()) {
-			songManager.getMeasureManager().removeVoice(voice, true);
+			// in free edition mode, if this is the last beat and all voices are rest, delete the full beat
+			// to ease fixing invalid measures
+			if (songManager.isFreeEditionMode(measure) && beat.isRestBeat() &&
+					(measureManager.getLastBeat(measure.getBeats()) == beat)) {
+				measureManager.removeBeat(beat);
+				}
+				else {
+					measureManager.removeVoice(voice, true);
+				}
 		} else {
-			songManager.getMeasureManager().removeNote(measure, beat.getStart(), voice.getIndex(), string);
+			measureManager.removeNote(measure, beat.getStart(), voice.getIndex(), string);
 		}
 	}
 

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGMeasureManager.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGMeasureManager.java
@@ -989,14 +989,56 @@ public class TGMeasureManager {
 	// (re)compute preciseStart of all beats in measure
 	// assumption: beats start is precise enough to ensure beats can be sorted correctly
 	public void updateBeatsPreciseStart(TGMeasure measure) {
+		List<TGBeat> beatsToDelete = new ArrayList<TGBeat>();
 		Collections.sort(measure.getBeats());
-		long preciseStart = measure.getPreciseStart();
+		long voiceEnd[] = new long[TGBeat.MAX_VOICES];
+		boolean isFirstBeat = true;
 		for (TGBeat beat : measure.getBeats()) {
-			beat.setPreciseStart(preciseStart);
-			TGDuration minDuration = getMinimumDuration(beat);
-			if (minDuration != null) {
-				preciseStart += minDuration.getPreciseTime();
+			if (isFirstBeat) {
+				// align beat at measure start
+				beat.setPreciseStart(beat.getMeasure().getPreciseStart());
+				long minVoiceEnd=0;
+				for (int v=0; v<TGBeat.MAX_VOICES; v++) {
+					if (!beat.getVoice(v).isEmpty()) {
+						voiceEnd[v] = beat.getPreciseStart() + beat.getVoice(v).getDuration().getPreciseTime();
+						if ((minVoiceEnd == 0) || (voiceEnd[v] < minVoiceEnd)) {
+							minVoiceEnd = voiceEnd[v];
+						}
+					}
+				}
+				// theoretically useless: if one voice of first beat is empty, logically the voice
+				// shall be empty in the full measure. But we never know
+				for (int v=0; v<TGBeat.MAX_VOICES; v++) {
+					voiceEnd[v] = Math.max(voiceEnd[v], minVoiceEnd);
+					}
 			}
+			else {
+				// align beat left (avoid "holes")
+				long beatPreciseStart = 0;
+				for (int v=0; v<TGBeat.MAX_VOICES; v++) {
+					if (!beat.getVoice(v).isEmpty()) {
+						if ((beatPreciseStart == 0) || (voiceEnd[v] > beatPreciseStart)) {
+							beatPreciseStart = voiceEnd[v];
+						}
+					}
+				}
+				if (beatPreciseStart == 0) {
+					// empty beat?!
+					beatsToDelete.add(beat);
+				}
+				else {
+					beat.setPreciseStart(beatPreciseStart);
+					for (int v=0; v<TGBeat.MAX_VOICES; v++) {
+						if (!beat.getVoice(v).isEmpty()) {
+							voiceEnd[v] = beat.getPreciseStart() + beat.getVoice(v).getDuration().getPreciseTime();
+						}
+					}
+				}
+			}
+			isFirstBeat = false;
+		}
+		for (TGBeat beat : beatsToDelete) {
+			this.removeBeat(beat);
 		}
 	}
 

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGMeasureManager.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGMeasureManager.java
@@ -1013,7 +1013,7 @@ public class TGMeasureManager {
 					}
 			}
 			else {
-				// align beat left (avoid "holes")
+				// align beat left, avoiding conflicts ("holes" are easier to fix than overlaps)
 				long beatPreciseStart = 0;
 				for (int v=0; v<TGBeat.MAX_VOICES; v++) {
 					if (!beat.getVoice(v).isEmpty()) {


### PR DESCRIPTION
@helge17: some testing would be appreciated if you can. I hope this should simplify the management of multi-voices in free edition mode.

Basically, the idea is to prefer "holes" in a voice than overlaps. These are easier to fix, as TG tries to fill them automatically with rests, and succeeds most of the times.
With this, your test file used in #760 should look very different. Here is an illustration of the difference before/after this PR.
In this test, one note duration is increased, first in normal mode, then in freeEditionMode. Before the PR, this creates an overlap with following beat (00:09 in video). After the PR, this inserts a rest in the other voice (00:25). That should be more understandable, and easier to fix.

https://github.com/user-attachments/assets/9d320ee8-c93e-4c9f-af53-78060367a09d



This PR also includes another modification: it's now easier to fix too long measures ending with rests (just deleting the last rest now works also in multi-voices)