### PR TITLE
feat: add HiDPI auto-detection, zoom shortcuts, and zoom persistence for tablature

### DIFF
--- a/desktop/TuxGuitar-ui-toolkit-jfx/src/app/tuxguitar/ui/jfx/JFXApplication.java
+++ b/desktop/TuxGuitar-ui-toolkit-jfx/src/app/tuxguitar/ui/jfx/JFXApplication.java
@@ -8,6 +8,7 @@ import app.tuxguitar.ui.appearance.UIAppearance;
 import app.tuxguitar.ui.jfx.appearance.JFXAppearance;
 
 import javafx.application.Platform;
+import javafx.stage.Screen;
 
 public class JFXApplication extends JFXComponent<JFXApplicationHandle> implements UIApplication {
 
@@ -43,6 +44,21 @@ public class JFXApplication extends JFXComponent<JFXApplicationHandle> implement
 
 	public boolean isInUiThread() {
 		return Platform.isFxApplicationThread();
+	}
+
+	public float getDisplayScale() {
+		try {
+			Screen primary = Screen.getPrimary();
+			if( primary != null ) {
+				float scale = (float) primary.getOutputScaleX();
+				if( scale > 1.0f ) {
+					return Math.min(scale, 3.0f);
+				}
+			}
+			return 1.0f;
+		} catch(Exception e) {
+			return 1.0f;
+		}
 	}
 
 	public void start(Runnable runnable) {

--- a/desktop/TuxGuitar-ui-toolkit-qt/src/app/tuxguitar/ui/qt/QTApplication.java
+++ b/desktop/TuxGuitar-ui-toolkit-qt/src/app/tuxguitar/ui/qt/QTApplication.java
@@ -52,6 +52,10 @@ public class QTApplication extends QTComponent<QTApplicationHandle> implements U
 		return (this.uiThread == Thread.currentThread());
 	}
 
+	public float getDisplayScale() {
+		return 1.0f;
+	}
+
 	public void start(Runnable runnable) {
 		this.uiThread = Thread.currentThread();
 		this.getControl().initialize();

--- a/desktop/TuxGuitar-ui-toolkit-swt/src/app/tuxguitar/ui/swt/SWTApplication.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/app/tuxguitar/ui/swt/SWTApplication.java
@@ -2,8 +2,11 @@ package app.tuxguitar.ui.swt;
 
 import java.net.URL;
 
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Monitor;
 import app.tuxguitar.ui.UIApplication;
 import app.tuxguitar.ui.UIFactory;
 import app.tuxguitar.ui.appearance.UIAppearance;
@@ -53,6 +56,54 @@ public class SWTApplication extends SWTComponent<Display> implements UIApplicati
 		Thread uiThread = this.getControl().getThread();
 		Thread currentThread = Thread.currentThread();
 		return (currentThread == uiThread);
+	}
+
+	public float getDisplayScale() {
+		if( this.isDisposed() ) {
+			return 1.0f;
+		}
+		try {
+			Display display = this.getDisplay();
+
+			// Signal 1: Display DPI vs platform reference
+			// macOS standard = 72, Windows/Linux = 96
+			Point dpi = display.getDPI();
+			String os = System.getProperty("os.name", "").toLowerCase();
+			float referenceDpi = os.contains("mac") ? 72.0f : 96.0f;
+			float dpiScale = dpi.x / referenceDpi;
+
+			// Retina guard: on macOS, if DPI indicates 2x, SWT already handles
+			// pixel doubling internally — don't double-scale
+			if( os.contains("mac") && dpiScale >= 2.0f ) {
+				return 1.0f;
+			}
+
+			if( dpiScale > 1.1f ) {
+				return Math.min(dpiScale, 3.0f);
+			}
+
+			// Signal 2: Resolution heuristic
+			// If DPI reports ~1.0 but monitor resolution is very high,
+			// compute scale from resolution ratio (catches "More Space" on
+			// non-HiDPI external displays)
+			Monitor primaryMonitor = display.getPrimaryMonitor();
+			if( primaryMonitor != null ) {
+				Rectangle bounds = primaryMonitor.getClientArea();
+				if( bounds.width > 2560 ) {
+					double monitorPixels = Math.sqrt((double) bounds.width * bounds.height);
+					double referencePixels = Math.sqrt(1920.0 * 1080.0);
+					float heuristicScale = (float)(monitorPixels / referencePixels);
+					heuristicScale = Math.max(1.0f, Math.min(heuristicScale, 3.0f));
+					if( heuristicScale > 1.1f ) {
+						return heuristicScale;
+					}
+				}
+			}
+
+			return Math.max(1.0f, dpiScale);
+		} catch(Exception e) {
+			return 1.0f;
+		}
 	}
 
 	public void start(Runnable runnable) {

--- a/desktop/TuxGuitar-ui-toolkit/src/app/tuxguitar/ui/UIApplication.java
+++ b/desktop/TuxGuitar-ui-toolkit/src/app/tuxguitar/ui/UIApplication.java
@@ -17,4 +17,8 @@ public interface UIApplication extends UIComponent {
 	void runInUiThread(Runnable runnable);
 
 	boolean isInUiThread();
+
+	default float getDisplayScale() {
+		return 1.0f;
+	}
 }

--- a/desktop/TuxGuitar/dist/tuxguitar-shortcuts.xml
+++ b/desktop/TuxGuitar/dist/tuxguitar-shortcuts.xml
@@ -77,4 +77,6 @@
 	<shortcut keys="F9" action="action.gui.open-transport-mode-dialog"/>
 	<shortcut keys="Space" action="action.transport.play"/>
 	<shortcut keys="Ctrl t" action="action.gui.toggle-transport-dialog"/>
+	<shortcut keys="Ctrl =" action="action.view.layout-increment-scale"/>
+	<shortcut keys="Ctrl -" action="action.view.layout-decrement-scale"/>
 </shortcuts>

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleAction.java
@@ -1,6 +1,8 @@
 package app.tuxguitar.app.action.impl.layout;
 
 import app.tuxguitar.action.TGActionContext;
+import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.view.component.tab.Tablature;
 import app.tuxguitar.app.view.component.tab.TablatureEditor;
 import app.tuxguitar.editor.action.TGActionBase;
@@ -21,5 +23,9 @@ public class TGSetLayoutScaleAction extends TGActionBase{
 
 		Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature();
 		tablature.scale(scale);
+
+		// Persist zoom level to config
+		TGConfigManager config = TGConfigManager.getInstance(getContext());
+		config.setValue(TGConfigKeys.LAYOUT_SCALE, Float.toString(scale));
 	}
 }

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleIncrementAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleIncrementAction.java
@@ -11,7 +11,7 @@ public class TGSetLayoutScaleIncrementAction extends TGActionBase{
 
 	public static final String NAME = "action.view.layout-increment-scale";
 
-	private static final Float MAXIMUM_VALUE = 2f;
+	private static final Float MAXIMUM_VALUE = 3f;
 	private static final Float INCREMENT_VALUE = 0.1f;
 
 	public TGSetLayoutScaleIncrementAction(TGContext context) {

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/system/TGDisposeAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/system/TGDisposeAction.java
@@ -40,6 +40,7 @@ public class TGDisposeAction extends TGActionBase {
 
 		config.setValue(TGConfigKeys.LAYOUT_MODE,TablatureEditor.getInstance(getContext()).getTablature().getViewLayout().getMode());
 		config.setValue(TGConfigKeys.LAYOUT_STYLE,TablatureEditor.getInstance(getContext()).getTablature().getViewLayout().getStyle());
+		config.setValue(TGConfigKeys.LAYOUT_SCALE, Float.toString(TablatureEditor.getInstance(getContext()).getTablature().getScale()));
 		config.setValue(TGConfigKeys.SHOW_PIANO,!TuxGuitar.getInstance().getPianoEditor().isDisposed());
 		config.setValue(TGConfigKeys.SHOW_MATRIX,!TuxGuitar.getInstance().getMatrixEditor().isDisposed());
 		config.setValue(TGConfigKeys.SHOW_FRETBOARD,TuxGuitar.getInstance().getFretBoardEditor().isVisible());

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -51,6 +51,7 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.SHOW_TRACKS, true);
 		loadProperty(properties, TGConfigKeys.LAYOUT_MODE, TGLayout.MODE_VERTICAL);
 		loadProperty(properties, TGConfigKeys.LAYOUT_STYLE, (TGLayout.DISPLAY_TABLATURE | TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_COMPACT | TGLayout.DISPLAY_CHORD_DIAGRAM | TGLayout.HIGHLIGHT_PLAYED_BEAT));
+		loadProperty(properties, TGConfigKeys.LAYOUT_SCALE, "1.0");
 		loadProperty(properties, TGConfigKeys.LANGUAGE, "");
 		loadProperty(properties, TGConfigKeys.EDITOR_MOUSE_MODE, EditorKit.MOUSE_MODE_SELECTION);
 		loadProperty(properties, TGConfigKeys.EDITOR_NATURAL_KEY_MODE, true);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
@@ -22,6 +22,7 @@ public class TGConfigKeys {
 	public static final String SHOW_TRACKS = "show.tracks";
 	public static final String LAYOUT_MODE = "layout.mode";
 	public static final String LAYOUT_STYLE = "layout.style";
+	public static final String LAYOUT_SCALE = "layout.scale";
 	public static final String LANGUAGE = "language";
 	public static final String EDITOR_MOUSE_MODE = "editor.mouse.mode";
 	public static final String EDITOR_NATURAL_KEY_MODE = "editor.natural.key.mode";

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/Tablature.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/Tablature.java
@@ -49,11 +49,13 @@ public class Tablature implements TGController {
 	private TGLayout viewLayout;
 	private EditorKit editorKit;
 	private Float scale;
+	private float displayScale;
 
 	public Tablature(TGContext context, TGDocumentManager documentManager) {
 		this.context = context;
 		this.documentManager = documentManager;
 		this.scale = DEFAULT_SCALE;
+		this.displayScale = 1.0f;
 		this.caret = new Caret(this);
 		this.selector = new Selector(this);
 		this.editorKit = new EditorKit(this);
@@ -66,6 +68,10 @@ public class Tablature implements TGController {
 				getResourceBuffer().disposeUnregisteredResources();
 			}
 		});
+	}
+
+	public void initDisplayScale(float displayScale) {
+		this.displayScale = Math.max(1.0f, Math.min(displayScale, 3.0f));
 	}
 
 	public void updateTablature(){
@@ -169,7 +175,7 @@ public class Tablature implements TGController {
 
 	public void reloadStyles() {
 		if( this.getViewLayout() != null ){
-			this.getViewLayout().loadStyles(this.scale);
+			this.getViewLayout().loadStyles(this.displayScale * this.scale);
 		}
 		this.loadCaretStyles();
 	}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/TablatureEditor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/TablatureEditor.java
@@ -3,6 +3,9 @@ package app.tuxguitar.app.view.component.tab;
 import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
+import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.system.config.TGConfigManager;
+import app.tuxguitar.app.ui.TGApplication;
 import app.tuxguitar.document.TGDocumentManager;
 import app.tuxguitar.editor.TGEditorManager;
 import app.tuxguitar.editor.event.TGUpdateEvent;
@@ -27,6 +30,17 @@ public class TablatureEditor implements TGEventListener{
 
 	public void initialize() {
 		this.tablature = new Tablature(this.context, TGDocumentManager.getInstance(this.context));
+
+		// Initialize display scale from system DPI detection
+		float displayScale = TGApplication.getInstance(this.context).getApplication().getDisplayScale();
+		this.tablature.initDisplayScale(displayScale);
+
+		// Restore saved zoom level from config, clamped to valid range
+		TGConfigManager config = TGConfigManager.getInstance(this.context);
+		float savedScale = config.getFloatValue(TGConfigKeys.LAYOUT_SCALE, Tablature.DEFAULT_SCALE);
+		savedScale = Math.max(0.5f, Math.min(savedScale, 3.0f));
+		this.tablature.scale(savedScale);
+
 		this.tablature.reloadViewLayout();
 		this.tablature.updateTablature();
 		this.tablature.resetCaret();

--- a/desktop/build-scripts/common-resources/common-macosx/Contents/MacOS/dist/tuxguitar-shortcuts.xml
+++ b/desktop/build-scripts/common-resources/common-macosx/Contents/MacOS/dist/tuxguitar-shortcuts.xml
@@ -75,4 +75,6 @@
 	<shortcut keys="F9" action="action.gui.open-transport-mode-dialog"/>
 	<shortcut keys="Space" action="action.transport.play"/>
 	<shortcut keys="Command t" action="action.gui.toggle-transport-dialog"/>
+	<shortcut keys="Command =" action="action.view.layout-increment-scale"/>
+	<shortcut keys="Command -" action="action.view.layout-decrement-scale"/>
 </shortcuts>


### PR DESCRIPTION
[37m## Summary[39;49;00m[37m[39;49;00m
[37m[39;49;00m
The[37m [39;49;00mtablature/score[37m [39;49;00marea[37m [39;49;00m[34mis[39;49;00m[37m [39;49;00munreadably[37m [39;49;00msmall[37m [39;49;00m[34mon[39;49;00m[37m [39;49;00mhigh-resolution[37m [39;49;00mdisplays.[37m [39;49;00m[34mOn[39;49;00m[37m [39;49;00mmy[37m [39;49;00mLG[37m [39;49;00m38WK95C-W[37m [39;49;00m(3840x1600)[37m [39;49;00m[34mwith[39;49;00m[37m [39;49;00mmacOS[37m [39;49;00m[33m"[39;49;00m[33mMore Space[39;49;00m[33m"[39;49;00m[37m [39;49;00m[34mat[39;49;00m[37m [39;49;00mmaximum,[37m [39;49;00mthe[37m [39;49;00m[34mdefault[39;49;00m[37m [39;49;00m[34m5[39;49;00m-8pt[37m [39;49;00mfonts[37m [39;49;00mare[37m [39;49;00mmicroscopic.[37m [39;49;00mThere[37m [39;49;00mare[37m [39;49;00malso[37m [39;49;00m[34mno[39;49;00m[37m [39;49;00mkeyboard[37m [39;49;00mshortcuts[37m [39;49;00m[34mfor[39;49;00m[37m [39;49;00mzoom[37m [39;49;00m—[37m [39;49;00m[34monly[39;49;00m[37m [39;49;00mthe[37m [39;49;00m[34mView[39;49;00m[37m [39;49;00mmenu[37m [39;49;00m[34mand[39;49;00m[37m [39;49;00mCtrl+MouseWheel[37m [39;49;00m—[37m [39;49;00m[34mand[39;49;00m[37m [39;49;00mthe[37m [39;49;00mzoom[37m [39;49;00mpreference[37m [39;49;00mresets[37m [39;49;00m[34mto[39;49;00m[37m [39;49;00m[34m1.0[39;49;00mx[37m [39;49;00m[34mon[39;49;00m[37m [39;49;00m[34mevery[39;49;00m[37m [39;49;00mlaunch.[37m[39;49;00m
[37m[39;49;00m
This[37m [39;49;00mPR[37m [39;49;00madds:[37m[39;49;00m
[37m[39;49;00m
-[37m [39;49;00m**DPI[37m [39;49;00mauto-detection[37m [39;49;00m[34mfor[39;49;00m[37m [39;49;00mthe[37m [39;49;00mtablature[37m [39;49;00marea**[37m [39;49;00m—[37m [39;49;00ma[37m [39;49;00m[34mnew[39;49;00m[37m [39;49;00m`getDisplayScale()`[37m [39;49;00mmethod[37m [39;49;00m[34mon[39;49;00m[37m [39;49;00mthe[37m [39;49;00m`UIApplication`[37m [39;49;00minterface,[37m [39;49;00m[34mwith[39;49;00m[37m [39;49;00mplatform-[34mspecific[39;49;00m[37m [39;49;00mimplementations:[37m[39;49;00m
[37m  [39;49;00m-[37m [39;49;00m**SWT**:[37m [39;49;00mMulti-[34msignal[39;49;00m[37m [39;49;00mdetection[37m [39;49;00m[34musing[39;49;00m[37m [39;49;00m`Display.getDPI()`[37m [39;49;00m[34magainst[39;49;00m[37m [39;49;00mplatform[37m [39;49;00m[34mreference[39;49;00m[37m [39;49;00mDPI[37m [39;49;00m([34m72[39;49;00m[37m [39;49;00mmacOS,[37m [39;49;00m[34m96[39;49;00m[37m [39;49;00mWindows/Linux),[37m [39;49;00m[34mwith[39;49;00m[37m [39;49;00ma[37m [39;49;00mresolution-based[37m [39;49;00mheuristic[37m [39;49;00mfallback[37m [39;49;00m[34mfor[39;49;00m[37m [39;49;00mnon-HiDPI[37m [39;49;00mexternal[37m [39;49;00mmonitors[37m [39;49;00m(catches[37m [39;49;00mmacOS[37m [39;49;00m[33m"[39;49;00m[33mMore Space[39;49;00m[33m"[39;49;00m[37m [39;49;00m[34mon[39;49;00m[37m [39;49;00multrawide[37m [39;49;00mdisplays).[37m [39;49;00mIncludes[37m [39;49;00ma[37m [39;49;00mRetina[37m [39;49;00mguard[37m [39;49;00m[34mto[39;49;00m[37m [39;49;00mavoid[37m [39;49;00m[36mdouble[39;49;00m-scaling[37m [39;49;00m[34mwhen[39;49;00m[37m [39;49;00mSWT[37m [39;49;00malready[37m [39;49;00mhandles[37m [39;49;00m2x[37m [39;49;00mpixel[37m [39;49;00mdoubling.[37m[39;49;00m
[37m  [39;49;00m-[37m [39;49;00m**JavaFX**:[37m [39;49;00mUses[37m [39;49;00m`Screen.getPrimary().getOutputScaleX()`[37m[39;49;00m
[37m  [39;49;00m-[37m [39;49;00m**Qt**:[37m [39;49;00m[34mReturns[39;49;00m[37m [39;49;00m[34m1.0[39;49;00m[37m [39;49;00m(experimental[37m [39;49;00mtoolkit)[37m[39;49;00m
-[37m [39;49;00m**Zoom[37m [39;49;00mkeyboard[37m [39;49;00mshortcuts**[37m [39;49;00m—[37m [39;49;00m`Ctrl+=`[37m [39;49;00m/[37m [39;49;00m`Ctrl+-`[37m [39;49;00m(SWT),[37m [39;49;00m`Command+=`[37m [39;49;00m/[37m [39;49;00m`Command+-`[37m [39;49;00m(macOS[37m [39;49;00mJFX)[37m[39;49;00m
-[37m [39;49;00m**Zoom[37m [39;49;00mpersistence**[37m [39;49;00m—[37m [39;49;00mthe[37m [39;49;00m[34muser[39;49;00m[33m'[39;49;00m[33ms zoom level is saved to `layout.scale` in config and restored on startup[39;49;00m
[33m- **Raised zoom ceiling** — from 2.0x to 3.0x for more headroom on high-DPI displays[39;49;00m
[33m[39;49;00m
[33mThe effective tablature scale is `displayScale × userZoom`. The DPI baseline is cached once at startup. The user[39;49;00m[33m'[39;49;00ms[37m [39;49;00mmanual[37m [39;49;00mzoom[37m [39;49;00m[34mrange[39;49;00m[37m [39;49;00m([34m0.5[39;49;00mx–3[34m.0[39;49;00mx)[37m [39;49;00moperates[37m [39;49;00mrelative[37m [39;49;00m[34mto[39;49;00m[37m [39;49;00mthis[37m [39;49;00mbaseline,[37m [39;49;00mso[37m [39;49;00m[33m"[39;49;00m[33m1.0x[39;49;00m[33m"[39;49;00m[37m [39;49;00mmeans[37m [39;49;00m[33m"[39;49;00m[33mcomfortable for this display.[39;49;00m[33m"[39;49;00m[37m[39;49;00m
[37m[39;49;00m
[37m### Scope[39;49;00m[37m[39;49;00m
[37m[39;49;00m
This[37m [39;49;00mPR[37m [39;49;00m[34monly[39;49;00m[37m [39;49;00maffects[37m [39;49;00mthe[37m [39;49;00mtablature/score[37m [39;49;00mrendering[37m [39;49;00marea.[37m [39;49;00mIt[37m [39;49;00mdoes[37m [39;49;00m[34mnot[39;49;00m[37m [39;49;00m[34mchange[39;49;00m[37m [39;49;00mmenus,[37m [39;49;00mtoolbars,[37m [39;49;00mdialogs,[37m [39;49;00m[34mor[39;49;00m[37m [39;49;00mother[37m [39;49;00mUI[37m [39;49;00melements.[37m[39;49;00m
[37m[39;49;00m
[37m### Example[39;49;00m[37m[39;49;00m
[37m[39;49;00m
[34mOn[39;49;00m[37m [39;49;00man[37m [39;49;00mLG[37m [39;49;00m38WK95C-W[37m [39;49;00m[34mat[39;49;00m[37m [39;49;00m3840×1600[37m [39;49;00m[34mwith[39;49;00m[37m [39;49;00mmacOS[37m [39;49;00m[33m"[39;49;00m[33mMore Space[39;49;00m[33m"[39;49;00m[37m [39;49;00mmaxed[37m [39;49;00m[34mout[39;49;00m,[37m [39;49;00mthe[37m [39;49;00mresolution[37m [39;49;00mheuristic[37m [39;49;00mcomputes[37m [39;49;00m`√(3840×1600) / √(1920×1080) ≈ 1.72`[37m [39;49;00m[34mas[39;49;00m[37m [39;49;00mthe[37m [39;49;00mDPI[37m [39;49;00mbaseline.[37m [39;49;00mThe[37m [39;49;00mtablature[37m [39;49;00mrenders[37m [39;49;00m[34mat[39;49;00m[37m [39;49;00m[34m1.72[39;49;00mx[37m [39;49;00m[34mby[39;49;00m[37m [39;49;00m[34mdefault[39;49;00m[37m [39;49;00minstead[37m [39;49;00m[34mof[39;49;00m[37m [39;49;00m[34m1.0[39;49;00mx[37m [39;49;00m—[37m [39;49;00mdramatically[37m [39;49;00mmore[37m [39;49;00mreadable[37m [39;49;00m[34mwithout[39;49;00m[37m [39;49;00m[34many[39;49;00m[37m [39;49;00mmanual[37m [39;49;00madjustment[37m [39;49;00mneeded.[37m[39;49;00m
[37m[39;49;00m
[34mOn[39;49;00m[37m [39;49;00ma[37m [39;49;00mstandard[37m [39;49;00m1080p[37m [39;49;00mdisplay,[37m [39;49;00m[34mall[39;49;00m[37m [39;49;00msignals[37m [39;49;00m[34mreturn[39;49;00m[37m [39;49;00m~[34m1.0[39;49;00m[37m [39;49;00m[34mand[39;49;00m[37m [39;49;00mbehavior[37m [39;49;00m[34mis[39;49;00m[37m [39;49;00midentical[37m [39;49;00m[34mto[39;49;00m[37m [39;49;00m[34mbefore[39;49;00m[37m [39;49;00mthis[37m [39;49;00m[34mchange[39;49;00m.[37m[39;49;00m
[37m[39;49;00m
[37m## Test plan[39;49;00m[37m[39;49;00m
[37m[39;49;00m
-[37m [39;49;00m[04m[91m[[39;49;00m[37m [39;49;00m[04m[91m][39;49;00m[37m [39;49;00mBuild[37m [39;49;00m[34mand[39;49;00m[37m [39;49;00mlaunch[37m [39;49;00m[34mon[39;49;00m[37m [39;49;00mmacOS[37m [39;49;00m[34mwith[39;49;00m[37m [39;49;00mSWT[37m [39;49;00m(`desktop/build-scripts/tuxguitar-macosx-swt-cocoa`)[37m[39;49;00m
-[37m [39;49;00m[04m[91m[[39;49;00m[37m [39;49;00m[04m[91m][39;49;00m[37m [39;49;00mVerify[37m [39;49;00mCmd+=[37m [39;49;00mzooms[37m [39;49;00m[34min[39;49;00m[37m [39;49;00m[34mand[39;49;00m[37m [39;49;00mCmd+-[37m [39;49;00mzooms[37m [39;49;00m[34mout[39;49;00m[37m [39;49;00m[34mon[39;49;00m[37m [39;49;00mthe[37m [39;49;00mtablature[37m [39;49;00marea[37m[39;49;00m
-[37m [39;49;00m[04m[91m[[39;49;00m[37m [39;49;00m[04m[91m][39;49;00m[37m [39;49;00mVerify[37m [39;49;00mzoom[37m [39;49;00m[34mlevel[39;49;00m[37m [39;49;00mpersists[37m [39;49;00m[34mafter[39;49;00m[37m [39;49;00mquitting[37m [39;49;00m[34mand[39;49;00m[37m [39;49;00mrelaunching[37m[39;49;00m
-[37m [39;49;00m[04m[91m[[39;49;00m[37m [39;49;00m[04m[91m][39;49;00m[37m [39;49;00mVerify[37m [39;49;00m[34mon[39;49;00m[37m [39;49;00ma[37m [39;49;00mstandard[37m [39;49;00mresolution[37m [39;49;00mdisplay[37m [39;49;00mthat[37m [39;49;00mtablature[37m [39;49;00mrenders[37m [39;49;00mthe[37m [39;49;00msame[37m [39;49;00m[34mas[39;49;00m[37m [39;49;00m[34mbefore[39;49;00m[37m [39;49;00m([34mno[39;49;00m[37m [39;49;00mregression)[37m[39;49;00m
-[37m [39;49;00m[04m[91m[[39;49;00m[37m [39;49;00m[04m[91m][39;49;00m[37m [39;49;00mVerify[37m [39;49;00m[34mon[39;49;00m[37m [39;49;00ma[37m [39;49;00mhigh-DPI[37m [39;49;00mdisplay[37m [39;49;00m(Retina[37m [39;49;00mMacBook,[37m [39;49;00mWindows[37m [39;49;00m[34mwith[39;49;00m[37m [39;49;00mscaling[37m [39;49;00m>[37m [39;49;00m[34m100[39;49;00m%,[37m [39;49;00m[34mor[39;49;00m[37m [39;49;00multrawide[37m [39;49;00m[34mwith[39;49;00m[37m [39;49;00m[33m"[39;49;00m[33mMore Space[39;49;00m[33m"[39;49;00m)[37m [39;49;00mthat[37m [39;49;00mtablature[37m [39;49;00mauto-scales[37m [39;49;00m[34mto[39;49;00m[37m [39;49;00ma[37m [39;49;00mreadable[37m [39;49;00msize[37m[39;49;00m
