### PR TITLE
fix issues when no instrument selected

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayer.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayer.java
@@ -494,18 +494,21 @@ public class MidiPlayer{
 			this.lock();
 			Map.Entry<Long, TGTempo> lastTempo = this.tempoMap.floorEntry(this.tickPosition);
 
-			return lastTempo.getValue();
+			return lastTempo == null ? null : lastTempo.getValue();
 		} finally {
 			this.unlock();
 		}
 	}
 
 	// does not consider tempo alteration defined in player mode
-	public long getCurrentTimestamp() {
+	public Long getCurrentTimestamp() {
 		try {
 			this.lock();
 			Map.Entry<Long, TGTempo> lastTempo = this.tempoMap.floorEntry(this.tickPosition);
 			Map.Entry<Long, Long> lastTimestamp = this.timestampMap.floorEntry(this.tickPosition);
+			if (lastTimestamp == null) {
+				return null;
+			}
 			long t = lastTimestamp.getValue();
 			return t + lastTempo.getValue().getTicksInMillis(this.tickPosition - lastTempo.getKey());
 		} finally {

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarItemTimeCounter.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarItemTimeCounter.java
@@ -151,7 +151,7 @@ public class TGMainToolBarItemTimeCounter extends TGMainToolBarItem implements T
 			int type = ((Integer) event.getAttribute(TGRedrawEvent.PROPERTY_REDRAW_MODE)).intValue();
 			if (type == TGRedrawEvent.PLAYING_THREAD || type == TGRedrawEvent.PLAYING_NEW_BEAT) {
 				MidiPlayer midiPlayer = MidiPlayer.getInstance(TGMainToolBarItemTimeCounter.this.context);
-				if (midiPlayer.isRunning()) {
+				if ((midiPlayer.isRunning()) && (midiPlayer.getCurrentTimestamp() != null)) {
 					long tMs = midiPlayer.getCurrentTimestamp();
 					if (tMs / 100 != this.timestamp / 100) {
 						this.redrawProcess.process();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarSectionTempo.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarSectionTempo.java
@@ -116,7 +116,7 @@ public class TGMainToolBarSectionTempo extends TGMainToolBarSection implements T
 		int tempoPercent = 100;
 
 		MidiPlayer midiPlayer = MidiPlayer.getInstance(getContext());
-		if (midiPlayer.isRunning()) {
+		if ((midiPlayer.isRunning() && (midiPlayer.getCurrentTempo() != null))) {
 			tempo = midiPlayer.getCurrentTempo();
 			tempoPercent = midiPlayer.getMode().getCurrentPercent();
 			this.tempoLabel.setIgnoreEvents(true);


### PR DESCRIPTION
see #842
to reproduce issue:
- open default template
- double-click on track to show track properties dialog
- in "Instrument" drop-down list, click "-- Select --'
- click on "Close" button
- click on "play" button in toolbar