### PR TITLE
Add Discard All option when closing with multiple unsaved documents

### DIFF
--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -195,6 +195,7 @@ file.save=Save
 file.save-as=Save As
 file.save.default-name=Untitled
 file.save-changes-question=The song has unsaved changes.\nDo you want to save the changes?
+file.discard-all-changes=Discard All
 file.overwrite-question=This file already exists. Do you want to overwrite it?
 file.import=Import
 file.export=Export

--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -195,6 +195,7 @@ file.save=Save
 file.save-as=Save As
 file.save.default-name=Untitled
 file.save-changes-question=The song has unsaved changes.\nDo you want to save the changes?
+file.save-changes-question-many=One song has unsaved changes.\nDo you want to save the changes?
 file.discard-all-changes=Discard All
 file.overwrite-question=This file already exists. Do you want to overwrite it?
 file.import=Import

--- a/common/resources/lang/messages_bg.properties
+++ b/common/resources/lang/messages_bg.properties
@@ -52,6 +52,7 @@ file.save=Запазване
 file.save-as=Запазване като
 file.save.default-name=Неозаглавено
 file.save-changes-question=Песента има незапазени промени.\nЖелаете ли да ги запазите?
+#file.discard-all-changes=
 file.overwrite-question=Такъв файл вече съществува. Желаете ли да го презапишете?
 file.import=Внасяне
 file.export=Изнасяне

--- a/common/resources/lang/messages_bg.properties
+++ b/common/resources/lang/messages_bg.properties
@@ -52,6 +52,7 @@ file.save=Запазване
 file.save-as=Запазване като
 file.save.default-name=Неозаглавено
 file.save-changes-question=Песента има незапазени промени.\nЖелаете ли да ги запазите?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Такъв файл вече съществува. Желаете ли да го презапишете?
 file.import=Внасяне

--- a/common/resources/lang/messages_ca.properties
+++ b/common/resources/lang/messages_ca.properties
@@ -52,6 +52,7 @@ file.save=Desa
 file.save-as=Desa com a
 file.save.default-name=Sense títol
 file.save-changes-question=L'arxiu té canvis sense desar.\nVoleu desar els canvis?
+#file.discard-all-changes=
 file.overwrite-question=L'arxiu ja existeix, desitgeu sobreescriure'l?
 file.import=Importa
 file.export=Exportar

--- a/common/resources/lang/messages_ca.properties
+++ b/common/resources/lang/messages_ca.properties
@@ -52,6 +52,7 @@ file.save=Desa
 file.save-as=Desa com a
 file.save.default-name=Sense títol
 file.save-changes-question=L'arxiu té canvis sense desar.\nVoleu desar els canvis?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=L'arxiu ja existeix, desitgeu sobreescriure'l?
 file.import=Importa

--- a/common/resources/lang/messages_cs.properties
+++ b/common/resources/lang/messages_cs.properties
@@ -52,6 +52,7 @@ file.save=Uložit
 file.save-as=Uložit jako...
 file.save.default-name=Bez názvu
 # file.save-changes-question=
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Tento soubor již existuje, opravdu ho chcete přepsat??
 file.import=Importovat

--- a/common/resources/lang/messages_cs.properties
+++ b/common/resources/lang/messages_cs.properties
@@ -52,6 +52,7 @@ file.save=Uložit
 file.save-as=Uložit jako...
 file.save.default-name=Bez názvu
 # file.save-changes-question=
+#file.discard-all-changes=
 file.overwrite-question=Tento soubor již existuje, opravdu ho chcete přepsat??
 file.import=Importovat
 file.export=Exportovat

--- a/common/resources/lang/messages_de.properties
+++ b/common/resources/lang/messages_de.properties
@@ -52,6 +52,7 @@ file.save=Speichern
 file.save-as=Speichern unter
 file.save.default-name=Unbenannt
 file.save-changes-question=Das Lied wurde seit dem letzten Speichern verändert.\nWollen Sie die Änderungen vor dem Beenden speichern?
+#file.discard-all-changes=
 file.overwrite-question=Diese Datei existiert bereits. Soll sie überschrieben werden?
 file.import=Importieren als
 file.export=Exportieren als

--- a/common/resources/lang/messages_de.properties
+++ b/common/resources/lang/messages_de.properties
@@ -52,6 +52,7 @@ file.save=Speichern
 file.save-as=Speichern unter
 file.save.default-name=Unbenannt
 file.save-changes-question=Das Lied wurde seit dem letzten Speichern verändert.\nWollen Sie die Änderungen vor dem Beenden speichern?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Diese Datei existiert bereits. Soll sie überschrieben werden?
 file.import=Importieren als

--- a/common/resources/lang/messages_el.properties
+++ b/common/resources/lang/messages_el.properties
@@ -52,6 +52,7 @@ file.save=Αποθήκευση
 file.save-as=Αποθήκευση Ως
 file.save.default-name=Χωρίς τίτλο
 file.save-changes-question=Το τραγούδι περιέχει μη αποθηκευμένες αλλαγές.\nΕπιθυμείτε να αποθηκεύσετε τις αλλαγές;
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Αυτός ο φάκελος υπάρχει ήδη. Επιθυμείτε να τον αντικαταστήσετε;
 file.import=Εισαγωγή

--- a/common/resources/lang/messages_el.properties
+++ b/common/resources/lang/messages_el.properties
@@ -52,6 +52,7 @@ file.save=Αποθήκευση
 file.save-as=Αποθήκευση Ως
 file.save.default-name=Χωρίς τίτλο
 file.save-changes-question=Το τραγούδι περιέχει μη αποθηκευμένες αλλαγές.\nΕπιθυμείτε να αποθηκεύσετε τις αλλαγές;
+#file.discard-all-changes=
 file.overwrite-question=Αυτός ο φάκελος υπάρχει ήδη. Επιθυμείτε να τον αντικαταστήσετε;
 file.import=Εισαγωγή
 file.export=Εξαγωγή

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -52,6 +52,7 @@ file.save=Guardar
 file.save-as=Guardar Como
 file.save.default-name=Sin Título
 file.save-changes-question=El archivo tiene cambios sin guardar.\n¿Desea guardar los cambios?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=El archivo ya existe, ¿desea reemplazarlo?
 file.import=Importar

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -52,6 +52,7 @@ file.save=Guardar
 file.save-as=Guardar Como
 file.save.default-name=Sin Título
 file.save-changes-question=El archivo tiene cambios sin guardar.\n¿Desea guardar los cambios?
+#file.discard-all-changes=
 file.overwrite-question=El archivo ya existe, ¿desea reemplazarlo?
 file.import=Importar
 file.export=Exportar

--- a/common/resources/lang/messages_eu.properties
+++ b/common/resources/lang/messages_eu.properties
@@ -52,6 +52,7 @@ file.save=Gorde
 file.save-as=Gorde beste izenarekin
 file.save.default-name=Izenburu gabea
 file.save-changes-question=Fitxategia aldaketak ditu, Gorde nahi al dituzu?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Badago Fitxategi bat izen honekin, Ordezkatu nahi duzu?
 file.import=Importatu

--- a/common/resources/lang/messages_eu.properties
+++ b/common/resources/lang/messages_eu.properties
@@ -52,6 +52,7 @@ file.save=Gorde
 file.save-as=Gorde beste izenarekin
 file.save.default-name=Izenburu gabea
 file.save-changes-question=Fitxategia aldaketak ditu, Gorde nahi al dituzu?
+#file.discard-all-changes=
 file.overwrite-question=Badago Fitxategi bat izen honekin, Ordezkatu nahi duzu?
 file.import=Importatu
 file.export=Exportatu

--- a/common/resources/lang/messages_fi.properties
+++ b/common/resources/lang/messages_fi.properties
@@ -52,6 +52,7 @@ file.save=Tallenna
 file.save-as=Tallenna nimellä
 file.save.default-name=Nimetön
 file.save-changes-question=Kappaleessa on tallentamattomia muutoksia. \nHaluatko tallentaa muutokset?
+#file.discard-all-changes=
 file.overwrite-question=Tämä tiedosto on jo olemassa. Haluatko korvata sen?
 file.import=Tuo
 file.export=Vie

--- a/common/resources/lang/messages_fi.properties
+++ b/common/resources/lang/messages_fi.properties
@@ -52,6 +52,7 @@ file.save=Tallenna
 file.save-as=Tallenna nimellä
 file.save.default-name=Nimetön
 file.save-changes-question=Kappaleessa on tallentamattomia muutoksia. \nHaluatko tallentaa muutokset?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Tämä tiedosto on jo olemassa. Haluatko korvata sen?
 file.import=Tuo

--- a/common/resources/lang/messages_fr.properties
+++ b/common/resources/lang/messages_fr.properties
@@ -52,6 +52,7 @@ file.save=Enregistrer
 file.save-as=Enregistrer sous...
 file.save.default-name=Sans titre
 file.save-changes-question=Le morceau a été modifié.\nVoulez-vous enregistrer les modifications ?
+#file.discard-all-changes=
 file.overwrite-question=Ce fichier existe déjà. Voulez-vous le remplacer ?
 file.import=Importer
 file.export=Exporter

--- a/common/resources/lang/messages_fr.properties
+++ b/common/resources/lang/messages_fr.properties
@@ -52,6 +52,7 @@ file.save=Enregistrer
 file.save-as=Enregistrer sous...
 file.save.default-name=Sans titre
 file.save-changes-question=Le morceau a été modifié.\nVoulez-vous enregistrer les modifications ?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Ce fichier existe déjà. Voulez-vous le remplacer ?
 file.import=Importer

--- a/common/resources/lang/messages_hu.properties
+++ b/common/resources/lang/messages_hu.properties
@@ -52,6 +52,7 @@ file.save=Mentés
 file.save-as=Mentés másként...
 file.save.default-name=Nincs cím
 # file.save-changes-question=
+#file.discard-all-changes=
 file.overwrite-question=A fájl már létezik, felülírod ???
 file.import=Importálás
 file.export=Exportálás

--- a/common/resources/lang/messages_hu.properties
+++ b/common/resources/lang/messages_hu.properties
@@ -52,6 +52,7 @@ file.save=Mentés
 file.save-as=Mentés másként...
 file.save.default-name=Nincs cím
 # file.save-changes-question=
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=A fájl már létezik, felülírod ???
 file.import=Importálás

--- a/common/resources/lang/messages_it.properties
+++ b/common/resources/lang/messages_it.properties
@@ -52,6 +52,7 @@ file.save=Salva
 file.save-as=Salva come
 file.save.default-name=Senza titolo
 file.save-changes-question=La canzone è stata modificata.\nVuoi salvare le modifiche?
+#file.discard-all-changes=
 file.overwrite-question=Questo file esiste già, vuoi sovrascriverlo??
 file.import=Importa
 file.export=Esporta

--- a/common/resources/lang/messages_it.properties
+++ b/common/resources/lang/messages_it.properties
@@ -52,6 +52,7 @@ file.save=Salva
 file.save-as=Salva come
 file.save.default-name=Senza titolo
 file.save-changes-question=La canzone è stata modificata.\nVuoi salvare le modifiche?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Questo file esiste già, vuoi sovrascriverlo??
 file.import=Importa

--- a/common/resources/lang/messages_ja.properties
+++ b/common/resources/lang/messages_ja.properties
@@ -52,6 +52,7 @@ file.save=保存
 file.save-as=別名保存
 # file.save.default-name=
 file.save-changes-question=ファイルが変更されています.\n変更を保存しますか?
+#file.discard-all-changes=
 file.overwrite-question=同名のファイルが存在します.\n上書きしますか?
 file.import=インポート
 file.export=エクスポート

--- a/common/resources/lang/messages_ja.properties
+++ b/common/resources/lang/messages_ja.properties
@@ -52,6 +52,7 @@ file.save=保存
 file.save-as=別名保存
 # file.save.default-name=
 file.save-changes-question=ファイルが変更されています.\n変更を保存しますか?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=同名のファイルが存在します.\n上書きしますか?
 file.import=インポート

--- a/common/resources/lang/messages_ko.properties
+++ b/common/resources/lang/messages_ko.properties
@@ -52,6 +52,7 @@ file.save=저장
 file.save-as=다른 이름으로 저장
 # file.save.default-name=
 file.save-changes-question=저장되지 않은 변경사항이 있습니다.\n변경 내용을 저장할까요?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=파일이 이미 존재합니다. 덮어쓸까요?
 file.import=불러오기

--- a/common/resources/lang/messages_ko.properties
+++ b/common/resources/lang/messages_ko.properties
@@ -52,6 +52,7 @@ file.save=저장
 file.save-as=다른 이름으로 저장
 # file.save.default-name=
 file.save-changes-question=저장되지 않은 변경사항이 있습니다.\n변경 내용을 저장할까요?
+#file.discard-all-changes=
 file.overwrite-question=파일이 이미 존재합니다. 덮어쓸까요?
 file.import=불러오기
 file.export=내보내기

--- a/common/resources/lang/messages_lt.properties
+++ b/common/resources/lang/messages_lt.properties
@@ -52,6 +52,7 @@ file.save=Įrašyti
 file.save-as=Įrašyti taip
 file.save.default-name=Be pavadinimo
 file.save-changes-question=Kūrinyje yra neįrašytų pakeitimų.\nAr dabar juos įrašyti?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Toks failas jau yra. Ar jį perrašyti?
 file.import=Importuoti

--- a/common/resources/lang/messages_lt.properties
+++ b/common/resources/lang/messages_lt.properties
@@ -52,6 +52,7 @@ file.save=Įrašyti
 file.save-as=Įrašyti taip
 file.save.default-name=Be pavadinimo
 file.save-changes-question=Kūrinyje yra neįrašytų pakeitimų.\nAr dabar juos įrašyti?
+#file.discard-all-changes=
 file.overwrite-question=Toks failas jau yra. Ar jį perrašyti?
 file.import=Importuoti
 file.export=Eksportuoti

--- a/common/resources/lang/messages_nl.properties
+++ b/common/resources/lang/messages_nl.properties
@@ -52,6 +52,7 @@ file.save=Opslaan
 file.save-as=Opslaan Als
 file.save.default-name=Naamloos
 file.save-changes-question=De track heeft niet opgeslagen wijzigingen.\nWilt u dit alsnog opslaan?
+#file.discard-all-changes=
 file.overwrite-question=Dit bestand bestaat al, wilt u dit overschrijven?
 file.import=Importeren
 file.export=Exporteren

--- a/common/resources/lang/messages_nl.properties
+++ b/common/resources/lang/messages_nl.properties
@@ -52,6 +52,7 @@ file.save=Opslaan
 file.save-as=Opslaan Als
 file.save.default-name=Naamloos
 file.save-changes-question=De track heeft niet opgeslagen wijzigingen.\nWilt u dit alsnog opslaan?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Dit bestand bestaat al, wilt u dit overschrijven?
 file.import=Importeren

--- a/common/resources/lang/messages_pl.properties
+++ b/common/resources/lang/messages_pl.properties
@@ -52,6 +52,7 @@ file.save=Zapisz
 file.save-as=Zapisz jako
 file.save.default-name=Bez nazwy
 file.save-changes-question=Utwór ma niezapisane zmiany.\nChcesz zapisać zmiany?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Plik już istnieje. Chcesz go zastąpić?
 file.import=Importuj

--- a/common/resources/lang/messages_pl.properties
+++ b/common/resources/lang/messages_pl.properties
@@ -52,6 +52,7 @@ file.save=Zapisz
 file.save-as=Zapisz jako
 file.save.default-name=Bez nazwy
 file.save-changes-question=Utwór ma niezapisane zmiany.\nChcesz zapisać zmiany?
+#file.discard-all-changes=
 file.overwrite-question=Plik już istnieje. Chcesz go zastąpić?
 file.import=Importuj
 file.export=Eksportuj

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -52,6 +52,7 @@ file.save=Salvar
 file.save-as=Salvar Como
 # file.save.default-name=
 file.save-changes-question=A música tem alterações não salvas.\nDeseja salvar as mudanças?
+#file.discard-all-changes=
 file.overwrite-question=Este arquivo já existe. Deseja sobreescrevê-lo?
 file.import=Importar
 file.export=Exportar

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -52,6 +52,7 @@ file.save=Salvar
 file.save-as=Salvar Como
 # file.save.default-name=
 file.save-changes-question=A música tem alterações não salvas.\nDeseja salvar as mudanças?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Este arquivo já existe. Deseja sobreescrevê-lo?
 file.import=Importar

--- a/common/resources/lang/messages_ru.properties
+++ b/common/resources/lang/messages_ru.properties
@@ -52,6 +52,7 @@ file.save=Сохранить
 file.save-as=Сохранить как
 file.save.default-name=Без названия
 file.save-changes-question=В композиции были сделаны изменения.\nСохранить их?
+#file.discard-all-changes=
 file.overwrite-question=Такой файл уже существует. Заменить его?
 file.import=Импорт
 file.export=Экспорт

--- a/common/resources/lang/messages_ru.properties
+++ b/common/resources/lang/messages_ru.properties
@@ -52,6 +52,7 @@ file.save=Сохранить
 file.save-as=Сохранить как
 file.save.default-name=Без названия
 file.save-changes-question=В композиции были сделаны изменения.\nСохранить их?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Такой файл уже существует. Заменить его?
 file.import=Импорт

--- a/common/resources/lang/messages_sr.properties
+++ b/common/resources/lang/messages_sr.properties
@@ -52,6 +52,7 @@ file.save=Snimi
 file.save-as=Snimi kao
 file.save.default-name=Nema_ime
 file.save-changes-question=Izmene koje ste izvršili nisu snimljene.\nŽelite li da ih snimite?
+#file.discard-all-changes=
 file.overwrite-question=Navedena datoteka već postoji, da li želite da je prepišete??
 # file.import=
 file.export=Eksportuj

--- a/common/resources/lang/messages_sr.properties
+++ b/common/resources/lang/messages_sr.properties
@@ -52,6 +52,7 @@ file.save=Snimi
 file.save-as=Snimi kao
 file.save.default-name=Nema_ime
 file.save-changes-question=Izmene koje ste izvršili nisu snimljene.\nŽelite li da ih snimite?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Navedena datoteka već postoji, da li želite da je prepišete??
 # file.import=

--- a/common/resources/lang/messages_sv.properties
+++ b/common/resources/lang/messages_sv.properties
@@ -52,6 +52,7 @@ file.save=Spara
 file.save-as=Spara som
 file.save.default-name=Utan titel
 file.save-changes-question=Sången har osparade ändringar.\nVill du spara ändringarna?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Denna fil finns redan. Vill du skriva över den?
 file.import=Importera

--- a/common/resources/lang/messages_sv.properties
+++ b/common/resources/lang/messages_sv.properties
@@ -52,6 +52,7 @@ file.save=Spara
 file.save-as=Spara som
 file.save.default-name=Utan titel
 file.save-changes-question=Sången har osparade ändringar.\nVill du spara ändringarna?
+#file.discard-all-changes=
 file.overwrite-question=Denna fil finns redan. Vill du skriva över den?
 file.import=Importera
 file.export=Exportera

--- a/common/resources/lang/messages_uk.properties
+++ b/common/resources/lang/messages_uk.properties
@@ -52,6 +52,7 @@ file.save=Зберегти
 file.save-as=Зберегти як
 file.save.default-name=Неназвана
 file.save-changes-question=Зміни до пісні не збережені.\nЗберегти?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Цей файл вже існує, перезаписати?
 file.import=Імпортувати

--- a/common/resources/lang/messages_uk.properties
+++ b/common/resources/lang/messages_uk.properties
@@ -52,6 +52,7 @@ file.save=Зберегти
 file.save-as=Зберегти як
 file.save.default-name=Неназвана
 file.save-changes-question=Зміни до пісні не збережені.\nЗберегти?
+#file.discard-all-changes=
 file.overwrite-question=Цей файл вже існує, перезаписати?
 file.import=Імпортувати
 file.export=Експортувати

--- a/common/resources/lang/messages_vi.properties
+++ b/common/resources/lang/messages_vi.properties
@@ -52,6 +52,7 @@ file.save=Lưu
 file.save-as=Lưu dạng
 file.save.default-name=Vô đề
 file.save-changes-question=Có nhiều thay đổi chưa lưu, bạn có muốn thoát mà không lưu chúng lại không?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=Tập tin này có rồi, Bạn có muốn ghi đè lên nó không??
 file.import=Nhập

--- a/common/resources/lang/messages_vi.properties
+++ b/common/resources/lang/messages_vi.properties
@@ -52,6 +52,7 @@ file.save=Lưu
 file.save-as=Lưu dạng
 file.save.default-name=Vô đề
 file.save-changes-question=Có nhiều thay đổi chưa lưu, bạn có muốn thoát mà không lưu chúng lại không?
+#file.discard-all-changes=
 file.overwrite-question=Tập tin này có rồi, Bạn có muốn ghi đè lên nó không??
 file.import=Nhập
 file.export=Xuất

--- a/common/resources/lang/messages_zh_CN.properties
+++ b/common/resources/lang/messages_zh_CN.properties
@@ -52,6 +52,7 @@ file.save=保存
 file.save-as=另存为
 file.save.default-name=未命名
 file.save-changes-question=曲谱还未保存。\n是否要保存更改?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=文件已存在！是否覆盖现有文件?
 file.import=导入

--- a/common/resources/lang/messages_zh_CN.properties
+++ b/common/resources/lang/messages_zh_CN.properties
@@ -52,6 +52,7 @@ file.save=保存
 file.save-as=另存为
 file.save.default-name=未命名
 file.save-changes-question=曲谱还未保存。\n是否要保存更改?
+#file.discard-all-changes=
 file.overwrite-question=文件已存在！是否覆盖现有文件?
 file.import=导入
 file.export=导出

--- a/common/resources/lang/messages_zh_TW.properties
+++ b/common/resources/lang/messages_zh_TW.properties
@@ -52,6 +52,7 @@ file.save=儲存檔案
 file.save-as=另存新檔
 file.save.default-name=未命名
 file.save-changes-question=這首曲子有尚未儲存的修改.\n你要儲存這些改變嗎?
+#file.save-changes-question-many=
 #file.discard-all-changes=
 file.overwrite-question=檔案已存在，是否覆寫？
 file.import=輸入

--- a/common/resources/lang/messages_zh_TW.properties
+++ b/common/resources/lang/messages_zh_TW.properties
@@ -52,6 +52,7 @@ file.save=儲存檔案
 file.save-as=另存新檔
 file.save.default-name=未命名
 file.save-changes-question=這首曲子有尚未儲存的修改.\n你要儲存這些改變嗎?
+#file.discard-all-changes=
 file.overwrite-question=檔案已存在，是否覆寫？
 file.import=輸入
 file.export=輸出

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/listener/save/TGUnsavedDocumentInterceptor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/listener/save/TGUnsavedDocumentInterceptor.java
@@ -76,14 +76,16 @@ public class TGUnsavedDocumentInterceptor implements TGActionInterceptor, TGEven
 	}
 
 	public void openSaveDialog(TGActionContext context) {
+		boolean hasMoreUnsaved = this.containsUnsavedDocument(context);
 		int style = TGConfirmDialog.BUTTON_YES | TGConfirmDialog.BUTTON_NO | TGConfirmDialog.BUTTON_CANCEL;
-		if(this.containsUnsavedDocument(context)) {
+		if(hasMoreUnsaved) {
 			style |= TGConfirmDialog.BUTTON_DISCARD_ALL;
 		}
 
+		String messageKey = hasMoreUnsaved ? "file.save-changes-question-many" : "file.save-changes-question";
 		TGActionProcessor tgActionProcessor = new TGActionProcessor(this.context, TGOpenViewAction.NAME);
 		tgActionProcessor.setAttribute(TGOpenViewAction.ATTRIBUTE_CONTROLLER, new TGConfirmDialogController());
-		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_MESSAGE, TuxGuitar.getProperty("file.save-changes-question"));
+		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_MESSAGE, TuxGuitar.getProperty(messageKey));
 		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_STYLE, style);
 		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_DEFAULT_BUTTON, TGConfirmDialog.BUTTON_YES);
 		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_RUNNABLE_YES, this.createThreadRunnable(createSaveActionRunnable(context)));

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/listener/save/TGUnsavedDocumentInterceptor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/listener/save/TGUnsavedDocumentInterceptor.java
@@ -76,14 +76,29 @@ public class TGUnsavedDocumentInterceptor implements TGActionInterceptor, TGEven
 	}
 
 	public void openSaveDialog(TGActionContext context) {
+		int style = TGConfirmDialog.BUTTON_YES | TGConfirmDialog.BUTTON_NO | TGConfirmDialog.BUTTON_CANCEL;
+		if(this.containsUnsavedDocument(context)) {
+			style |= TGConfirmDialog.BUTTON_DISCARD_ALL;
+		}
+
 		TGActionProcessor tgActionProcessor = new TGActionProcessor(this.context, TGOpenViewAction.NAME);
 		tgActionProcessor.setAttribute(TGOpenViewAction.ATTRIBUTE_CONTROLLER, new TGConfirmDialogController());
 		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_MESSAGE, TuxGuitar.getProperty("file.save-changes-question"));
-		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_STYLE, TGConfirmDialog.BUTTON_YES | TGConfirmDialog.BUTTON_NO | TGConfirmDialog.BUTTON_CANCEL);
+		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_STYLE, style);
 		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_DEFAULT_BUTTON, TGConfirmDialog.BUTTON_YES);
 		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_RUNNABLE_YES, this.createThreadRunnable(createSaveActionRunnable(context)));
 		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_RUNNABLE_NO, this.createThreadRunnable(createInterceptedActionRunnable(context)));
+		tgActionProcessor.setAttribute(TGConfirmDialog.ATTRIBUTE_RUNNABLE_DISCARD_ALL, this.createThreadRunnable(createDiscardAllRunnable(context)));
 		tgActionProcessor.process();
+	}
+
+	public Runnable createDiscardAllRunnable(final TGActionContext tgActionContext) {
+		return new Runnable() {
+			public void run() {
+				tgActionContext.setAttribute(UNSAVED_INTERCEPTOR_BY_PASS, true);
+				executeInterceptedAction(tgActionContext);
+			}
+		};
 	}
 
 	public Runnable createThreadRunnable(final Runnable target) {

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/confirm/TGConfirmDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/confirm/TGConfirmDialog.java
@@ -24,10 +24,12 @@ public class TGConfirmDialog {
 	public static final String ATTRIBUTE_RUNNABLE_YES = "yesRunnable";
 	public static final String ATTRIBUTE_RUNNABLE_NO = "noRunnable";
 	public static final String ATTRIBUTE_RUNNABLE_CANCEL = "cancelRunnable";
+	public static final String ATTRIBUTE_RUNNABLE_DISCARD_ALL = "discardAllRunnable";
 
 	public static int BUTTON_CANCEL = 0x01;
 	public static int BUTTON_YES = 0x02;
 	public static int BUTTON_NO = 0x04;
+	public static int BUTTON_DISCARD_ALL = 0x08;
 
 	public void show(final TGViewContext context) {
 		final String message = context.getAttribute(ATTRIBUTE_MESSAGE);
@@ -36,6 +38,7 @@ public class TGConfirmDialog {
 		final Runnable yesRunnable = context.getAttribute(ATTRIBUTE_RUNNABLE_YES);
 		final Runnable noRunnable = context.getAttribute(ATTRIBUTE_RUNNABLE_NO);
 		final Runnable cancelRunnable = context.getAttribute(ATTRIBUTE_RUNNABLE_CANCEL);
+		final Runnable discardAllRunnable = context.getAttribute(ATTRIBUTE_RUNNABLE_DISCARD_ALL);
 
 		final UIFactory uiFactory = TGApplication.getInstance(context.getContext()).getFactory();
 		final UIWindow uiParent = context.getAttribute(TGViewContext.ATTRIBUTE_PARENT);
@@ -71,6 +74,9 @@ public class TGConfirmDialog {
 		}
 		if((style & BUTTON_NO) != 0){
 			addCloseButton(uiFactory, dialog, buttons, TuxGuitar.getProperty("no"), noRunnable, (defaultButton == BUTTON_NO), ++columns);
+		}
+		if((style & BUTTON_DISCARD_ALL) != 0){
+			addCloseButton(uiFactory, dialog, buttons, TuxGuitar.getProperty("file.discard-all-changes"), discardAllRunnable, (defaultButton == BUTTON_DISCARD_ALL), ++columns);
 		}
 		if((style & BUTTON_CANCEL) != 0){
 			addCloseButton(uiFactory, dialog, buttons, TuxGuitar.getProperty("cancel"), cancelRunnable, (defaultButton == BUTTON_CANCEL), ++columns);

--- a/desktop/build-scripts/common-resources/common-windows/tuxguitar.bat
+++ b/desktop/build-scripts/common-resources/common-windows/tuxguitar.bat
@@ -5,7 +5,7 @@ SET "TG_START=%cd%"
 cd %~dp0
 SET "TG_DIR=."
 ::JAVA
-SET "JAVA=jre\bin\java"
+IF EXIST "jre\bin\java.exe" (SET "JAVA=jre\bin\java") ELSE (SET "JAVA=java")
 ::LIBRARY_PATH
 SET "JAVA_LIBRARY_PATH=%JAVA_LIBRARY_PATH%;lib\"
 ::CLASSPATH

--- a/desktop/build-scripts/common-resources/common-windows/tuxguitar.bat
+++ b/desktop/build-scripts/common-resources/common-windows/tuxguitar.bat
@@ -5,7 +5,7 @@ SET "TG_START=%cd%"
 cd %~dp0
 SET "TG_DIR=."
 ::JAVA
-IF EXIST "jre\bin\java.exe" (SET "JAVA=jre\bin\java") ELSE (SET "JAVA=java")
+SET "JAVA=jre\bin\java"
 ::LIBRARY_PATH
 SET "JAVA_LIBRARY_PATH=%JAVA_LIBRARY_PATH%;lib\"
 ::CLASSPATH


### PR DESCRIPTION
Should fix issue #921.

When multiple songs have unsaved changes and the user closes TuxGuitar, a **Discard All** button now appears in the save-changes dialog. Clicking it discards all remaining unsaved changes at once, without prompting for each document individually.

The button only appears when there is more than one unsaved document remaining, so the single-document case is unchanged.

Also updated `tuxguitar.bat` to fall back to system `java` when no local `jre` folder is present, making it easier to run from source without bundling a JRE.