### PR TITLE
feat(#986): Tuning name in PDF export, print preview and print

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/print/TGPrintLayout.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/print/TGPrintLayout.java
@@ -11,12 +11,14 @@ import app.tuxguitar.graphics.control.TGMeasureImpl;
 import app.tuxguitar.graphics.control.TGTrackImpl;
 import app.tuxguitar.graphics.control.TGTrackSpacing;
 import app.tuxguitar.song.models.TGMeasureHeader;
+import app.tuxguitar.song.models.TGString;
 import app.tuxguitar.song.models.TGTrack;
 import app.tuxguitar.ui.resource.UIFont;
 import app.tuxguitar.ui.resource.UIPainter;
 import app.tuxguitar.ui.resource.UIRectangle;
 import app.tuxguitar.ui.resource.UIResourceFactory;
 import app.tuxguitar.util.TGMessagesManager;
+import app.tuxguitar.util.TGMusicKeyUtils;
 
 public class TGPrintLayout extends TGLayout {
 
@@ -227,8 +229,42 @@ public class TGPrintLayout extends TGLayout {
 				);
 				headerOffset += 20.0f * getScale();
 			}
+
+			if (!track.isPercussion()) {
+				String tuningLabel = getStringsTuningLabel(track);
+				if (tuningLabel != null && !tuningLabel.isEmpty()) {
+					String tuningLine = TGMessagesManager.getProperty("tuning") + ": " + tuningLabel;
+					painter.setFont(getTrackNameFont());
+					painter.drawString(
+						tuningLine,
+						x,
+						fmTopLine + y + Math.round(headerOffset)
+					);
+					headerOffset += 20.0f * getScale();
+				}
+			}
 		}
 		return headerOffset;
+	}
+
+	private String getStringsTuningLabel(TGTrack track) {
+		List<TGString> strings = track.getStrings();
+		if (strings == null || strings.isEmpty()) {
+			return null;
+		}
+		// print strings from highest string number (lowest pitch) to lowest string number (highest pitch)
+		StringBuilder label = new StringBuilder();
+		for (int i = strings.size() - 1; i >= 0; i--) {
+			TGString string = strings.get(i);
+			String noteName = TGMusicKeyUtils.sharpNoteName(string.getValue());
+			if (noteName != null && !noteName.isEmpty()) {
+				if (label.length() > 0) {
+					label.append(' ');
+				}
+				label.append(noteName);
+			}
+		}
+		return label.toString();
 	}
 
 	private void paintFooter(UIPainter painter){


### PR DESCRIPTION
- `app.tuxguitar.song.helpers.tuning.TuningManager` is responsible for setting a correct tuning name for specific track and also for getting default tuning name (tuning with top priority in tunings.xml file)
- because `TuningManager` is used by `TGSongManager` and transitively by `TGDocumentManager` and they did not have a `TGContext` reference, I must have propagated the `TGContext` throughout constructors on many places to be always present. This makes this dependency explicit and clean and won't cause any bugs with missing context
- tuning name is set when a new song or track is created (default tuning name is applied), or a song is loaded from a file

Examples (exported PDFs):
<img width="822" height="290" alt="image" src="https://github.com/user-attachments/assets/2eb48ac7-1d06-44d3-a8d2-dc0f0379f78b" />
<img width="441" height="263" alt="image" src="https://github.com/user-attachments/assets/2f443056-cbb0-4694-9d27-d266583a4073" />

