### PR TITLE
allow env var to specify the compiler for audiounit jni

### DIFF
--- a/desktop/TuxGuitar-AudioUnit/jni/Makefile
+++ b/desktop/TuxGuitar-AudioUnit/jni/Makefile
@@ -1,4 +1,4 @@
-CXX = g++
+CXX ?= g++
 
 INCLUDES = -I ../../build-scripts/native-modules/common-include/
 


### PR DESCRIPTION
this is needed for nix on darwin when only clang toolchain is in path and there is no g++