### PR TITLE
android: fix count-in and metronome

### DIFF
--- a/android/TuxGuitar-android/src/app/tuxguitar/android/action/listener/cache/controller/TGUpdateLoadedSongController.java
+++ b/android/TuxGuitar-android/src/app/tuxguitar/android/action/listener/cache/controller/TGUpdateLoadedSongController.java
@@ -1,8 +1,11 @@
 package app.tuxguitar.android.action.listener.cache.controller;
 
 import app.tuxguitar.action.TGActionContext;
+import app.tuxguitar.document.TGDocumentContextAttributes;
 import app.tuxguitar.editor.undo.TGUndoableManager;
 import app.tuxguitar.player.base.MidiPlayer;
+import app.tuxguitar.song.managers.TGSongManager;
+import app.tuxguitar.song.models.TGSong;
 import app.tuxguitar.util.TGContext;
 
 public class TGUpdateLoadedSongController extends TGUpdateItemsController {
@@ -19,6 +22,16 @@ public class TGUpdateLoadedSongController extends TGUpdateItemsController {
 		midiPlayer.resetChannels();
 
 		TGUndoableManager.getInstance(context).discardAllEdits();
+
+		// Ensure percussion channel, required for features like metronome and count down
+		TGSongManager mgr = actionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SONG_MANAGER);
+		if (mgr != null) {
+			TGSong song = actionContext.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_SONG);
+			if (song != null) {
+				mgr.ensurePercussionChannel(song);
+			}
+		}
+
 
 		this.findUpdateBuffer(context).requestUpdateLoadedSong();
 


### PR DESCRIPTION
were inactive when a gp file was loaded without any percussion track (#943)