### PR TITLE
GUI for play-when-move with two languages

### DIFF
--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -705,6 +705,7 @@ settings.config.main.window-title.var.description.songauthor=This variable repre
 settings.config.main.options=Options
 settings.config.main.table.auto-size.enabled=Enable Automatic Table resizing
 settings.config.main.splash-enabled=Launch splash screen on startup
+settings.config.main.play-when-moving=Play the beat when moving the cursor
 settings.config.styles=Styles
 settings.config.styles.general=General Styles
 settings.config.styles.printer=Printer Styles

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -562,6 +562,7 @@ settings.config.main.window-title.var.description.songauthor=Representa el autor
 settings.config.main.options=Opciones
 settings.config.main.table.auto-size.enabled=Ajustar automáticamente el tamaño de la previsualización de pistas
 settings.config.main.splash-enabled=Mostrar el splash al inicio.
+settings.config.main.play-when-moving=Reproducir el tiempo al mover el cursor
 settings.config.styles=Estilos
 settings.config.styles.general=Estilos Generales
 settings.config.styles.printer=Estilos de Impresion

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/settings/items/MainOption.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/settings/items/MainOption.java
@@ -32,6 +32,7 @@ public class MainOption extends TGSettingsOption {
 	private boolean initialized;
 	private UICheckBox showSplash;
 	private UICheckBox autoSizeTable;
+	private UICheckBox playWhenMoving;
 	private UITextField windowTitle;
 
 	public MainOption(TGSettingsEditor configEditor, UIToolBar toolBar, UILayoutContainer parent){
@@ -94,6 +95,10 @@ public class MainOption extends TGSettingsOption {
 		this.showSplash.setText(TuxGuitar.getProperty("settings.config.main.splash-enabled"));
 		optionsLayout.set(this.showSplash, 2, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
 
+		this.playWhenMoving = uiFactory.createCheckBox(options);
+		this.playWhenMoving.setText(TuxGuitar.getProperty("settings.config.main.play-when-moving"));
+		optionsLayout.set(this.playWhenMoving, 3, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
+
 		this.loadConfig();
 	}
 
@@ -103,12 +108,14 @@ public class MainOption extends TGSettingsOption {
 				final String windowTitle = getConfig().getStringValue(TGConfigKeys.WINDOW_TITLE);
 				final boolean showSplash = getConfig().getBooleanValue(TGConfigKeys.SHOW_SPLASH);
 				final boolean autoSizeTable = getConfig().getBooleanValue(TGConfigKeys.TABLE_AUTO_SIZE);
+				final boolean playWhenMoving = getConfig().getBooleanValue(TGConfigKeys.PLAY_WHEN_MOVING);
 				TGSynchronizer.getInstance(getViewContext().getContext()).executeLater(new Runnable() {
 					public void run() {
 						if(!isDisposed()){
 							MainOption.this.windowTitle.setText(windowTitle);
 							MainOption.this.showSplash.setSelected(showSplash);
 							MainOption.this.autoSizeTable.setSelected(autoSizeTable);
+							MainOption.this.playWhenMoving.setSelected(playWhenMoving);
 							MainOption.this.initialized = true;
 							MainOption.this.pack();
 						}
@@ -123,6 +130,7 @@ public class MainOption extends TGSettingsOption {
 			getConfig().setValue(TGConfigKeys.WINDOW_TITLE,this.windowTitle.getText());
 			getConfig().setValue(TGConfigKeys.SHOW_SPLASH,this.showSplash.isSelected());
 			getConfig().setValue(TGConfigKeys.TABLE_AUTO_SIZE,this.autoSizeTable.isSelected());
+			getConfig().setValue(TGConfigKeys.PLAY_WHEN_MOVING, this.playWhenMoving.isSelected());
 		}
 	}
 
@@ -131,6 +139,7 @@ public class MainOption extends TGSettingsOption {
 			getConfig().setValue(TGConfigKeys.WINDOW_TITLE, getDefaults().getValue(TGConfigKeys.WINDOW_TITLE));
 			getConfig().setValue(TGConfigKeys.SHOW_SPLASH, getDefaults().getValue(TGConfigKeys.SHOW_SPLASH));
 			getConfig().setValue(TGConfigKeys.TABLE_AUTO_SIZE, getDefaults().getValue(TGConfigKeys.TABLE_AUTO_SIZE));
+			getConfig().setValue(TGConfigKeys.PLAY_WHEN_MOVING, getDefaults().getValue(TGConfigKeys.PLAY_WHEN_MOVING));
 		}
 	}
 


### PR DESCRIPTION
I have made a GUI for play-when-moving, in case you want to add this feature to the official version.

I have added English and Spanish (because Spanish is my native language). I could try to translate the other languages using Artificial Intelligence, although I assume you already have a better way to do it.

Hope it helps.

![configure_con_playwhenmove](https://github.com/user-attachments/assets/591d1c9d-03fe-473d-9c27-3d54c7bdbc9e)
