### PR TITLE
fix issue when renaming percussion track

### DIFF
--- a/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/track/TGSetTrackInfoAction.java
+++ b/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/track/TGSetTrackInfoAction.java
@@ -28,7 +28,7 @@ public class TGSetTrackInfoAction extends TGActionBase {
 			TGColor color = ((TGColor) context.getAttribute(ATTRIBUTE_TRACK_COLOR));
 			Integer maxFret = (Integer) context.getAttribute(ATTRIBUTE_TRACK_MAXFRET);
 
-			if (maxFret == null) {
+			if ((maxFret == null) || track.isPercussion()) {
 				getSongManager(context).getTrackManager().changeInfo(track, name, color, offset);
 			} else {
 				getSongManager(context).getTrackManager().changeInfo(track, name, color, offset, maxFret);


### PR DESCRIPTION
don't consider max fret number for percussion track, or most of its content is deleted when track is renamed
fix for issue #829 