### PR TITLE
bug fix

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/models/TGVoice.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/models/TGVoice.java
@@ -51,6 +51,9 @@ public abstract class TGVoice {
 
 	public void setEmpty(boolean empty) {
 		this.empty = empty;
+		if (empty) {
+			this.clearNotes();
+		}
 	}
 
 	public int getDirection() {


### PR DESCRIPTION
only observed in free edition mode, but could have had other impact surprisingly, when setting a voice "empty", the list of associated notes was not cleared.
Observable consequence: erroneous undo/redo sequence after fixing a too long measure in free edition mode (#767)