### PR TITLE
no line break for new measures

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGSongManager.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGSongManager.java
@@ -575,6 +575,7 @@ public class TGSongManager {
 			header = getMeasureHeader(song, (number - 1)).clone(getFactory());
 			header.setStart(header.getStart() + header.getLength());
 			header.setNumber(header.getNumber() + 1);
+			header.setLineBreak(false);
 		}
 		header.setMarker(null);
 		header.setRepeatOpen(false);


### PR DESCRIPTION
fix #863

bug scenario (before this fix):
- put caret on last beat of song
- add line break to current measure
- move right with keyboard

this creates a new measure (ok), but with a line break (KO)