### PR TITLE
Fix TGSystemOutStreamWrapper.close() to close all streams on failure

### DIFF
--- a/desktop/TuxGuitar-debug-helper/src/app/tuxguitar/debug/TGSystemOutStreamWrapper.java
+++ b/desktop/TuxGuitar-debug-helper/src/app/tuxguitar/debug/TGSystemOutStreamWrapper.java
@@ -29,8 +29,20 @@ public class TGSystemOutStreamWrapper extends OutputStream {
 
 	@Override
 	public void close() throws IOException {
-		for(OutputStream outputStream : this.outputStreams) {
-			outputStream.close();
+		IOException first = null;
+		for (OutputStream outputStream : this.outputStreams) {
+			try {
+				outputStream.close();
+			} catch (IOException e) {
+				if (first == null) {
+					first = e;
+				} else {
+					first.addSuppressed(e);
+				}
+			}
+		}
+		if (first != null) {
+			throw first;
 		}
 	}
 }


### PR DESCRIPTION
This PR improves exception safety in `TGSystemOutStreamWrapper`.

**Problem**
`TGSystemOutStreamWrapper.close()` closes multiple underlying `OutputStream`s sequentially. If one `close()` throws an `IOException`, the method exits immediately and the remaining streams are never closed, which can leave resources open.

**Fix**
Wrap each `OutputStream.close()` in a try/catch, continue closing the remaining streams even after a failure, then throw the first `IOException` and attach later ones as suppressed exceptions.
