### PR TITLE
Jack: option to strip PC events for exclusive ports

### DIFF
--- a/desktop/TuxGuitar-jack-ui/share/lang/messages.properties
+++ b/desktop/TuxGuitar-jack-ui/share/lang/messages.properties
@@ -6,6 +6,7 @@ jack.settings.channel.gm.channel.label-2=Effect Channel
 jack.settings.channel.gm.channel.value-1=CH #{0}
 jack.settings.channel.gm.channel.value-2=EC #{0}
 jack.settings.channel.exclusive.port=Exclusive Jack Port
+jack.settings.channel.strip-pc=Strip all Program Change midi events
 
 # Tools -> Jack Console
 jack.console.title=Jack Console

--- a/desktop/TuxGuitar-jack-ui/share/lang/messages_de.properties
+++ b/desktop/TuxGuitar-jack-ui/share/lang/messages_de.properties
@@ -6,6 +6,7 @@ jack.settings.channel.gm.channel.label-2=Effektkanal
 # jack.settings.channel.gm.channel.value-1=
 # jack.settings.channel.gm.channel.value-2=
 jack.settings.channel.exclusive.port=Exklusiver Jack-Port
+# jack.settings.channel.strip-pc=
 
 # Tools -> Jack Console
 jack.console.title=Jack-Konsole

--- a/desktop/TuxGuitar-jack-ui/share/lang/messages_es.properties
+++ b/desktop/TuxGuitar-jack-ui/share/lang/messages_es.properties
@@ -6,6 +6,7 @@ jack.settings.channel.gm.channel.label-2=Canal de Efectos
 jack.settings.channel.gm.channel.value-1=CN #{0}
 jack.settings.channel.gm.channel.value-2=CE #{0}
 jack.settings.channel.exclusive.port=Puerto Jack Exclusivo
+# jack.settings.channel.strip-pc=
 
 # Tools -> Jack Console
 # jack.console.title=

--- a/desktop/TuxGuitar-jack-ui/share/lang/messages_fr.properties
+++ b/desktop/TuxGuitar-jack-ui/share/lang/messages_fr.properties
@@ -6,6 +6,7 @@ jack.settings.channel.gm.channel.label-2=Canal avec effets
 # jack.settings.channel.gm.channel.value-1=
 # jack.settings.channel.gm.channel.value-2=
 jack.settings.channel.exclusive.port=Port Jack exclusif
+jack.settings.channel.strip-pc=Exclure les événements midi Program Change
 
 # Tools -> Jack Console
 jack.console.title=Console Jack

--- a/desktop/TuxGuitar-jack-ui/share/lang/messages_it.properties
+++ b/desktop/TuxGuitar-jack-ui/share/lang/messages_it.properties
@@ -6,6 +6,7 @@ jack.settings.channel.gm.channel.label-2=Canale effetti
 # jack.settings.channel.gm.channel.value-1=
 # jack.settings.channel.gm.channel.value-2=
 jack.settings.channel.exclusive.port=Porta Jack esclusiva
+# jack.settings.channel.strip-pc=
 
 # Tools -> Jack Console
 jack.console.title=Console Jack

--- a/desktop/TuxGuitar-jack-ui/share/lang/messages_zh_CN.properties
+++ b/desktop/TuxGuitar-jack-ui/share/lang/messages_zh_CN.properties
@@ -6,6 +6,7 @@ jack.settings.channel.gm.channel.label-2=效果通道
 # jack.settings.channel.gm.channel.value-1=
 # jack.settings.channel.gm.channel.value-2=
 jack.settings.channel.exclusive.port=单独插孔端口
+# jack.settings.channel.strip-pc=
 
 # Tools -> Jack Console
 jack.console.title=插孔控制台

--- a/desktop/TuxGuitar-jack/src/app/tuxguitar/jack/synthesizer/JackChannelParameter.java
+++ b/desktop/TuxGuitar-jack/src/app/tuxguitar/jack/synthesizer/JackChannelParameter.java
@@ -5,5 +5,6 @@ public final class JackChannelParameter {
 	public static final String PARAMETER_EXCLUSIVE_PORT = "jack-port-exclusive";
 	public static final String PARAMETER_GM_CHANNEL_1 = "gm-channel-1";
 	public static final String PARAMETER_GM_CHANNEL_2 = "gm-channel-2";
+	public static final String PARAMETER_STRIP_PC = "jack-strip-pc";
 
 }

--- a/desktop/TuxGuitar-jack/src/app/tuxguitar/jack/synthesizer/JackChannelProxy.java
+++ b/desktop/TuxGuitar-jack/src/app/tuxguitar/jack/synthesizer/JackChannelProxy.java
@@ -11,6 +11,7 @@ public class JackChannelProxy implements MidiChannel {
 	private JackPort jackPort;
 	private MidiChannel midiChannel;
 	private boolean exclusive;
+	private boolean stripPC;
 
 	public JackChannelProxy(int jackChannelId, JackSynthesizer jackSynthesizer) {
 		this.jackChannelId = jackChannelId;
@@ -36,7 +37,7 @@ public class JackChannelProxy implements MidiChannel {
 	}
 
 	public void sendProgramChange(int value) throws MidiPlayerException {
-		if( this.midiChannel != null ){
+		if( (this.midiChannel != null) && !this.stripPC ){
 			this.midiChannel.sendProgramChange(value);
 		}
 	}
@@ -59,6 +60,8 @@ public class JackChannelProxy implements MidiChannel {
 			if( this.exclusive != exclusive ){
 				this.jackSynthesizer.openChannel(getJackChannelId(), exclusive);
 			}
+		} else if (JackChannelParameter.PARAMETER_STRIP_PC.equals(key)) {
+			this.stripPC = Boolean.TRUE.toString().equals(value);
 		} else if( this.midiChannel != null ){
 			this.midiChannel.sendParameter(key, value);
 		}
@@ -91,4 +94,5 @@ public class JackChannelProxy implements MidiChannel {
 	public void setExclusive(boolean exclusive) {
 		this.exclusive = exclusive;
 	}
+
 }


### PR DESCRIPTION
and make specified channels for exclusive ports remanent (they were overwritten when channels settings dialog was opened)
see #769 