### PR TITLE
improve duration allocation when importing midi

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/models/TGDuration.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/models/TGDuration.java
@@ -161,18 +161,10 @@ public abstract class TGDuration implements Comparable<TGDuration> {
  */
 	
 	public static List<TGDuration> splitPreciseDuration(long timeToSplit, long max, TGFactory factory) {
-		return splitPreciseDuration(timeToSplit, max, factory, null, null, false);
+		return splitPreciseDuration(timeToSplit, max, factory, null, null);
 	}
 	public static List<TGDuration> splitPreciseDuration(long timeToSplit, long max, TGFactory factory,
 			Integer maxDurationValue, Integer maxDivision) {
-		return splitPreciseDuration(timeToSplit, max, factory, maxDurationValue, maxDivision, false);
-	}
-	public static List<TGDuration> splitPreciseDurationApproximately(long timeToSplit, long max, TGFactory factory,
-			Integer maxDurationValue, Integer maxDivision) {
-		return splitPreciseDuration(timeToSplit, max, factory, maxDurationValue, maxDivision, true);
-	}
-	private static List<TGDuration> splitPreciseDuration(long timeToSplit, long max, TGFactory factory,
-			Integer maxDurationValue, Integer maxDivision, boolean approximate) {
 
 		long D = timeToSplit;
 		List<TGDuration> list = new ArrayList<TGDuration>();
@@ -222,19 +214,10 @@ public abstract class TGDuration implements Comparable<TGDuration> {
 						}
 					}
 					// if the amount of time to subtract removes the contribution of time division, then let's go
-					if ((approximate || (toSubtract % base == 0)) && (toSubtract <= D)) {
-						long nBase;
+					if ((toSubtract % base == 0) && (toSubtract <= D)) {
+						// number of occurrences of base duration
+						long nBase = toSubtract / base;
 						long n = 1;
-						if (approximate) {
-							// number of occurrences of base duration (rounded)
-							// apply -1 offset, because Math.round(1.5)==2, and 1 is preferred
-							// (better a bit too short than too long)
-							nBase = Math.round((float)(toSubtract-1) / (float)base);
-						}
-						else {
-							// number of occurrences of base duration
-							nBase = toSubtract / base;
-						}
 						// merge powers of 2
 						while ((nBase != 0) && (nBase % 2 == 0) && (n*2*base <= max)) {
 							n *= 2;
@@ -286,10 +269,87 @@ public abstract class TGDuration implements Comparable<TGDuration> {
 				}
 			}
 		}
-		if (!approximate && (D != 0)) {
+		if (D != 0) {
 			return null;
 		}
 		return list;
+	}
+
+	public static List<TGDuration> splitPreciseDurationApproximately(long timeToSplit, long max, TGFactory factory,
+			Integer maxDurationValue, Integer maxDivision) {
+
+		if (timeToSplit == 0) {
+			return new ArrayList<TGDuration>();
+		}
+		long shortest = (maxDurationValue == null ? TGDuration.SHORTEST : maxDurationValue);
+
+		// look for a single duration with an acceptable error
+		long bestError = -1;
+		TGDuration bestDuration = null;
+		for (TGDuration d : durationMap.values()) {
+			// exclude double-dotted: purely arbitrary criterion
+			if ((d.getValue() <= shortest) && ((maxDivision == null) || (d.getDivision().getEnters() <= maxDivision)) && !d.isDoubleDotted()) {
+				long maxError = TGDuration.WHOLE_PRECISE_DURATION * d.getDivision().getTimes() / shortest / d.getDivision().getEnters() / 2;
+				long error = Math.abs(d.getPreciseTime() - timeToSplit);
+				if ((error <= maxError) &&
+						((bestError < 0) || (error < bestError) || ((error == bestError) && (!d.isDotted())))) {
+					bestDuration = d;
+					bestError = error;
+				}
+			}
+		}
+		if (bestDuration != null) {
+			// found
+			List<TGDuration> list = new ArrayList<TGDuration>();
+			list.add(bestDuration.clone(factory));
+			return(list);
+		}
+
+		// if no single duration found, try a combination of several
+		List<TGDuration> bestList = null;
+		bestError = 0;
+
+		// max: power of 2, no longer than a whole
+		max = Math.min(max, TGDuration.WHOLE_PRECISE_DURATION);
+		long maxBase = TGDuration.WHOLE_PRECISE_DURATION;
+		while (max < maxBase) {
+			maxBase /= 2;
+		}
+		// look for all division types, starting with longest divisions, except excluded ones
+		for (TGDivisionType dt : divisionTypes) {
+			if ((maxDivision == null) || (dt.getEnters() <= maxDivision)) {
+				List<TGDuration> list = new ArrayList<TGDuration>();
+				if ((maxDivision==null || dt.getEnters()<=maxDivision)) {
+					long base = TGDuration.WHOLE_PRECISE_DURATION * dt.getTimes() / (dt.getEnters() * shortest);  // shortest possible duration for this time division
+					if (base > maxBase)  {
+						break;
+					}
+					// number of occurrences of base duration (rounded)
+					// apply -1 offset, because Math.round(1.5)==2, and 1 is preferred
+					// (better a bit too short than too long)
+					long nBase = Math.round((float)(timeToSplit-1) / (float)base);
+					long n = 1;
+					// merge powers of 2
+					while ((nBase != 0) && (nBase % 2 == 0) && (n*2*base <= max)) {
+						n *= 2;
+						nBase /= 2;
+					}
+					long listPreciseDuration = 0;
+					for (int i=0; i<nBase; i++) {
+						TGDuration duration = factory.newDuration();
+						duration.setPreciseValue(n* base);
+						list.add(duration);
+						listPreciseDuration += duration.getPreciseTime();
+					}
+					long error = Math.abs(timeToSplit - listPreciseDuration);
+					if ((bestList == null) || (error <= bestError)) {
+						bestList = list;
+						bestError = error;
+					}
+				}
+		}
+		}
+		return bestList;
 	}
 
 	private static long gcd(long a, long b) {

--- a/common/TuxGuitar-lib/src/test/java/app/tuxguitar/song/models/TestTGDuration.java
+++ b/common/TuxGuitar-lib/src/test/java/app/tuxguitar/song/models/TestTGDuration.java
@@ -291,18 +291,24 @@ public class TestTGDuration {
 		sum = getListSumDuration(list, null);
 		assertEquals(sum, toSplit);
 
+	}
+
+	@Test
+	public void testSplitApproximately() {
+		// triplet 16th
+		long toSplit = TGDuration.WHOLE_PRECISE_DURATION*2/3/16;
 		// limit division to 3, and value to 16, to avoid getting 3 * 9-tuplet of 64th
-		list = TGDuration.splitPreciseDuration(toSplit, TGDuration.WHOLE_PRECISE_DURATION, factory,
+		List<TGDuration> list = TGDuration.splitPreciseDurationApproximately(toSplit, TGDuration.WHOLE_PRECISE_DURATION, factory,
 				16, 3);
 		assertNotNull(list);
-		sum = getListSumDuration(list, null);
+		long sum = getListSumDuration(list, null);
 		assertEquals(sum, toSplit);
 		for (TGDuration d : list) {
 			assertTrue(d.getDivision().getEnters() <= 3);
 		}
 
 		// limit division to 3, and value to 32, should give the same result
-		list = TGDuration.splitPreciseDuration(toSplit, TGDuration.WHOLE_PRECISE_DURATION, factory,
+		list = TGDuration.splitPreciseDurationApproximately(toSplit, TGDuration.WHOLE_PRECISE_DURATION, factory,
 				32, 3);
 		assertNotNull(list);
 		sum = getListSumDuration(list, null);
@@ -310,6 +316,26 @@ public class TestTGDuration {
 		for (TGDuration d : list) {
 			assertTrue(d.getDivision().getEnters() <= 3);
 		}
+
+		// 1 quarter + 1 eighth triplet: shall return something with homogeneous time division
+		// 1/4 + (2/3) * 1/16 = 6/24 + 1/24 = 7/24
+		list = TGDuration.splitPreciseDurationApproximately(TGDuration.WHOLE_PRECISE_DURATION * 7 / 24, TGDuration.WHOLE_PRECISE_DURATION/4, factory,
+				16, 3);
+		assertNotNull(list);
+		int division = list.get(0).getDivision().getEnters();
+		for (TGDuration d : list) {
+			assertEquals(division, d.getDivision().getEnters());
+		}
+		
+		// a basic 8th triplet, with the minimum possible error
+		toSplit = TGDuration.WHOLE_PRECISE_DURATION*2/3/8 + 1;
+		list = TGDuration.splitPreciseDurationApproximately(toSplit, TGDuration.WHOLE_PRECISE_DURATION, factory,
+				16, 3);
+		assertNotNull(list);
+		assertEquals(1, list.size());
+		assertEquals(8, list.get(0).getValue());
+		assertEquals(2, list.get(0).getDivision().getTimes());
+		assertEquals(3, list.get(0).getDivision().getEnters());
 	}
 
 	// get sum of notes list duration, and check max (if specified)

--- a/common/TuxGuitar-midi/src/main/java/app/tuxguitar/io/midi/MidiSongReader.java
+++ b/common/TuxGuitar-midi/src/main/java/app/tuxguitar/io/midi/MidiSongReader.java
@@ -18,6 +18,7 @@ import app.tuxguitar.io.midi.base.MidiSequence;
 import app.tuxguitar.io.midi.base.MidiTrack;
 import app.tuxguitar.player.base.MidiControllers;
 import app.tuxguitar.song.factory.TGFactory;
+import app.tuxguitar.song.helpers.TGMeasureError;
 import app.tuxguitar.song.helpers.tuning.TuningManager;
 import app.tuxguitar.song.managers.TGSongManager;
 import app.tuxguitar.song.models.TGBeat;
@@ -780,6 +781,11 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 		private void process(TGMeasure measure, boolean isPercussionTrack, int maxFret){
 			tgSongManager.getMeasureManager().updateBeatsPreciseStart(measure);
 			tgSongManager.getMeasureManager().autoCompleteSilences(measure);
+			// some measures may be a little short, if the empty space at measure end could not be filled because of quantization constraints
+			// fix them: it's preferred to have all measures valid even if some trailing rests do not respect quantization criteria
+			for (TGMeasureError err : tgSongManager.getMeasureManager().getMeasureErrors(measure)) {
+				tgSongManager.getMeasureManager().fixVoice(measure, err.getVoiceIndex(), err.getErrCode());
+			}
 			adjustStrings(measure, isPercussionTrack, maxFret);
 		}
 


### PR DESCRIPTION
- prefer a single duration if it fulfills the precision criterion
  even if a combination of several values would have been more precise
  (prefer readability over fidelity)

- do not allocate a chain of tied notes with different time division
 e.g. no quarter tied to a triplet 8th
 (subjective criterion)