### PR TITLE
adaptation to some (weird) gp files: markers

### DIFF
--- a/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentReader.java
+++ b/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentReader.java
@@ -276,7 +276,7 @@ public class GPXDocumentReader {
 					masterBar.setAlternateEndings(getChildNodeIntegerContentArray(masterBarNode, "AlternateEndings"));
 					Node sectionNode = getChildNode(masterBarNode, "Section");
 					if (sectionNode != null) {
-						masterBar.setMarkerText(getChildNodeContent(sectionNode, "Text"));
+						masterBar.setMarkerText(getChildNodeContent(sectionNode, "Text").replace("\n","").trim());
 					}
 
 					this.gpxDocument.getMasterBars().add( masterBar );


### PR DESCRIPTION
see #923
some .gp files produced by songsterr have line breaks in marker names :(
similar to f9e51d927f2ba0993903766db7b12f93146ec870