### PR TITLE
fix bug when closing transport mode dialog

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/transport/TGTransportModeDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/transport/TGTransportModeDialog.java
@@ -22,8 +22,8 @@ import app.tuxguitar.song.models.TGMeasureHeader;
 import app.tuxguitar.song.models.TGSong;
 import app.tuxguitar.song.models.TGTrack;
 import app.tuxguitar.ui.UIFactory;
-import app.tuxguitar.ui.event.UICloseEvent;
-import app.tuxguitar.ui.event.UICloseListener;
+import app.tuxguitar.ui.event.UIDisposeEvent;
+import app.tuxguitar.ui.event.UIDisposeListener;
 import app.tuxguitar.ui.event.UISelectionEvent;
 import app.tuxguitar.ui.event.UISelectionListener;
 import app.tuxguitar.ui.layout.UITableLayout;
@@ -82,9 +82,9 @@ public class TGTransportModeDialog {
 
 		dialog.setLayout(dialogLayout);
 		dialog.setText(TuxGuitar.getProperty("transport.mode"));
-		dialog.addCloseListener(new UICloseListener() {
+		dialog.addDisposeListener(new UIDisposeListener() {
 			@Override
-			public void onClose(UICloseEvent event) {
+			public void onDispose(UIDisposeEvent event) {
 				if ((TGTransportModeDialog.this.colorErr != null) && !TGTransportModeDialog.this.colorErr.isDisposed()) {
 					TGTransportModeDialog.this.colorErr.dispose();
 				}


### PR DESCRIPTION
bug: open transport mode dialog (F9) and try to close window (without using Cancel/OK), it doesn't work

bug introduced by 3669dca52c7fd51472a3f2742f4be16a5738f9b1
confusion between CloseListener and DisposeListener, fixed