### PR TITLE
define supported soundfont formats independently for each plugin

### DIFF
--- a/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/utils/MidiConfigUtils.java
+++ b/desktop/TuxGuitar-AudioUnit/src/app/tuxguitar/player/impl/midiport/audiounit/utils/MidiConfigUtils.java
@@ -1,7 +1,7 @@
 package app.tuxguitar.player.impl.midiport.audiounit.utils;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
@@ -30,6 +30,10 @@ import app.tuxguitar.util.configuration.TGConfigManager;
 public class MidiConfigUtils {
 
 	public static final String SOUNDBANK_KEY = "soundbank.custom.path";
+	
+	private static final List<TGFileFormat> soundfontFormats = Arrays.asList(
+			new TGFileFormat("SoundFont SF2", "audio/x-sf2", new String[]{"sf2"}),
+			new TGFileFormat("Downloadable Sounds DLS", "audio/x-dls", new String[]{"dls"}));
 
 	public static TGConfigManager getConfig(TGContext context){
 		return new TGConfigManager(context, "tuxguitar-audio-unit");
@@ -86,11 +90,6 @@ public class MidiConfigUtils {
 		sbCustomChooser.setEnabled((soundbank != null));
 		sbCustomChooser.addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
-
-				List<TGFileFormat> soundfontFormats = new ArrayList<TGFileFormat>();
-				soundfontFormats.add(TGFileChooser.SOUNDBANK_SF2_FORMAT);
-				soundfontFormats.add(TGFileChooser.SOUNDBANK_DLS_FORMAT);
-
 				TGFileChooser.getInstance(context).openChooser(new TGFileChooserHandler() {
 					public void updateFileName(String fileName) {
 						sbCustomPath.setText(fileName);

--- a/desktop/TuxGuitar-fluidsynth/src/app/tuxguitar/player/impl/midiport/fluidsynth/MidiOutputPortSettings.java
+++ b/desktop/TuxGuitar-fluidsynth/src/app/tuxguitar/player/impl/midiport/fluidsynth/MidiOutputPortSettings.java
@@ -2,6 +2,7 @@ package app.tuxguitar.player.impl.midiport.fluidsynth;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -31,6 +32,10 @@ import app.tuxguitar.ui.widget.UITableItem;
 import app.tuxguitar.ui.widget.UIWindow;
 
 public class MidiOutputPortSettings extends MidiSettings {
+	
+	private static final List<TGFileFormat> soundfontFormats = Arrays.asList(
+			new TGFileFormat("SoundFont SF2", "audio/x-sf2", new String[]{"sf2"}),
+			new TGFileFormat("SoundFont SF3", "audio/x-sf3", new String[]{"sf3"}));
 
 	public MidiOutputPortSettings(MidiOutputPortProviderImpl provider){
 		super( provider );
@@ -72,10 +77,6 @@ public class MidiOutputPortSettings extends MidiSettings {
 		buttonAdd.setText(TuxGuitar.getProperty("add"));
 		buttonAdd.addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
-
-				List<TGFileFormat> soundfontFormats = new ArrayList<TGFileFormat>();
-				soundfontFormats.add(TGFileChooser.SOUNDBANK_SF2_FORMAT);
-				soundfontFormats.add(TGFileChooser.SOUNDBANK_SF3_FORMAT);
 
 				TGFileChooser.getInstance(getProvider().getContext()).openChooser(new TGFileChooserHandler() {
 					public void updateFileName(String file) {

--- a/desktop/TuxGuitar-jsa/src/app/tuxguitar/player/impl/jsa/utils/MidiConfigUtils.java
+++ b/desktop/TuxGuitar-jsa/src/app/tuxguitar/player/impl/jsa/utils/MidiConfigUtils.java
@@ -1,7 +1,6 @@
 package app.tuxguitar.player.impl.jsa.utils;
 
 import java.io.File;
-
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.ui.TGApplication;
@@ -10,6 +9,7 @@ import app.tuxguitar.app.util.TGMessageDialogUtil;
 import app.tuxguitar.app.view.dialog.file.TGFileChooserDialog;
 import app.tuxguitar.app.view.dialog.file.TGFileChooserHandler;
 import app.tuxguitar.app.view.util.TGDialogUtil;
+import app.tuxguitar.io.base.TGFileFormat;
 import app.tuxguitar.ui.UIFactory;
 import app.tuxguitar.ui.event.UISelectionEvent;
 import app.tuxguitar.ui.event.UISelectionListener;
@@ -27,6 +27,8 @@ import app.tuxguitar.util.configuration.TGConfigManager;
 public class MidiConfigUtils {
 
 	public static final String SOUNDBANK_KEY = "soundbank.custom.path";
+
+	private static final TGFileFormat soundfontFormat = new TGFileFormat("SoundFont SF2", "audio/x-sf2", new String[]{"sf2"});
 
 	public static TGConfigManager getConfig(TGContext context){
 		return new TGConfigManager(context, "tuxguitar-jsa");
@@ -87,7 +89,7 @@ public class MidiConfigUtils {
 					public void updateFileName(String fileName) {
 						sbCustomPath.setText(fileName);
 					}
-				}, TGFileChooser.SOUNDBANK_SF2_FORMAT, TGFileChooserDialog.STYLE_OPEN);
+				}, soundfontFormat, TGFileChooserDialog.STYLE_OPEN);
 			}
 		});
 		soundbankLayout.set(sbCustomChooser, 3, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/util/TGFileChooser.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/util/TGFileChooser.java
@@ -20,10 +20,6 @@ public class TGFileChooser {
 
 	public static final String DEFAULT_OPEN_FILENAME = null;
 
-	public static final TGFileFormat SOUNDBANK_SF2_FORMAT = new TGFileFormat("SoundFont SF2", "audio/x-sf2", new String[]{"sf2"});
-	public static final TGFileFormat SOUNDBANK_SF3_FORMAT = new TGFileFormat("SoundFont SF3", "audio/x-sf3", new String[]{"sf3"});
-	public static final TGFileFormat SOUNDBANK_DLS_FORMAT = new TGFileFormat("Downloadable Sounds DLS", "audio/x-dls", new String[]{"dls"});
-
 	public static TGFileFormat ALL_FORMATS = new TGFileFormat(TuxGuitar.getProperty("file.all-files"), "*/*", new String[]{"*"});
 
 	private TGContext context;


### PR DESCRIPTION
@helge17: this PR follows your [request](https://github.com/helge17/tuxguitar/discussions/41#discussioncomment-13565354) to review commits a93007bb47fc3618d8fb51ec49fe48b3c449dccb and bcb08dd919ae8cab008785e8e454c4291fcc8236.

I have nothing to say about the dialogs, it's fine.
Just one remark: `TGFileChooser` is a class providing generic *behavior* to manipulate files, I don't find it appropriate for the storage of *data* (especially [plugins-specific ones](https://github.com/helge17/tuxguitar/blob/01d7f6db89d7c5fabfe3815d68e11b29d8f201ad/desktop/TuxGuitar/src/app/tuxguitar/app/util/TGFileChooser.java#L23)) so we need to move the declaration of soundfont file formats elsewhere. I see 2 options, none of them being perfect:
1. create a dedicated class (in tuxguitar-lib?) to declare these 3 file formats
2. keep plugins independent of each other: each plugin defines the format(s) it can handle. With the drawback of duplicated declarations

Option 2 is my preferred one, corresponding to this PR.
What do you think?