### PR TITLE
windows/SWT: exclude scrollbars from display area

### DIFF
--- a/desktop/TuxGuitar-ui-toolkit/src/app/tuxguitar/ui/widget/UIScrollBar.java
+++ b/desktop/TuxGuitar-ui-toolkit/src/app/tuxguitar/ui/widget/UIScrollBar.java
@@ -33,4 +33,6 @@ public interface UIScrollBar extends UIComponent {
 	void removeSelectionListener(UISelectionListener listener);
 
 	void setVisible(boolean visible);
+
+	boolean isVisible();
 }

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -147,6 +147,8 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.STYLE_LINE_WIDTHS, new float[] {0f, 1f, 2f, 3f, 4f, 5f});
 		loadProperty(properties, TGConfigKeys.STYLE_DURATION_WIDTHS, new float[] {30f, 25f, 21f, 20f, 19f,18f});
 
+		loadProperty(properties, TGConfigKeys.DISPLAY_EXCLUDE_SCROLLBARS, false);
+
 		loadProperty(properties, TGConfigKeys.HOMEPAGE_URL, "https://tuxguitar.app");
 		loadProperty(properties, TGConfigKeys.CONFIG_APP_VERSION, "");
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
@@ -119,6 +119,8 @@ public class TGConfigKeys {
 	public static final String STYLE_LINE_WIDTHS = "style.lineWidths";
 	public static final String STYLE_DURATION_WIDTHS = "style.durationWidths";
 
+	public static final String DISPLAY_EXCLUDE_SCROLLBARS = "display.exclude-scrollbars";
+
 	public static final String HOMEPAGE_URL = "homepage.url";
 	public static final String CONFIG_APP_VERSION = "config.app.version";
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/Tablature.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/Tablature.java
@@ -29,6 +29,7 @@ import app.tuxguitar.song.models.TGSong;
 import app.tuxguitar.ui.resource.UIPainter;
 import app.tuxguitar.ui.resource.UIRectangle;
 import app.tuxguitar.ui.resource.UIResourceFactory;
+import app.tuxguitar.ui.resource.UISize;
 import app.tuxguitar.util.TGBeatRange;
 import app.tuxguitar.util.TGContext;
 import app.tuxguitar.util.TGNoteRange;
@@ -85,9 +86,13 @@ public class Tablature implements TGController {
 		this.caret.update(1, TGDuration.QUARTER_TIME, 1);
 	}
 
-	public void paintTablature(UIPainter painter, UIRectangle area, float fromX, float fromY){
+	public void paintTablature(UIPainter painter, UIRectangle area, float fromX, float fromY, float marginRight, float marginBottom){
 		this.getViewLayout().fillBackground(painter, area);
-		this.getViewLayout().paint(painter, area, fromX, fromY);
+		UIRectangle availableArea = area.clone();
+		UISize availableAreaSize = availableArea.getSize();
+		availableAreaSize.setWidth(availableAreaSize.getWidth() - marginRight);
+		availableAreaSize.setHeight(availableAreaSize.getHeight() - marginBottom);
+		this.getViewLayout().paint(painter, availableArea, fromX, fromY);
 		this.getCaret().paintCaret(this.getViewLayout(), painter);
 		this.getEditorKit().paintSelection(this.getViewLayout(), painter);
 		this.getSelector().paintSelectedArea(this.getViewLayout(), painter);

--- a/desktop/build-scripts/tuxguitar-windows-jfx-x86_64/dist/tuxguitar.cfg
+++ b/desktop/build-scripts/tuxguitar-windows-jfx-x86_64/dist/tuxguitar.cfg
@@ -1,2 +1,2 @@
-# Non-default settings for Windows
+# Non-default settings for Windows JFX configuration
 font.main-toolbar.timestamp=Courier,18.0,false,false

--- a/desktop/build-scripts/tuxguitar-windows-jfx-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-windows-jfx-x86_64/pom.xml
@@ -372,6 +372,9 @@
 								<copy todir="${project.build.directory}/${project.finalName}" overwrite="true">
 									<fileset dir="../common-resources/common-windows" />
 								</copy>
+								<copy todir="${project.build.directory}/${project.finalName}/dist" overwrite="true">
+									<fileset dir="./dist/" />
+								</copy>
 							</target>
 						</configuration>
 						<goals>

--- a/desktop/build-scripts/tuxguitar-windows-swt-x86_64/dist/tuxguitar.cfg
+++ b/desktop/build-scripts/tuxguitar-windows-swt-x86_64/dist/tuxguitar.cfg
@@ -1,0 +1,3 @@
+# Non-default settings for Windows SWT configuration
+font.main-toolbar.timestamp=Courier,18.0,false,false
+display.exclude-scrollbars=true

--- a/desktop/build-scripts/tuxguitar-windows-swt-x86_64/pom.xml
+++ b/desktop/build-scripts/tuxguitar-windows-swt-x86_64/pom.xml
@@ -353,6 +353,9 @@
 								<copy todir="${project.build.directory}/${project.finalName}" overwrite="true">
 									<fileset dir="../common-resources/common-windows" />
 								</copy>
+								<copy todir="${project.build.directory}/${project.finalName}/dist" overwrite="true">
+									<fileset dir="./dist/" />
+								</copy>
 							</target>
 						</configuration>
 						<goals>


### PR DESCRIPTION
#966

Avoid coupling between vertical and horizontal canvas sizes
Before this fix:
- start with a tab just high enough to fill the full canvas but not high enough to show vertical scrollbar
- increase vertical size of tab (e.g. add a note on last line)
- this makes the vertical scrollbar appear
- this reduces horizontal size of canvas (windows/SWT-specific)
- measures may move from one line to another
- this can reduce tablature height
If, at this stage, the vertical scrollbar is not needed any more, then the canvas horizontal size changes again
... and it can permanently oscillate

note: this specific handling of scrollbars is limited to windows/SWT
It's not applicable for Windows/JFX, where display area size is NOT impacted by scrollbars visibility status
Drawback: no more common config file for the 2 windows variants
could not find any simpler solution :(