### PR TITLE
workaround for a SWT issue

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/browser/main/TGBrowserDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/browser/main/TGBrowserDialog.java
@@ -213,6 +213,7 @@ public class TGBrowserDialog implements TGBrowserFactoryListener, TGBrowserConne
 					if(!isDisposed()){
 						TGBrowserDialog.this.menu.updateCollections(selection);
 						TGBrowserDialog.this.toolBar.updateCollections(selection);
+						TGBrowserDialog.this.dialog.layout();
 					}
 				}
 			});


### PR DESCRIPTION
without this, selection of a collection leads to an erroneous display of the drop-down list, plus permanent warnings sent to console.

Not really understood :(
Something unidentified triggers an erroneous update of geometry of some widgets. I don't know neither what nor why,
but forcing a re-computation of the geometry seems to solve the issue.

see #791