### PR TITLE
android workflow: remove apk

### DIFF
--- a/.github/workflows/android-gradle.yml
+++ b/.github/workflows/android-gradle.yml
@@ -28,10 +28,6 @@ jobs:
         cache: gradle
     - name: Build the app
       run: cd android/build-scripts/tuxguitar-android && ./gradlew && ./gradlew assembleRelease
-    - uses: actions/upload-artifact@v4
-      with:
-        name: Package-Android
-        path: android/build-scripts/tuxguitar-android/apk/build/outputs/apk/release/
     
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive


### PR DESCRIPTION
apk is useless, as not signed
without this, the test is sufficient to check Android app builds correctly