### PR TITLE
fix Jack sequencer

### DIFF
--- a/desktop/TuxGuitar-jack/src/app/tuxguitar/jack/sequencer/JackSequencer.java
+++ b/desktop/TuxGuitar-jack/src/app/tuxguitar/jack/sequencer/JackSequencer.java
@@ -75,7 +75,6 @@ public class JackSequencer implements MidiSequencer{
 	}
 
 	public void setTickPosition(long tickPosition, boolean transportUpdate ){
-		this.reset = true;
 		this.jackTickController.setTick(tickPosition , transportUpdate);
 	}
 
@@ -104,6 +103,7 @@ public class JackSequencer implements MidiSequencer{
 	}
 
 	public void start() throws MidiPlayerException{
+		this.reset = true;
 		this.start( true );
 	}
 


### PR DESCRIPTION
I don't understand why sequencer was reset each time tick position was updated
This triggered the transmission of CC and PitchBend events every 20ms

should be fixed now (see #401)