### PR TITLE
fix update of loop start/end

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/installer/TGActionConfigMap.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/installer/TGActionConfigMap.java
@@ -549,7 +549,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		this.map(TGTransportStopAction.NAME, LOCKABLE | SHORTCUT);
 		this.map(TGTransportMetronomeAction.NAME, LOCKABLE | SHORTCUT);
 		this.map(TGTransportCountDownAction.NAME, LOCKABLE | SHORTCUT);
-		this.map(TGTransportModeAction.NAME, LOCKABLE);
+		this.map(TGTransportModeAction.NAME, LOCKABLE, UPDATE_SONG_CTL);
 		this.map(TGTransportSetLoopSHeaderAction.NAME, LOCKABLE | SHORTCUT);
 		this.map(TGTransportSetLoopEHeaderAction.NAME, LOCKABLE | SHORTCUT);
 


### PR DESCRIPTION
was moved to buffered measure by 687fd42391e309d50369d0e3038e7cc03dd92dac for performance optimization when scrolling, but buffer was not systematically refreshed when transport mode changed
see #997