### PR TITLE
[macos][audiounit] Allow customization of the soundbank

### DIFF
--- a/desktop/TuxGuitar-AudioUnit/jni/app_tuxguitar_player_impl_midiport_audiounit_MidiReceiverJNI.cpp
+++ b/desktop/TuxGuitar-AudioUnit/jni/app_tuxguitar_player_impl_midiport_audiounit_MidiReceiverJNI.cpp
@@ -79,7 +79,7 @@ class MidiPlayer
 	public:
 
 	// ----------------------------------------------------------------------------------------
-	MidiPlayer(const char* bankPath = 0)
+	MidiPlayer()
 	{
 		graph = 0;
 		__Require_noErr (result = this->createAUGraph (graph, synthUnit), ctor_home);
@@ -116,16 +116,16 @@ class MidiPlayer
 
 	OSStatus changeSoundBank(const char *bankPath) {
 		CFURLRef url = CFURLCreateFromFileSystemRepresentation(
-										kCFAllocatorDefault,
-										(const UInt8*)bankPath,
-										strlen(bankPath), false);
+									kCFAllocatorDefault,
+									(const UInt8*)bankPath,
+									strlen(bankPath), false);
 
 		// printf ("Setting Sound Bank:%s\n", bankPath);
 
 		OSStatus result = AudioUnitSetProperty(synthUnit, kMusicDeviceProperty_SoundBankURL,
-															kAudioUnitScope_Global, 0, &url, sizeof(url));
+							kAudioUnitScope_Global, 0, &url, sizeof(url));
 		CFRelease(url);
-      return result;
+		return result;
 	}
 
 	// ----------------------------------------------------------------------------------------

--- a/desktop/TuxGuitar-AudioUnit/jni/app_tuxguitar_player_impl_midiport_audiounit_MidiReceiverJNI.h
+++ b/desktop/TuxGuitar-AudioUnit/jni/app_tuxguitar_player_impl_midiport_audiounit_MidiReceiverJNI.h
@@ -41,6 +41,14 @@ JNIEXPORT void JNICALL Java_app_tuxguitar_player_impl_midiport_audiounit_MidiRec
 
 /*
  * Class:     app_tuxguitar_player_impl_midiport_alsa_MidiReceiverJNI
+ * Method:    changeSoundBank
+ * Signature: (II)V
+ */
+JNIEXPORT jint JNICALL
+Java_app_tuxguitar_player_impl_midiport_audiounit_MidiReceiverJNI_changeSoundBank(JNIEnv *, jobject, jstring);
+
+/*
+ * Class:     app_tuxguitar_player_impl_midiport_alsa_MidiReceiverJNI
  * Method:    noteOn
  * Signature: (III)V
  */

--- a/desktop/TuxGuitar-AudioUnit/pom.xml
+++ b/desktop/TuxGuitar-AudioUnit/pom.xml
@@ -37,5 +37,10 @@
 			<artifactId>tuxguitar</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar-ui-toolkit</artifactId>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/desktop/TuxGuitar-AudioUnit/share/META-INF/services/app.tuxguitar.util.plugin.TGPlugin
+++ b/desktop/TuxGuitar-AudioUnit/share/META-INF/services/app.tuxguitar.util.plugin.TGPlugin
@@ -1,1 +1,2 @@
 app.tuxguitar.player.impl.midiport.audiounit.MidiPortReaderPlugin
+app.tuxguitar.player.impl.midiport.audiounit.settings.MidiSettingsPlugin

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages.properties
@@ -1,7 +1,3 @@
-audiounit.error.unknown=AudioUnit API cannot be loaded
-audiounit.error.midi.unavailable=MIDI System is unavailable
-audiounit.error.soundbank=Soundbank Error
-audiounit.error.soundbank.unavailable=Unavailable Soundbank Error.
 audiounit.error.soundbank.custom=Failed to open custom soundbank file.
 
 audiounit.settings.title=Configuration
@@ -9,16 +5,3 @@ audiounit.settings.soundbank.tip=Soundbank Configuration
 audiounit.settings.soundbank.default=Use default soundbank
 audiounit.settings.soundbank.custom=Use custom soundbank
 audiounit.settings.soundbank-restart-message=You need to restart TuxGuitar for soundbank changes to take effect
-audiounit.settings.soundbank-error=Error will loading {0} custom soundbank, fallback to the default one
-
-audiounit.soundbank-assistant.confirm-message=You don't seem to have any soundbank installed.\nDo you want TuxGuitar to attempt to download an install one?
-
-audiounit.soundbank-assistant.select=Select one
-audiounit.soundbank-assistant.minimal=Minimal
-audiounit.soundbank-assistant.medium=Medium
-audiounit.soundbank-assistant.deluxe=Deluxe
-
-audiounit.soundbank-assistant.process.tip=This operation may take a long time, please be patience
-audiounit.soundbank-assistant.process.downloading=Downloading soundbank files
-audiounit.soundbank-assistant.process.uncompressing=Uncompressing: {0}
-audiounit.soundbank-assistant.process.installing=Installing: {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages.properties
@@ -1,0 +1,24 @@
+audiounit.error.unknown=AudioUnit API cannot be loaded
+audiounit.error.midi.unavailable=MIDI System is unavailable
+audiounit.error.soundbank=Soundbank Error
+audiounit.error.soundbank.unavailable=Unavailable Soundbank Error.
+audiounit.error.soundbank.custom=Failed to open custom soundbank file.
+
+audiounit.settings.title=Configuration
+audiounit.settings.soundbank.tip=Soundbank Configuration
+audiounit.settings.soundbank.default=Use default soundbank
+audiounit.settings.soundbank.custom=Use custom soundbank
+audiounit.settings.soundbank-restart-message=You need to restart TuxGuitar for soundbank changes to take effect
+audiounit.settings.soundbank-error=Error will loading {0} custom soundbank, fallback to the default one
+
+audiounit.soundbank-assistant.confirm-message=You don't seem to have any soundbank installed.\nDo you want TuxGuitar to attempt to download an install one?
+
+audiounit.soundbank-assistant.select=Select one
+audiounit.soundbank-assistant.minimal=Minimal
+audiounit.soundbank-assistant.medium=Medium
+audiounit.soundbank-assistant.deluxe=Deluxe
+
+audiounit.soundbank-assistant.process.tip=This operation may take a long time, please be patience
+audiounit.soundbank-assistant.process.downloading=Downloading soundbank files
+audiounit.soundbank-assistant.process.uncompressing=Uncompressing: {0}
+audiounit.soundbank-assistant.process.installing=Installing: {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_de.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_de.properties
@@ -1,0 +1,23 @@
+audiounit.error.unknown=AudioUnit API kann nicht geladen werden
+audiounit.error.midi.unavailable=MIDI ist nicht verfügbar
+audiounit.error.soundbank=Soundbank-Fehler
+audiounit.error.soundbank.unavailable=Soundbank nicht verfügbar.
+audiounit.error.soundbank.custom=Kann Soundbank-Datei nicht öffnen.
+
+audiounit.settings.title=Konfiguration
+audiounit.settings.soundbank.tip=Soundbank-Konfiguration
+audiounit.settings.soundbank.default=Standard-Soundbank verwenden
+audiounit.settings.soundbank.custom=Eigene Soundbank verwenden
+audiounit.settings.soundbank-restart-message=TuxGuitar muss neu gestartet werden, um die neue Soundbank zu laden
+
+audiounit.soundbank-assistant.confirm-message=Es scheint keine Soundbank installiert zu sein. Soll TuxGuitar versuchen, eine Soundbank herunterzuladen und zu installieren?
+
+audiounit.soundbank-assistant.select=Auswählen
+# audiounit.soundbank-assistant.minimal=
+# audiounit.soundbank-assistant.medium=
+# audiounit.soundbank-assistant.deluxe=
+
+audiounit.soundbank-assistant.process.tip=Diese Operarion kann etwas länger dauern, bitte warten
+audiounit.soundbank-assistant.process.downloading=Lade Soundbank-Dateien herunter
+audiounit.soundbank-assistant.process.uncompressing=Entpacke {0}
+audiounit.soundbank-assistant.process.installing=Installiere {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_de.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_de.properties
@@ -1,7 +1,3 @@
-audiounit.error.unknown=AudioUnit API kann nicht geladen werden
-audiounit.error.midi.unavailable=MIDI ist nicht verfügbar
-audiounit.error.soundbank=Soundbank-Fehler
-audiounit.error.soundbank.unavailable=Soundbank nicht verfügbar.
 audiounit.error.soundbank.custom=Kann Soundbank-Datei nicht öffnen.
 
 audiounit.settings.title=Konfiguration
@@ -9,15 +5,3 @@ audiounit.settings.soundbank.tip=Soundbank-Konfiguration
 audiounit.settings.soundbank.default=Standard-Soundbank verwenden
 audiounit.settings.soundbank.custom=Eigene Soundbank verwenden
 audiounit.settings.soundbank-restart-message=TuxGuitar muss neu gestartet werden, um die neue Soundbank zu laden
-
-audiounit.soundbank-assistant.confirm-message=Es scheint keine Soundbank installiert zu sein. Soll TuxGuitar versuchen, eine Soundbank herunterzuladen und zu installieren?
-
-audiounit.soundbank-assistant.select=Auswählen
-# audiounit.soundbank-assistant.minimal=
-# audiounit.soundbank-assistant.medium=
-# audiounit.soundbank-assistant.deluxe=
-
-audiounit.soundbank-assistant.process.tip=Diese Operarion kann etwas länger dauern, bitte warten
-audiounit.soundbank-assistant.process.downloading=Lade Soundbank-Dateien herunter
-audiounit.soundbank-assistant.process.uncompressing=Entpacke {0}
-audiounit.soundbank-assistant.process.installing=Installiere {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_fr.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_fr.properties
@@ -1,0 +1,24 @@
+audiounit.error.unknown=L'API de son AudioUnit ne peut être chargée
+audiounit.error.midi.unavailable=Système MIDI indisponible
+audiounit.error.soundbank=Erreur de la banque de sons
+audiounit.error.soundbank.unavailable=Erreur banque de sons indisponible.
+audiounit.error.soundbank.custom=Impossible d'ouvrir la banque de sons personnalisée.
+
+# audiounit.settings.title=
+audiounit.settings.soundbank.tip=Configuration de la banque de sons
+audiounit.settings.soundbank.default=Utiliser la banque de sons par défaut
+audiounit.settings.soundbank.custom=Utiliser la banque de sons personnalisée
+audiounit.settings.soundbank-restart-message=Vous devez redémarrer TuxGuitar pour que les modifications apportées à la banque de sons prennent effet
+audiounit.settings.soundbank-error=Erreur lors du chargement de la banque de sons personnalisée {0}, retour sur celle par défaut
+
+audiounit.soundbank-assistant.confirm-message=Il semble que vous n'ayez aucune banque de sons installée.\nVoulez-vous que TuxGuitar tente d'en télécharger et d'en installer une ?
+
+audiounit.soundbank-assistant.select=En choisir une
+audiounit.soundbank-assistant.minimal=Minimale
+audiounit.soundbank-assistant.medium=Moyenne
+# audiounit.soundbank-assistant.deluxe=
+
+audiounit.soundbank-assistant.process.tip=Cette opération peut prendre du temps, veuillez patienter
+audiounit.soundbank-assistant.process.downloading=Téléchargement de fichiers de banque de sons
+audiounit.soundbank-assistant.process.uncompressing=Décompression : {0}
+audiounit.soundbank-assistant.process.installing=Installation : {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_fr.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_fr.properties
@@ -1,24 +1,7 @@
-audiounit.error.unknown=L'API de son AudioUnit ne peut être chargée
-audiounit.error.midi.unavailable=Système MIDI indisponible
-audiounit.error.soundbank=Erreur de la banque de sons
-audiounit.error.soundbank.unavailable=Erreur banque de sons indisponible.
 audiounit.error.soundbank.custom=Impossible d'ouvrir la banque de sons personnalisée.
 
-# audiounit.settings.title=
 audiounit.settings.soundbank.tip=Configuration de la banque de sons
 audiounit.settings.soundbank.default=Utiliser la banque de sons par défaut
 audiounit.settings.soundbank.custom=Utiliser la banque de sons personnalisée
 audiounit.settings.soundbank-restart-message=Vous devez redémarrer TuxGuitar pour que les modifications apportées à la banque de sons prennent effet
-audiounit.settings.soundbank-error=Erreur lors du chargement de la banque de sons personnalisée {0}, retour sur celle par défaut
 
-audiounit.soundbank-assistant.confirm-message=Il semble que vous n'ayez aucune banque de sons installée.\nVoulez-vous que TuxGuitar tente d'en télécharger et d'en installer une ?
-
-audiounit.soundbank-assistant.select=En choisir une
-audiounit.soundbank-assistant.minimal=Minimale
-audiounit.soundbank-assistant.medium=Moyenne
-# audiounit.soundbank-assistant.deluxe=
-
-audiounit.soundbank-assistant.process.tip=Cette opération peut prendre du temps, veuillez patienter
-audiounit.soundbank-assistant.process.downloading=Téléchargement de fichiers de banque de sons
-audiounit.soundbank-assistant.process.uncompressing=Décompression : {0}
-audiounit.soundbank-assistant.process.installing=Installation : {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_it.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_it.properties
@@ -1,0 +1,23 @@
+audiounit.error.unknown=AudioUnit API non può essere caricata
+audiounit.error.midi.unavailable=Systema MIDI non disponibile
+audiounit.error.soundbank=Errore Soundbank
+audiounit.error.soundbank.unavailable=Soundbank non disponibile.
+audiounit.error.soundbank.custom=Errore durante l'apertura del file soundbank personalizzato.
+
+audiounit.settings.title=Configura
+audiounit.settings.soundbank.tip=Configurazione della soundbank
+audiounit.settings.soundbank.default=Usa la soundbank predefinita
+audiounit.settings.soundbank.custom=Usa una soundbank personalizzata
+audiounit.settings.soundbank-restart-message=Bisogna riavviare TuxGuitar perché le modifiche alle soundbank abbiano effetto
+
+audiounit.soundbank-assistant.confirm-message=Sembra che non hai installato nessuna soundbank.\nVuoi che TuxGuitar tenti di scaricarne una?
+
+audiounit.soundbank-assistant.select=Seleziona una
+# audiounit.soundbank-assistant.minimal=
+# audiounit.soundbank-assistant.medium=
+# audiounit.soundbank-assistant.deluxe=
+
+audiounit.soundbank-assistant.process.tip=Questa operazione potrebbe richiedere molto tempo, si prega di avere pazienza
+audiounit.soundbank-assistant.process.downloading=Sto per scaricare i file soundbank
+audiounit.soundbank-assistant.process.uncompressing=Sto per decomprimere {0}
+audiounit.soundbank-assistant.process.installing=Sto per installare {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_it.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_it.properties
@@ -1,7 +1,3 @@
-audiounit.error.unknown=AudioUnit API non può essere caricata
-audiounit.error.midi.unavailable=Systema MIDI non disponibile
-audiounit.error.soundbank=Errore Soundbank
-audiounit.error.soundbank.unavailable=Soundbank non disponibile.
 audiounit.error.soundbank.custom=Errore durante l'apertura del file soundbank personalizzato.
 
 audiounit.settings.title=Configura
@@ -9,15 +5,3 @@ audiounit.settings.soundbank.tip=Configurazione della soundbank
 audiounit.settings.soundbank.default=Usa la soundbank predefinita
 audiounit.settings.soundbank.custom=Usa una soundbank personalizzata
 audiounit.settings.soundbank-restart-message=Bisogna riavviare TuxGuitar perché le modifiche alle soundbank abbiano effetto
-
-audiounit.soundbank-assistant.confirm-message=Sembra che non hai installato nessuna soundbank.\nVuoi che TuxGuitar tenti di scaricarne una?
-
-audiounit.soundbank-assistant.select=Seleziona una
-# audiounit.soundbank-assistant.minimal=
-# audiounit.soundbank-assistant.medium=
-# audiounit.soundbank-assistant.deluxe=
-
-audiounit.soundbank-assistant.process.tip=Questa operazione potrebbe richiedere molto tempo, si prega di avere pazienza
-audiounit.soundbank-assistant.process.downloading=Sto per scaricare i file soundbank
-audiounit.soundbank-assistant.process.uncompressing=Sto per decomprimere {0}
-audiounit.soundbank-assistant.process.installing=Sto per installare {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_ja.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_ja.properties
@@ -1,0 +1,23 @@
+audiounit.error.unknown=AudioUnit API がロードできません
+audiounit.error.midi.unavailable=MIDI が無効です
+audiounit.error.soundbank=サウンドバンク・エラー
+audiounit.error.soundbank.unavailable=サウンドバンクが無効です
+audiounit.error.soundbank.custom=カスタム・サウンドバンクのファイルを開くことに失敗しました
+
+audiounit.settings.title=設定
+audiounit.settings.soundbank.tip=サウンドバンク設定
+audiounit.settings.soundbank.default=デフォルト・サウンドバンクを使用する
+audiounit.settings.soundbank.custom=カスタム・サウンドバンクを使用する
+audiounit.settings.soundbank-restart-message=サウンドバンク変更しエフェクトを使用するにはTuxGuitarを再起動する必要があります
+
+audiounit.soundbank-assistant.confirm-message=サウンドバンクがインストールされていないようです.\nTuxGuitarでJavaサウンドバンクのパッケージをダウンロードしますか?
+
+audiounit.soundbank-assistant.select=1つ選択
+audiounit.soundbank-assistant.minimal=最小
+audiounit.soundbank-assistant.medium=標準
+audiounit.soundbank-assistant.deluxe=最大
+
+audiounit.soundbank-assistant.process.tip=この操作には時間がかかるかもしれません.ご了承ください.
+audiounit.soundbank-assistant.process.downloading=Javaサウンドバンクをダウンロード中
+audiounit.soundbank-assistant.process.uncompressing=解凍中: {0}
+audiounit.soundbank-assistant.process.installing=インストール中: {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_ja.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_ja.properties
@@ -1,7 +1,3 @@
-audiounit.error.unknown=AudioUnit API がロードできません
-audiounit.error.midi.unavailable=MIDI が無効です
-audiounit.error.soundbank=サウンドバンク・エラー
-audiounit.error.soundbank.unavailable=サウンドバンクが無効です
 audiounit.error.soundbank.custom=カスタム・サウンドバンクのファイルを開くことに失敗しました
 
 audiounit.settings.title=設定
@@ -9,15 +5,3 @@ audiounit.settings.soundbank.tip=サウンドバンク設定
 audiounit.settings.soundbank.default=デフォルト・サウンドバンクを使用する
 audiounit.settings.soundbank.custom=カスタム・サウンドバンクを使用する
 audiounit.settings.soundbank-restart-message=サウンドバンク変更しエフェクトを使用するにはTuxGuitarを再起動する必要があります
-
-audiounit.soundbank-assistant.confirm-message=サウンドバンクがインストールされていないようです.\nTuxGuitarでJavaサウンドバンクのパッケージをダウンロードしますか?
-
-audiounit.soundbank-assistant.select=1つ選択
-audiounit.soundbank-assistant.minimal=最小
-audiounit.soundbank-assistant.medium=標準
-audiounit.soundbank-assistant.deluxe=最大
-
-audiounit.soundbank-assistant.process.tip=この操作には時間がかかるかもしれません.ご了承ください.
-audiounit.soundbank-assistant.process.downloading=Javaサウンドバンクをダウンロード中
-audiounit.soundbank-assistant.process.uncompressing=解凍中: {0}
-audiounit.soundbank-assistant.process.installing=インストール中: {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_sv.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_sv.properties
@@ -1,9 +1,5 @@
 # John Gustafsson <jamminjohn@users.sourceforge.net>, 2008.
 
-audiounit.error.unknown=AudioUnit-API kan inte läsas in
-audiounit.error.midi.unavailable=MIDI-systemet är inte åtkomligt
-audiounit.error.soundbank=Ljudbanksfel
-audiounit.error.soundbank.unavailable=Fel: Ljudbanken inte åtkomlig
 audiounit.error.soundbank.custom=Misslyckades att öppna anpassad ljudbanksfil
 
 audiounit.settings.title=Konfiguration
@@ -11,15 +7,3 @@ audiounit.settings.soundbank.tip=Konfiguration av ljudbank
 audiounit.settings.soundbank.default=Använd standardljudbank
 audiounit.settings.soundbank.custom=Använd anpassad ljudbank
 audiounit.settings.soundbank-restart-message=Du måste starta om TuxGuitar för att ljudbanksändringar skall få effekt
-
-audiounit.soundbank-assistant.confirm-message=Du verkar inte ha någon ljudbank installerad.\nVill du att TuxGuitar försöker att hämta och installera en?
-
-audiounit.soundbank-assistant.select=Välj en
-# audiounit.soundbank-assistant.minimal=
-# audiounit.soundbank-assistant.medium=
-# audiounit.soundbank-assistant.deluxe=
-
-audiounit.soundbank-assistant.process.tip=Denna åtgärd kan ta lång tid
-audiounit.soundbank-assistant.process.downloading=Hämtar ljudbanksfiler
-audiounit.soundbank-assistant.process.uncompressing=Packar upp: {0}
-audiounit.soundbank-assistant.process.installing=Installerar: {0}

--- a/desktop/TuxGuitar-AudioUnit/share/lang/messages_sv.properties
+++ b/desktop/TuxGuitar-AudioUnit/share/lang/messages_sv.properties
@@ -1,0 +1,25 @@
+# John Gustafsson <jamminjohn@users.sourceforge.net>, 2008.
+
+audiounit.error.unknown=AudioUnit-API kan inte läsas in
+audiounit.error.midi.unavailable=MIDI-systemet är inte åtkomligt
+audiounit.error.soundbank=Ljudbanksfel
+audiounit.error.soundbank.unavailable=Fel: Ljudbanken inte åtkomlig
+audiounit.error.soundbank.custom=Misslyckades att öppna anpassad ljudbanksfil
+
+audiounit.settings.title=Konfiguration
+audiounit.settings.soundbank.tip=Konfiguration av ljudbank
+audiounit.settings.soundbank.default=Använd standardljudbank
+audiounit.settings.soundbank.custom=Använd anpassad ljudbank
+audiounit.settings.soundbank-restart-message=Du måste starta om TuxGuitar för att ljudbanksändringar skall få effekt
+
+audiounit.soundbank-assistant.confirm-message=Du verkar inte ha någon ljudbank installerad.\nVill du att TuxGuitar försöker att hämta och installera en?
+
+audiounit.soundbank-assistant.select=Välj en
+# audiounit.soundbank-assistant.minimal=
+# audiounit.soundbank-assistant.medium=
+# audiounit.soundbank-assistant.deluxe=
+
+audiounit.soundbank-assistant.process.tip=Denna åtgärd kan ta lång tid
+audiounit.soundbank-assistant.process.downloading=Hämtar ljudbanksfiler
+audiounit.soundbank-assistant.process.uncompressing=Packar upp: {0}
+audiounit.soundbank-assistant.process.installing=Installerar: {0}

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiPortReaderAudioUnit.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiPortReaderAudioUnit.java
@@ -16,7 +16,6 @@ public class MidiPortReaderAudioUnit implements MidiOutputPortProvider{
 	}
 
 	public boolean setSoundbankPath(String soundbankPath) {
-		System.out.println("call change soundbank");
 		return midiOut.changeSoundBank(soundbankPath) == 0;
 	}
 

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiPortReaderAudioUnit.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiPortReaderAudioUnit.java
@@ -4,13 +4,20 @@ import java.util.List;
 
 import app.tuxguitar.player.base.MidiOutputPort;
 import app.tuxguitar.player.base.MidiOutputPortProvider;
+import app.tuxguitar.util.TGContext;
 
 public class MidiPortReaderAudioUnit implements MidiOutputPortProvider{
 
-	private static final MidiReceiverImpl midiOut = new MidiReceiverImpl();
+	private final MidiReceiverImpl midiOut;
 
-	public MidiPortReaderAudioUnit(){
+	public MidiPortReaderAudioUnit(TGContext context) {
 		super();
+		midiOut = new MidiReceiverImpl(context);
+	}
+
+	public boolean setSoundbankPath(String soundbankPath) {
+		System.out.println("call change soundbank");
+		return midiOut.changeSoundBank(soundbankPath) == 0;
 	}
 
 	public List<MidiOutputPort> listPorts() {

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiPortReaderPlugin.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiPortReaderPlugin.java
@@ -9,7 +9,7 @@ public class MidiPortReaderPlugin extends TGMidiOutputPortProviderPlugin{
 	public static final String MODULE_ID = "tuxguitar-audiounit";
 
 	protected MidiOutputPortProvider createProvider(TGContext context) {
-		return new MidiPortReaderAudioUnit();
+		return new MidiPortReaderAudioUnit(context);
 	}
 
 	public String getModuleId() {

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiReceiverImpl.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiReceiverImpl.java
@@ -3,18 +3,26 @@ package app.tuxguitar.player.impl.midiport.audiounit;
 import java.util.ArrayList;
 import java.util.List;
 
+import app.tuxguitar.app.TuxGuitar;
+import app.tuxguitar.app.util.TGMessageDialogUtil;
+import app.tuxguitar.app.view.main.TGWindow;
 import app.tuxguitar.gm.port.GMReceiver;
 import app.tuxguitar.player.base.MidiControllers;
 import app.tuxguitar.player.base.MidiOutputPort;
+import app.tuxguitar.player.impl.midiport.audiounit.utils.MidiConfigUtils;
+import app.tuxguitar.util.TGContext;
+import app.tuxguitar.util.TGExpressionResolver;
 
-public class MidiReceiverImpl extends MidiReceiverJNI implements GMReceiver{
+public class MidiReceiverImpl extends MidiReceiverJNI implements GMReceiver {
 	private boolean open; // unnecessary
-    private boolean connected;
+	private boolean connected;
 	private List<MidiOutputPort> ports;
+	private TGContext context;
 
-	public MidiReceiverImpl(){
+	public MidiReceiverImpl(TGContext context) {
 		this.ports = new ArrayList<MidiOutputPort>();
-        this.connected = false;
+		this.connected = false;
+		this.context = context;
 	}
 
 	public void open(){
@@ -38,19 +46,31 @@ public class MidiReceiverImpl extends MidiReceiverJNI implements GMReceiver{
 		return (this.isOpen() && this.connected);
 	}
 
-    public void connect(){
-        if(isOpen()){
-            if(!isConnected()){
-                this.connected = true;
-                this.openDevice();
-            }
-        }
-    }
+	public void connect() {
+		if (isOpen()) {
+			if (!isConnected()) {
+				this.connected = true;
+				this.openDevice();
+				this.changeSoundbank();
+			}
+		}
+	}
 
 	public void disconnect() {
-		if(isConnected()){
+		if (isConnected()) {
 			this.closeDevice();
 			this.connected = false;
+		}
+	}
+
+	private void changeSoundbank() {
+		String soundBankPath = MidiConfigUtils.getSoundbankPath(context);
+		String soundBank = TGExpressionResolver.getInstance(context).resolve(soundBankPath);
+		if (soundBank != null && !soundBank.isEmpty()) {
+			if (this.changeSoundBank(soundBank) != 0) {
+				TGMessageDialogUtil.errorMessage(context, TGWindow.getInstance(context).getWindow(),
+						TuxGuitar.getProperty("audiounit.settings.soundbank-error", new String[] { soundBankPath }));
+			}
 		}
 	}
 

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiReceiverImpl.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiReceiverImpl.java
@@ -69,7 +69,7 @@ public class MidiReceiverImpl extends MidiReceiverJNI implements GMReceiver {
 		if (soundBank != null && !soundBank.isEmpty()) {
 			if (this.changeSoundBank(soundBank) != 0) {
 				TGMessageDialogUtil.errorMessage(context, TGWindow.getInstance(context).getWindow(),
-						TuxGuitar.getProperty("audiounit.settings.soundbank-error", new String[] { soundBankPath }));
+						TuxGuitar.getProperty("audiounit.error.soundbank.custom"));
 			}
 		}
 	}

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiReceiverJNI.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiReceiverJNI.java
@@ -22,6 +22,8 @@ public abstract class MidiReceiverJNI{
 
 	protected native void closeDevice();
 
+	protected native int changeSoundBank(String soundbankPath);
+
 	protected native void noteOn(int channel,int note,int velocity);
 
 	protected native void noteOff(int channel,int note,int velocity);

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiReceiverJNI.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/MidiReceiverJNI.java
@@ -16,8 +16,6 @@ public abstract class MidiReceiverJNI{
 
 	protected native void close();
 
-	//protected native void findDevices();
-
 	protected native void openDevice();
 
 	protected native void closeDevice();
@@ -34,6 +32,4 @@ public abstract class MidiReceiverJNI{
 
 	protected native void pitchBend(int channel,int value);
 
-
-	//protected abstract void addDevice(String name);
 }

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/settings/MidiSettingsHandler.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/settings/MidiSettingsHandler.java
@@ -1,0 +1,19 @@
+package app.tuxguitar.player.impl.midiport.audiounit.settings;
+
+import app.tuxguitar.app.system.plugins.TGPluginSettingsHandler;
+import app.tuxguitar.player.impl.midiport.audiounit.utils.MidiConfigUtils;
+import app.tuxguitar.ui.widget.UIWindow;
+import app.tuxguitar.util.TGContext;
+
+public class MidiSettingsHandler implements TGPluginSettingsHandler {
+
+	private TGContext context;
+
+	public MidiSettingsHandler(TGContext context){
+		this.context = context;
+	}
+
+	public void openSettingsDialog(UIWindow parent) {
+		MidiConfigUtils.setupDialog(this.context, parent);
+	}
+}

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/settings/MidiSettingsPlugin.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/settings/MidiSettingsPlugin.java
@@ -1,0 +1,18 @@
+package app.tuxguitar.player.impl.midiport.audiounit.settings;
+
+import app.tuxguitar.app.system.plugins.TGPluginSettingsAdapter;
+import app.tuxguitar.app.system.plugins.TGPluginSettingsHandler;
+import app.tuxguitar.player.impl.midiport.audiounit.MidiPortReaderPlugin;
+import app.tuxguitar.util.TGContext;
+import app.tuxguitar.util.plugin.TGPluginException;
+
+public class MidiSettingsPlugin extends TGPluginSettingsAdapter {
+
+	protected TGPluginSettingsHandler createHandler(TGContext context) throws TGPluginException {
+		return new MidiSettingsHandler(context);
+	}
+
+	public String getModuleId() {
+		return MidiPortReaderPlugin.MODULE_ID;
+	}
+}

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/utils/MidiConfigUtils.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/utils/MidiConfigUtils.java
@@ -1,0 +1,145 @@
+package app.tuxguitar.player.impl.midiport.audiounit.utils;
+
+import app.tuxguitar.app.TuxGuitar;
+import app.tuxguitar.app.system.icons.TGIconManager;
+import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGFileChooser;
+import app.tuxguitar.app.util.TGMessageDialogUtil;
+import app.tuxguitar.app.view.dialog.file.TGFileChooserDialog;
+import app.tuxguitar.app.view.dialog.file.TGFileChooserHandler;
+import app.tuxguitar.app.view.util.TGDialogUtil;
+import app.tuxguitar.ui.UIFactory;
+import app.tuxguitar.ui.event.UISelectionEvent;
+import app.tuxguitar.ui.event.UISelectionListener;
+import app.tuxguitar.ui.layout.UITableLayout;
+import app.tuxguitar.ui.widget.UIButton;
+import app.tuxguitar.ui.widget.UILegendPanel;
+import app.tuxguitar.ui.widget.UIPanel;
+import app.tuxguitar.ui.widget.UIRadioButton;
+import app.tuxguitar.ui.widget.UITextField;
+import app.tuxguitar.ui.widget.UIWindow;
+import app.tuxguitar.util.TGContext;
+import app.tuxguitar.util.configuration.TGConfigManager;
+
+public class MidiConfigUtils {
+
+	public static final String SOUNDBANK_KEY = "soundbank.custom.path";
+
+	public static TGConfigManager getConfig(TGContext context){
+		return new TGConfigManager(context, "tuxguitar-audio-unit");
+	}
+
+	public static String getSoundbankPath(TGContext context){
+		return getSoundbankPath(getConfig(context));
+	}
+
+	public static String getSoundbankPath(final TGConfigManager config){
+		return config.getStringValue(SOUNDBANK_KEY);
+	}
+
+	public static void setupDialog(TGContext context, UIWindow parent) {
+		setupDialog(context, parent, getConfig(context));
+	}
+
+	public static void setupDialog(final TGContext context, final UIWindow parent, final TGConfigManager config) {
+		final String soundbank = getSoundbankPath(config);
+
+		final UIFactory uiFactory = TGApplication.getInstance(context).getFactory();
+		final UITableLayout dialogLayout = new UITableLayout();
+
+		final UIWindow dialog = uiFactory.createWindow(parent, true, false);
+		dialog.setLayout(dialogLayout);
+		dialog.setText(TuxGuitar.getProperty("audiounit.settings.title"));
+
+		//------------------SOUNDBANK-----------------------
+		UITableLayout soundbankLayout = new UITableLayout();
+		UILegendPanel soundbankGroup = uiFactory.createLegendPanel(dialog);
+		soundbankGroup.setLayout(soundbankLayout);
+		soundbankGroup.setText(TuxGuitar.getProperty("audiounit.settings.soundbank.tip"));
+		dialogLayout.set(soundbankGroup, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 400f, null, null);
+
+		final UIRadioButton sbDefault = uiFactory.createRadioButton(soundbankGroup);
+		sbDefault.setText(TuxGuitar.getProperty("audiounit.settings.soundbank.default"));
+		sbDefault.setSelected( (soundbank == null) );
+		soundbankLayout.set(sbDefault, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false, 1, 2);
+		soundbankLayout.set(sbDefault, UITableLayout.PACKED_WIDTH, 0f);
+
+		final UIRadioButton sbCustom = uiFactory.createRadioButton(soundbankGroup);
+		sbCustom.setText(TuxGuitar.getProperty("audiounit.settings.soundbank.custom"));
+		sbCustom.setSelected( (soundbank != null) );
+		soundbankLayout.set(sbCustom, 2, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false, 1, 2);
+		soundbankLayout.set(sbCustom, UITableLayout.PACKED_WIDTH, 0f);
+
+		final UITextField sbCustomPath = uiFactory.createTextField(soundbankGroup);
+		sbCustomPath.setText((soundbank == null ? new String() : soundbank));
+		sbCustomPath.setEnabled( (soundbank != null) );
+		soundbankLayout.set(sbCustomPath, 3, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, false);
+
+		final UIButton sbCustomChooser = uiFactory.createButton(soundbankGroup);
+		sbCustomChooser.setImage(TuxGuitar.getInstance().getIconManager().getImageByName(TGIconManager.FILE_OPEN));
+		sbCustomChooser.setEnabled((soundbank != null));
+		sbCustomChooser.addSelectionListener(new UISelectionListener() {
+			public void onSelect(UISelectionEvent event) {
+				TGFileChooser.getInstance(context).openChooser(new TGFileChooserHandler() {
+					public void updateFileName(String fileName) {
+						sbCustomPath.setText(fileName);
+					}
+				}, TGFileChooser.ALL_FORMATS, TGFileChooserDialog.STYLE_OPEN);
+			}
+		});
+		soundbankLayout.set(sbCustomChooser, 3, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false);
+
+		UISelectionListener sbRadioSelectionListener = new UISelectionListener() {
+			public void onSelect(UISelectionEvent event) {
+				sbCustomPath.setEnabled(sbCustom.isSelected());
+				sbCustomChooser.setEnabled(sbCustom.isSelected());
+			}
+		};
+		sbDefault.addSelectionListener(sbRadioSelectionListener);
+		sbCustom.addSelectionListener(sbRadioSelectionListener);
+
+		//------------------BUTTONS--------------------------
+		UITableLayout buttonsLayout = new UITableLayout(0f);
+		UIPanel buttons = uiFactory.createPanel(dialog, false);
+		buttons.setLayout(buttonsLayout);
+		dialogLayout.set(buttons, 2, 1, UITableLayout.ALIGN_RIGHT, UITableLayout.ALIGN_FILL, true, true);
+
+		UIButton buttonOK = uiFactory.createButton(buttons);
+		buttonOK.setText(TuxGuitar.getProperty("ok"));
+		buttonOK.setDefaultButton();
+		buttonOK.addSelectionListener(new UISelectionListener() {
+			public void onSelect(UISelectionEvent event) {
+				String selection = (sbCustom.isSelected() ? sbCustomPath.getText() : null);
+
+				boolean changed = false;
+				changed = (selection == null && soundbank != null);
+				changed = changed || (selection != null && soundbank == null);
+				changed = changed || (selection != null && !selection.equals(soundbank) ) ;
+				if(changed){
+					if(selection != null){
+						config.setValue(SOUNDBANK_KEY,selection);
+					}else{
+						config.remove(SOUNDBANK_KEY);
+					}
+					config.save();
+
+					TGMessageDialogUtil.infoMessage(context, TuxGuitar.getProperty("warning"), TuxGuitar.getProperty("audiounit.settings.soundbank-restart-message"));
+				}
+				dialog.dispose();
+			}
+		});
+		buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+
+		UIButton buttonCancel = uiFactory.createButton(buttons);
+		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
+		buttonCancel.addSelectionListener(new UISelectionListener() {
+			public void onSelect(UISelectionEvent event) {
+				dialog.dispose();
+			}
+		});
+		buttonsLayout.set(buttonCancel, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
+
+		TGDialogUtil.openDialog(dialog, TGDialogUtil.OPEN_STYLE_CENTER | TGDialogUtil.OPEN_STYLE_PACK);
+	}
+}

--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/utils/MidiConfigUtils.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/utils/MidiConfigUtils.java
@@ -1,5 +1,7 @@
 package app.tuxguitar.player.impl.midiport.audiounit.utils;
 
+import java.io.File;
+
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.ui.TGApplication;
@@ -19,6 +21,7 @@ import app.tuxguitar.ui.widget.UIRadioButton;
 import app.tuxguitar.ui.widget.UITextField;
 import app.tuxguitar.ui.widget.UIWindow;
 import app.tuxguitar.util.TGContext;
+import app.tuxguitar.util.TGExpressionResolver;
 import app.tuxguitar.util.configuration.TGConfigManager;
 
 public class MidiConfigUtils {
@@ -117,6 +120,11 @@ public class MidiConfigUtils {
 				changed = changed || (selection != null && !selection.equals(soundbank) ) ;
 				if(changed){
 					if(selection != null){
+						File soundfont = new File(TGExpressionResolver.getInstance(context).resolve(selection));
+						if(!soundfont.isFile()){
+							TGMessageDialogUtil.errorMessage(context, dialog, TuxGuitar.getProperty("audiounit.error.soundbank.custom"));
+							return;
+						}
 						config.setValue(SOUNDBANK_KEY,selection);
 					}else{
 						config.remove(SOUNDBANK_KEY);


### PR DESCRIPTION
AudioUnit support SF2 sound bank, this commit allow customization of it with tuxguitar-synth-audiounit.soundbank.path variable from tuxguitar-synth-audiounit.cfg configuration file.

In addition, small "bugfix" to call send NoteOff MIDI event during noteOff call.