### PR TITLE
Piano octaves numering

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/piano/TGPiano.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/piano/TGPiano.java
@@ -235,6 +235,15 @@ public class TGPiano {
 				painter.setAntialias(false);
 				painter.addRectangle(x,y,NATURAL_WIDTH,NATURAL_HEIGHT);
 				painter.closePath();
+
+				// If it is a C key, the number of the octave is written. This number is the same as the one in matrix editor.
+				if ((i % 12) == 0) {
+					final int offset = -1; // offset to match the same number as matrix editor
+					int n = (i / 12) + offset;
+					if (n >= 0)
+						painter.drawString(""+n, x+3, y+2);
+				}
+
 				x += NATURAL_WIDTH;
 			}else{
 				painter.setBackground(this.config.getColorNotNatural());


### PR DESCRIPTION
I have kept my implementation unchanged as you asked.

I've tried to center the numbers as much as possible, but according to your previous picture, they seem to appear differently in Windows and Linux, and I can only adjust it for Windows. It's just a pixel, but it's noticeable in such a small space.

![PIANO_NUMEROS](https://github.com/user-attachments/assets/9e58b20f-9c84-4d36-a7d2-02ffff315ad8)

On the other hand, everything seems to indicate that I can’t request a review because I only have permissions on my fork, not on the original repository.


