### PR TITLE
readme: clarify license

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TuxGuitar is an open source multitrack tablature editor and player written in Ja
 
 ## License
 
-TuxGuitar is released under the GNU Lesser General Public License.
+TuxGuitar is released under the GNU Lesser General Public License v2.1 only
 
 Copyright (C) 2005-2022 Julián Casadesús
               2023-2025 guiv42, helge17


### PR DESCRIPTION
the sourceforge website says lgplv2.0 while LICENSE in src tar.gz says lgpl 2.1

https://sourceforge.net/projects/tuxguitar/

https://sourceforge.net/projects/tuxguitar/files/TuxGuitar/TuxGuitar-1.5.6/tuxguitar-1.5.6-src.tar.gz/download

I guess lgpl v2.1 was the intention.

