### PR TITLE
detect dark mode applied by TuxGuitar when app starts and adapt skin 

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -33,6 +33,7 @@ public class TGConfigDefaults{
 
 	public static void loadProperties(TGProperties properties){
 		loadProperty(properties, TGConfigKeys.SKIN, DEFAULT_SKIN);
+		loadProperty(properties, TGConfigKeys.SKIN_DARK_AUTO, true);
 		loadProperty(properties, TGConfigKeys.WINDOW_TITLE, "${appname} - ${filename}");
 		loadProperty(properties, TGConfigKeys.SHOW_SPLASH, true);
 		loadProperty(properties, TGConfigKeys.MAXIMIZED, false);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
@@ -4,6 +4,7 @@ public class TGConfigKeys {
 
 	// valid configuration key names
 	public static final String SKIN = "skin";
+	public static final String SKIN_DARK_AUTO = "skin.dark-mode.auto";
 	public static final String WINDOW_TITLE = "window.title";
 	public static final String SHOW_SPLASH = "show.splash";
 	public static final String MAXIMIZED = "window.maximized";


### PR DESCRIPTION
a user config parameter enables inhibition of the feature

This is an attempt to supersede #920.
Comparison with #920:
- it is now consistent with the light/dark theme applied by SWT (not yet tested with JFX)
- code is independent from OS and desktop (KDE/Gnome/...)

@helge17 and/or @G-eos: could you please test on macOS?