### PR TITLE
docs: fix links

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Contributions to this project are welcome, and you do not need to have any devel
 
 ## Test the application, suggest improvements
 
-[Issues](https://github.com/helge17/tuxguitar/issues) are used for bug reports and feature requests. Take care to read this [guideline](ISSUES.md) before creating a new issue.
+[Issues](https://github.com/helge17/tuxguitar/issues) are used for bug reports and feature requests. Take care to read this [guideline](https://github.com/helge17/tuxguitar/blob/master/docs/ISSUES.md) before creating a new issue.
 If you have questions, you need support or you want to contact the developers it's preferable to create a [discussion](https://github.com/helge17/tuxguitar/discussions).
 
 To test the application, work-in-progress *snapshots* are published quite frequently, see [releases](https://github.com/helge17/tuxguitar/releases). Try to always use the most recent snapshot, and report the issues you may get through.
@@ -26,16 +26,16 @@ Other translation files specific to Android are present, these are derived from 
 The easiest way to update one translation is probably to open the English "messages.properties" file and the corresponding file for your language side by side. Those files can be edited with any standard text editor. Every line starting with a "#" character will be ignored and the corresponding message will be displayed in English. To translate a string: add the translated text after the "=" sign, remove the leading "# " and you're done.
 
 To submit an updated translation, use the standard [GitHub process](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).
-For small fixes you can as well drop an updated (zipped) file in a [discussion](TODO).
+For small fixes you can as well drop an updated (zipped) file in a [discussion](https://github.com/helge17/tuxguitar/discussions).
 
 
 ## Contributing code
 
 TuxGuitar provides Android and desktop applications:
 
-- files specific to Android application are located in the [android](../android) folder;
-- files specific to desktop applications are located in the [desktop](../desktop) folder;
-- files common to Android and desktop applications are located in the [common](../common) folder.
+- files specific to Android application are located in the [android](https://github.com/helge17/tuxguitar/tree/master/android) folder;
+- files specific to desktop applications are located in the [desktop](https://github.com/helge17/tuxguitar/tree/master/desktop) folder;
+- files common to Android and desktop applications are located in the [common](https://github.com/helge17/tuxguitar/tree/master/common) folder.
 
 Desktop application is available in different flavors:
 
@@ -44,13 +44,13 @@ Desktop application is available in different flavors:
 
 Note: only the SWT variants are included in the official releases, JavaFX variants support is not guaranteed.
 
-Application is essentially developed in Java, however, some *native modules* can also include parts developed in another language (e.g. C). The application is built using Maven. For detailed build instructions please refer to [INSTALL.md](../INSTALL.md) file.
+Application is essentially developed in Java, however, some *native modules* can also include parts developed in another language (e.g. C). The application is built using Maven. For detailed build instructions please refer to [INSTALL.md](https://github.com/helge17/tuxguitar/blob/master/INSTALL.md) file.
 
-For each {platform, UI framework} couple, one Maven project is defined in a `pom.xml` file. All Maven projects are located in the [desktop/build-scripts](../desktop/build-scripts) folder. Each pom file defines all the successive build steps.
+For each {platform, UI framework} couple, one Maven project is defined in a `pom.xml` file. All Maven projects are located in the [desktop/build-scripts](https://github.com/helge17/tuxguitar/tree/master/desktop/build-scripts) folder. Each pom file defines all the successive build steps.
 
 Note: it should be possible to build TuxGuitar also on some other architectures, but only x86_64 architecture is supported in this repo.
 
-Refer to [IDEs](IDEs.md) for instructions to set up a development environment.
+Refer to [IDEs](https://github.com/helge17/tuxguitar/tree/master/docs/IDEs.md) for instructions to set up a development environment.
 
 ## Submit a contribution
 


### PR DESCRIPTION
GitHub displays CONTRIBUTING.md file when browsing docs/ folder AND home page,
so relative links cannot work: replace by absolute links

problem: some links in this doc will only be correct after merging in master