### PR TITLE
feat: add HiDPI auto-detection, zoom shortcuts, and zoom persistence for tablature

### DIFF
--- a/desktop/TuxGuitar-ui-toolkit-jfx/src/app/tuxguitar/ui/jfx/JFXApplication.java
+++ b/desktop/TuxGuitar-ui-toolkit-jfx/src/app/tuxguitar/ui/jfx/JFXApplication.java
@@ -8,6 +8,7 @@ import app.tuxguitar.ui.appearance.UIAppearance;
 import app.tuxguitar.ui.jfx.appearance.JFXAppearance;
 
 import javafx.application.Platform;
+import javafx.stage.Screen;
 
 public class JFXApplication extends JFXComponent<JFXApplicationHandle> implements UIApplication {
 
@@ -43,6 +44,21 @@ public class JFXApplication extends JFXComponent<JFXApplicationHandle> implement
 
 	public boolean isInUiThread() {
 		return Platform.isFxApplicationThread();
+	}
+
+	public float getDisplayScale() {
+		try {
+			Screen primary = Screen.getPrimary();
+			if( primary != null ) {
+				float scale = (float) primary.getOutputScaleX();
+				if( scale > 1.0f ) {
+					return Math.min(scale, 3.0f);
+				}
+			}
+			return 1.0f;
+		} catch(Exception e) {
+			return 1.0f;
+		}
 	}
 
 	public void start(Runnable runnable) {

--- a/desktop/TuxGuitar-ui-toolkit-qt/src/app/tuxguitar/ui/qt/QTApplication.java
+++ b/desktop/TuxGuitar-ui-toolkit-qt/src/app/tuxguitar/ui/qt/QTApplication.java
@@ -52,6 +52,10 @@ public class QTApplication extends QTComponent<QTApplicationHandle> implements U
 		return (this.uiThread == Thread.currentThread());
 	}
 
+	public float getDisplayScale() {
+		return 1.0f;
+	}
+
 	public void start(Runnable runnable) {
 		this.uiThread = Thread.currentThread();
 		this.getControl().initialize();

--- a/desktop/TuxGuitar-ui-toolkit-swt/src/app/tuxguitar/ui/swt/SWTApplication.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/app/tuxguitar/ui/swt/SWTApplication.java
@@ -2,8 +2,11 @@ package app.tuxguitar.ui.swt;
 
 import java.net.URL;
 
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Monitor;
 import app.tuxguitar.ui.UIApplication;
 import app.tuxguitar.ui.UIFactory;
 import app.tuxguitar.ui.appearance.UIAppearance;
@@ -53,6 +56,54 @@ public class SWTApplication extends SWTComponent<Display> implements UIApplicati
 		Thread uiThread = this.getControl().getThread();
 		Thread currentThread = Thread.currentThread();
 		return (currentThread == uiThread);
+	}
+
+	public float getDisplayScale() {
+		if( this.isDisposed() ) {
+			return 1.0f;
+		}
+		try {
+			Display display = this.getDisplay();
+
+			// Signal 1: Display DPI vs platform reference
+			// macOS standard = 72, Windows/Linux = 96
+			Point dpi = display.getDPI();
+			String os = System.getProperty("os.name", "").toLowerCase();
+			float referenceDpi = os.contains("mac") ? 72.0f : 96.0f;
+			float dpiScale = dpi.x / referenceDpi;
+
+			// Retina guard: on macOS, if DPI indicates 2x, SWT already handles
+			// pixel doubling internally — don't double-scale
+			if( os.contains("mac") && dpiScale >= 2.0f ) {
+				return 1.0f;
+			}
+
+			if( dpiScale > 1.1f ) {
+				return Math.min(dpiScale, 3.0f);
+			}
+
+			// Signal 2: Resolution heuristic
+			// If DPI reports ~1.0 but monitor resolution is very high,
+			// compute scale from resolution ratio (catches "More Space" on
+			// non-HiDPI external displays)
+			Monitor primaryMonitor = display.getPrimaryMonitor();
+			if( primaryMonitor != null ) {
+				Rectangle bounds = primaryMonitor.getClientArea();
+				if( bounds.width > 2560 ) {
+					double monitorPixels = Math.sqrt((double) bounds.width * bounds.height);
+					double referencePixels = Math.sqrt(1920.0 * 1080.0);
+					float heuristicScale = (float)(monitorPixels / referencePixels);
+					heuristicScale = Math.max(1.0f, Math.min(heuristicScale, 3.0f));
+					if( heuristicScale > 1.1f ) {
+						return heuristicScale;
+					}
+				}
+			}
+
+			return Math.max(1.0f, dpiScale);
+		} catch(Exception e) {
+			return 1.0f;
+		}
 	}
 
 	public void start(Runnable runnable) {

--- a/desktop/TuxGuitar-ui-toolkit-swt/src/app/tuxguitar/ui/swt/appearance/SWTAppearance.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/app/tuxguitar/ui/swt/appearance/SWTAppearance.java
@@ -26,7 +26,7 @@ public class SWTAppearance implements UIAppearance {
 		this.colorMap.put(UIColorAppearance.WidgetForeground, this.createColorModel(SWT.COLOR_WIDGET_FOREGROUND));
 		this.colorMap.put(UIColorAppearance.WidgetLightBackground, this.createColorModel(SWT.COLOR_WIDGET_BACKGROUND, SWT.COLOR_WIDGET_HIGHLIGHT_SHADOW));
 		this.colorMap.put(UIColorAppearance.WidgetLightForeground, this.createColorModel(SWT.COLOR_WIDGET_FOREGROUND));
-		this.colorMap.put(UIColorAppearance.WidgetHighlightBackground, this.createColorModel(SWT.COLOR_WIDGET_HIGHLIGHT_SHADOW));
+		this.colorMap.put(UIColorAppearance.WidgetHighlightBackground, this.createColorModel(SWT.COLOR_WIDGET_BACKGROUND, SWT.COLOR_WIDGET_NORMAL_SHADOW));
 		this.colorMap.put(UIColorAppearance.WidgetHighlightForeground, this.createColorModel(SWT.COLOR_WIDGET_FOREGROUND));
 		this.colorMap.put(UIColorAppearance.WidgetSelectedBackground, this.createColorModel(SWT.COLOR_WIDGET_BACKGROUND, SWT.COLOR_WIDGET_NORMAL_SHADOW));
 		this.colorMap.put(UIColorAppearance.WidgetSelectedForeground, this.createColorModel(SWT.COLOR_LIST_SELECTION_TEXT));

--- a/desktop/TuxGuitar-ui-toolkit/src/app/tuxguitar/ui/UIApplication.java
+++ b/desktop/TuxGuitar-ui-toolkit/src/app/tuxguitar/ui/UIApplication.java
@@ -17,4 +17,8 @@ public interface UIApplication extends UIComponent {
 	void runInUiThread(Runnable runnable);
 
 	boolean isInUiThread();
+
+	default float getDisplayScale() {
+		return 1.0f;
+	}
 }

--- a/desktop/TuxGuitar/dist/tuxguitar-shortcuts.xml
+++ b/desktop/TuxGuitar/dist/tuxguitar-shortcuts.xml
@@ -77,4 +77,6 @@
 	<shortcut keys="F9" action="action.gui.open-transport-mode-dialog"/>
 	<shortcut keys="Space" action="action.transport.play"/>
 	<shortcut keys="Ctrl t" action="action.gui.toggle-transport-dialog"/>
+	<shortcut keys="Ctrl =" action="action.view.layout-increment-scale"/>
+	<shortcut keys="Ctrl -" action="action.view.layout-decrement-scale"/>
 </shortcuts>

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleAction.java
@@ -1,6 +1,8 @@
 package app.tuxguitar.app.action.impl.layout;
 
 import app.tuxguitar.action.TGActionContext;
+import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.view.component.tab.Tablature;
 import app.tuxguitar.app.view.component.tab.TablatureEditor;
 import app.tuxguitar.editor.action.TGActionBase;
@@ -21,5 +23,9 @@ public class TGSetLayoutScaleAction extends TGActionBase{
 
 		Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature();
 		tablature.scale(scale);
+
+		// Persist zoom level to config
+		TGConfigManager config = TGConfigManager.getInstance(getContext());
+		config.setValue(TGConfigKeys.LAYOUT_SCALE, Float.toString(scale));
 	}
 }

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleIncrementAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleIncrementAction.java
@@ -11,7 +11,7 @@ public class TGSetLayoutScaleIncrementAction extends TGActionBase{
 
 	public static final String NAME = "action.view.layout-increment-scale";
 
-	private static final Float MAXIMUM_VALUE = 2f;
+	private static final Float MAXIMUM_VALUE = 3f;
 	private static final Float INCREMENT_VALUE = 0.1f;
 
 	public TGSetLayoutScaleIncrementAction(TGContext context) {

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/system/TGDisposeAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/system/TGDisposeAction.java
@@ -40,6 +40,7 @@ public class TGDisposeAction extends TGActionBase {
 
 		config.setValue(TGConfigKeys.LAYOUT_MODE,TablatureEditor.getInstance(getContext()).getTablature().getViewLayout().getMode());
 		config.setValue(TGConfigKeys.LAYOUT_STYLE,TablatureEditor.getInstance(getContext()).getTablature().getViewLayout().getStyle());
+		config.setValue(TGConfigKeys.LAYOUT_SCALE, Float.toString(TablatureEditor.getInstance(getContext()).getTablature().getScale()));
 		config.setValue(TGConfigKeys.SHOW_PIANO,!TuxGuitar.getInstance().getPianoEditor().isDisposed());
 		config.setValue(TGConfigKeys.SHOW_MATRIX,!TuxGuitar.getInstance().getMatrixEditor().isDisposed());
 		config.setValue(TGConfigKeys.SHOW_FRETBOARD,TuxGuitar.getInstance().getFretBoardEditor().isVisible());

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -51,6 +51,7 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.SHOW_TRACKS, true);
 		loadProperty(properties, TGConfigKeys.LAYOUT_MODE, TGLayout.MODE_VERTICAL);
 		loadProperty(properties, TGConfigKeys.LAYOUT_STYLE, (TGLayout.DISPLAY_TABLATURE | TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_COMPACT | TGLayout.DISPLAY_CHORD_DIAGRAM | TGLayout.HIGHLIGHT_PLAYED_BEAT));
+		loadProperty(properties, TGConfigKeys.LAYOUT_SCALE, "1.0");
 		loadProperty(properties, TGConfigKeys.LANGUAGE, "");
 		loadProperty(properties, TGConfigKeys.EDITOR_MOUSE_MODE, EditorKit.MOUSE_MODE_SELECTION);
 		loadProperty(properties, TGConfigKeys.EDITOR_NATURAL_KEY_MODE, true);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
@@ -22,6 +22,7 @@ public class TGConfigKeys {
 	public static final String SHOW_TRACKS = "show.tracks";
 	public static final String LAYOUT_MODE = "layout.mode";
 	public static final String LAYOUT_STYLE = "layout.style";
+	public static final String LAYOUT_SCALE = "layout.scale";
 	public static final String LANGUAGE = "language";
 	public static final String EDITOR_MOUSE_MODE = "editor.mouse.mode";
 	public static final String EDITOR_NATURAL_KEY_MODE = "editor.natural.key.mode";

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/util/TGDisplayScale.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/util/TGDisplayScale.java
@@ -1,0 +1,21 @@
+package app.tuxguitar.app.util;
+
+public class TGDisplayScale {
+	private static float displayScale = 1.0f;
+
+	public static void init(float scale) {
+		displayScale = scale;
+	}
+
+	public static float getDisplayScale() {
+		return displayScale;
+	}
+
+	public static float scale(float value) {
+		return value * displayScale;
+	}
+
+	public static int scaleInt(float value) {
+		return Math.round(value * displayScale);
+	}
+}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/TGControl.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/TGControl.java
@@ -6,6 +6,7 @@ import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.system.keybindings.KeyBindingActionManager;
 import app.tuxguitar.app.transport.TGTransport;
 import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.util.TGBufferedPainterListenerLocked;
 import app.tuxguitar.graphics.control.TGBeatImpl;
 import app.tuxguitar.graphics.control.TGLayout;
@@ -100,14 +101,14 @@ public class TGControl {
 		this.canvas.addMouseDragListener(this.tablature.getEditorKit().getMouseKit());
 		this.canvas.addZoomListener(this.tablature.getEditorKit().getMouseKit());
 
-		this.hScroll.setIncrement(SCROLL_INCREMENT);
+		this.hScroll.setIncrement(TGDisplayScale.scaleInt(SCROLL_INCREMENT));
 		this.hScroll.addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				TGControl.this.redraw();
 			}
 		});
 
-		this.vScroll.setIncrement(SCROLL_INCREMENT);
+		this.vScroll.setIncrement(TGDisplayScale.scaleInt(SCROLL_INCREMENT));
 		this.vScroll.addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				TGControl.this.redraw();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/Tablature.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/Tablature.java
@@ -49,11 +49,13 @@ public class Tablature implements TGController {
 	private TGLayout viewLayout;
 	private EditorKit editorKit;
 	private Float scale;
+	private float displayScale;
 
 	public Tablature(TGContext context, TGDocumentManager documentManager) {
 		this.context = context;
 		this.documentManager = documentManager;
 		this.scale = DEFAULT_SCALE;
+		this.displayScale = 1.0f;
 		this.caret = new Caret(this);
 		this.selector = new Selector(this);
 		this.editorKit = new EditorKit(this);
@@ -66,6 +68,10 @@ public class Tablature implements TGController {
 				getResourceBuffer().disposeUnregisteredResources();
 			}
 		});
+	}
+
+	public void initDisplayScale(float displayScale) {
+		this.displayScale = Math.max(1.0f, Math.min(displayScale, 3.0f));
 	}
 
 	public void updateTablature(){
@@ -169,7 +175,7 @@ public class Tablature implements TGController {
 
 	public void reloadStyles() {
 		if( this.getViewLayout() != null ){
-			this.getViewLayout().loadStyles(this.scale);
+			this.getViewLayout().loadStyles(this.displayScale * this.scale);
 		}
 		this.loadCaretStyles();
 	}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/TablatureEditor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/TablatureEditor.java
@@ -3,6 +3,9 @@ package app.tuxguitar.app.view.component.tab;
 import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
+import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.system.config.TGConfigManager;
+import app.tuxguitar.app.ui.TGApplication;
 import app.tuxguitar.document.TGDocumentManager;
 import app.tuxguitar.editor.TGEditorManager;
 import app.tuxguitar.editor.event.TGUpdateEvent;
@@ -27,6 +30,17 @@ public class TablatureEditor implements TGEventListener{
 
 	public void initialize() {
 		this.tablature = new Tablature(this.context, TGDocumentManager.getInstance(this.context));
+
+		// Initialize display scale from system DPI detection
+		float displayScale = TGApplication.getInstance(this.context).getApplication().getDisplayScale();
+		this.tablature.initDisplayScale(displayScale);
+
+		// Restore saved zoom level from config, clamped to valid range
+		TGConfigManager config = TGConfigManager.getInstance(this.context);
+		float savedScale = config.getFloatValue(TGConfigKeys.LAYOUT_SCALE, Tablature.DEFAULT_SCALE);
+		savedScale = Math.max(0.5f, Math.min(savedScale, 3.0f));
+		this.tablature.scale(savedScale);
+
 		this.tablature.reloadViewLayout();
 		this.tablature.updateTablature();
 		this.tablature.resetCaret();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/table/TGTableColorModel.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/table/TGTableColorModel.java
@@ -58,8 +58,8 @@ public class TGTableColorModel {
 		colorModels[EVEN_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetHighlightForeground);
 		colorModels[ODD_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightBackground);
 		colorModels[ODD_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightForeground);
-		colorModels[SELECTED_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetSelectedBackground);
-		colorModels[SELECTED_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetSelectedForeground);
+		colorModels[SELECTED_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.InputSelectedBackground);
+		colorModels[SELECTED_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.InputSelectedForeground);
 		colorModels[CELL_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightBackground);
 		colorModels[CELL_REST_MEASURE] = appearance.getColorModel(UIColorAppearance.WidgetSelectedBackground);
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/about/TGAboutDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/about/TGAboutDialog.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.about;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.ui.TGApplication;
 import app.tuxguitar.app.view.controller.TGViewContext;
@@ -71,10 +72,10 @@ public class TGAboutDialog {
 				float height = TGAboutDialog.this.image.getHeight();
 
 				UIPainter tgPainter = event.getPainter();
-				tgPainter.drawImage(TGAboutDialog.this.image, ((IMAGE_WIDTH - width) / 2f),((IMAGE_HEIGHT - height) / 2f));
+				tgPainter.drawImage(TGAboutDialog.this.image, ((TGDisplayScale.scale(IMAGE_WIDTH) - width) / 2f),((TGDisplayScale.scale(IMAGE_HEIGHT) - height) / 2f));
 			}
 		});
-		headerLayout.set(this.imageComposite, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false, 1, 1, IMAGE_WIDTH, IMAGE_HEIGHT, null);
+		headerLayout.set(this.imageComposite, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false, 1, 1, TGDisplayScale.scale(IMAGE_WIDTH), TGDisplayScale.scale(IMAGE_HEIGHT), null);
 
 		final UIColor titleColor = uiFactory.createColor(0xc0, 0xc0, 0xc0);
 		final UIFont titleFont = uiFactory.createFont(configManager.getFontModelConfigValue(TGConfigKeys.FONT_ABOUT_DIALOG_TITLE));
@@ -97,7 +98,7 @@ public class TGAboutDialog {
 		dialogLayout.set(tabs, 2, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
 
 		final UITabFolder tabFolder = uiFactory.createTabFolder(tabs, false);
-		tabsLayout.set(tabFolder, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TAB_ITEM_WIDTH, TAB_ITEM_HEIGHT, null);
+		tabsLayout.set(tabFolder, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(TAB_ITEM_WIDTH), TGDisplayScale.scale(TAB_ITEM_HEIGHT), null);
 
 		TGAboutContentReader docReader = new TGAboutContentReader(context.getContext());
 
@@ -133,7 +134,7 @@ public class TGAboutDialog {
 				dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonClose, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonClose, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 
 		tabFolder.setSelectedIndex(0);
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/bend/TGBendDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/bend/TGBendDialog.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.icons.TGColorManager;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.icons.TGColorManager.TGSkinnableColor;
 import app.tuxguitar.app.ui.TGApplication;
 import app.tuxguitar.app.view.controller.TGViewContext;
@@ -69,15 +70,15 @@ public class TGBendDialog {
 	private void init(){
 		this.x = new int[X_LENGTH];
 		this.y = new int[Y_LENGTH];
-		this.width = ((X_SPACING * X_LENGTH) - X_SPACING);
-		this.height = ((Y_SPACING * Y_LENGTH) - Y_SPACING);
+		this.width = ((TGDisplayScale.scaleInt(X_SPACING) * X_LENGTH) - TGDisplayScale.scaleInt(X_SPACING));
+		this.height = ((TGDisplayScale.scaleInt(Y_SPACING) * Y_LENGTH) - TGDisplayScale.scaleInt(Y_SPACING));
 		this.points = new ArrayList<UIPosition>();
 
 		for(int i = 0;i < this.x.length;i++){
-			this.x[i] = ((i + 1) * X_SPACING);
+			this.x[i] = ((i + 1) * TGDisplayScale.scaleInt(X_SPACING));
 		}
 		for(int i = 0;i < this.y.length;i++){
-			this.y[i] = ((i + 1) * Y_SPACING);
+			this.y[i] = ((i + 1) * TGDisplayScale.scaleInt(Y_SPACING));
 		}
 	}
 
@@ -136,7 +137,7 @@ public class TGBendDialog {
 					TGBendDialog.this.editor.redraw();
 				}
 			});
-			leftCompositeLayout.set(this.editor, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, getWidth() + (X_SPACING * 2f), getHeight() + (Y_SPACING * 2f), null);
+			leftCompositeLayout.set(this.editor, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, getWidth() + (TGDisplayScale.scaleInt(X_SPACING) * 2f), getHeight() + (TGDisplayScale.scaleInt(Y_SPACING) * 2f), null);
 
 			//-------------DEFAULT BEND LIST---------------------------------------------------
 			final List<UISelectItem<TGEffectBend>> presetItems = this.createPresetItems();
@@ -210,16 +211,16 @@ public class TGBendDialog {
 			this.setStyleX(painter,i);
 			painter.initPath();
 			painter.setAntialias(false);
-			painter.moveTo(this.x[i],Y_SPACING);
-			painter.lineTo(this.x[i],Y_SPACING + this.height);
+			painter.moveTo(this.x[i],TGDisplayScale.scaleInt(Y_SPACING));
+			painter.lineTo(this.x[i],TGDisplayScale.scaleInt(Y_SPACING) + this.height);
 			painter.closePath();
 		}
 		for(int i = 0;i < this.y.length;i++){
 			this.setStyleY(painter,i);
 			painter.initPath();
 			painter.setAntialias(false);
-			painter.moveTo(X_SPACING,this.y[i]);
-			painter.lineTo(X_SPACING + this.width,this.y[i]);
+			painter.moveTo(TGDisplayScale.scaleInt(X_SPACING),this.y[i]);
+			painter.lineTo(TGDisplayScale.scaleInt(X_SPACING) + this.width,this.y[i]);
 			painter.closePath();
 		}
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/browser/main/TGBrowserDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/browser/main/TGBrowserDialog.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.document.TGDocumentListAttributes;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.system.icons.TGSkinEvent;
 import app.tuxguitar.app.system.icons.TGSkinManager;
@@ -119,7 +120,7 @@ public class TGBrowserDialog implements TGBrowserFactoryListener, TGBrowserConne
 		this.updateCollections(null);
 		this.updateTable();
 
-		this.dialog.setBounds(new UIRectangle(0, 0, SHELL_WIDTH,SHELL_HEIGHT));
+		this.dialog.setBounds(new UIRectangle(0, 0, TGDisplayScale.scale(SHELL_WIDTH),TGDisplayScale.scale(SHELL_HEIGHT)));
 		this.dialog.addDisposeListener(new UIDisposeListener() {
 			public void onDispose(UIDisposeEvent event) {
 				exit();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/channel/TGChannelList.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/channel/TGChannelList.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.song.models.TGChannel;
 import app.tuxguitar.ui.UIFactory;
 import app.tuxguitar.ui.event.UISelectionEvent;
@@ -35,7 +36,7 @@ public class TGChannelList {
 		this.channelItemAreaSC = uiFactory.createScrollBarPanel(parent, true, false, true);
 		this.channelItemAreaSC.setLayout(new UIScrollBarPanelLayout(false, true, true, true, false, true));
 
-		this.channelItemAreaSC.getVScroll().setIncrement(SCROLL_INCREMENT);
+		this.channelItemAreaSC.getVScroll().setIncrement(TGDisplayScale.scaleInt(SCROLL_INCREMENT));
 		this.channelItemAreaSC.getVScroll().addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				TGChannelList.this.channelItemAreaSC.layout();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/channel/TGChannelManagerDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/channel/TGChannelManagerDialog.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.channel;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.icons.TGSkinEvent;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.system.language.TGLanguageEvent;
 import app.tuxguitar.app.ui.TGApplication;
@@ -139,8 +140,8 @@ public class TGChannelManagerDialog implements TGEventListener {
 
 	private UISize createPreferredSize(UISize size) {
 		UISize preferredSize = new UISize(size.getWidth(), size.getHeight());
-		if( preferredSize.getHeight() < MINIMUN_HEIGHT ) {
-			preferredSize.setHeight(MINIMUN_HEIGHT);
+		if( preferredSize.getHeight() < TGDisplayScale.scale(MINIMUN_HEIGHT) ) {
+			preferredSize.setHeight(TGDisplayScale.scale(MINIMUN_HEIGHT));
 		}
 		return preferredSize;
 	}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordCustomList.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordCustomList.java
@@ -1,6 +1,7 @@
 package app.tuxguitar.app.view.dialog.chord;
 
 import app.tuxguitar.app.TuxGuitar;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.util.TGMessageDialogUtil;
 import app.tuxguitar.song.models.TGChord;
 import app.tuxguitar.ui.UIFactory;
@@ -48,7 +49,7 @@ public class TGChordCustomList {
 			}
 		});
 		compositeLayout.set(this.chords, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
-		compositeLayout.set(this.chords, UITableLayout.MAXIMUM_PACKED_HEIGHT, MAXIMUM_LIST_PACKED_HEIGHT);
+		compositeLayout.set(this.chords, UITableLayout.MAXIMUM_PACKED_HEIGHT, TGDisplayScale.scale(MAXIMUM_LIST_PACKED_HEIGHT));
 
 		//-------------BUTTONS-----------------------------
 		UITableLayout buttonsLayout = new UITableLayout();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordEditor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordEditor.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.graphics.control.TGChordImpl;
 import app.tuxguitar.song.models.TGChannel;
 import app.tuxguitar.song.models.TGChord;
@@ -78,8 +79,8 @@ public class TGChordEditor {
 		this.firstFrets = new boolean[this.maxStrings];
 		this.strings = new int[this.maxStrings];
 		this.frets = new int[TGChordImpl.MAX_FRETS];
-		this.width = ((STRING_SPACING * this.maxStrings) - STRING_SPACING);
-		this.height = ((FRET_SPACING * TGChordImpl.MAX_FRETS) - FRET_SPACING);
+		this.width = ((TGDisplayScale.scaleInt(STRING_SPACING) * this.maxStrings) - TGDisplayScale.scaleInt(STRING_SPACING));
+		this.height = ((TGDisplayScale.scaleInt(FRET_SPACING) * TGChordImpl.MAX_FRETS) - TGDisplayScale.scaleInt(FRET_SPACING));
 		this.points = new ArrayList<UIPosition>();
 
 		for (int i = 0; i < this.firstFrets.length; i++) {
@@ -87,11 +88,11 @@ public class TGChordEditor {
 		}
 
 		for (int i = 0; i < this.strings.length; i++) {
-			this.strings[i] = ((i + 1) * STRING_SPACING);
+			this.strings[i] = ((i + 1) * TGDisplayScale.scaleInt(STRING_SPACING));
 		}
 
 		for (int i = 0; i < this.frets.length; i++) {
-			this.frets[i] = ((i + 1) * FRET_SPACING);
+			this.frets[i] = ((i + 1) * TGDisplayScale.scaleInt(FRET_SPACING));
 		}
 
 		UITableLayout compositeLayout = new UITableLayout();
@@ -106,8 +107,8 @@ public class TGChordEditor {
 
 		this.canvas = uiFactory.createCanvas(this.scrollBarPanel, false);
 
-		float minimumWidth = (getWidth() + (STRING_SPACING * 2f));
-		float minimumHeight = (getHeight() + (FRET_SPACING * 2f));
+		float minimumWidth = (getWidth() + (TGDisplayScale.scaleInt(STRING_SPACING) * 2f));
+		float minimumHeight = (getHeight() + (TGDisplayScale.scaleInt(FRET_SPACING) * 2f));
 		scrollBarLayout.set(this.canvas, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, minimumWidth, minimumHeight, 0f);
 
 		UITableLayout nameLayout = new UITableLayout(0f);
@@ -154,7 +155,7 @@ public class TGChordEditor {
 	}
 
 	private void paintEditor(UIPainter painter) {
-		int noteSize = (FRET_SPACING / 2);
+		int noteSize = (TGDisplayScale.scaleInt(FRET_SPACING) / 2);
 
 		painter.setLineWidth(UIPainter.THINNEST_LINE_WIDTH);
 
@@ -170,18 +171,18 @@ public class TGChordEditor {
 		// dibujo el puente
 		painter.initPath();
 		painter.setAntialias(false);
-		painter.moveTo((STRING_SPACING - 10), (FRET_SPACING - 10));
-		painter.lineTo(STRING_SPACING + (this.width + 10), (FRET_SPACING - 10));
+		painter.moveTo((TGDisplayScale.scaleInt(STRING_SPACING) - 10), (TGDisplayScale.scaleInt(FRET_SPACING) - 10));
+		painter.lineTo(TGDisplayScale.scaleInt(STRING_SPACING) + (this.width + 10), (TGDisplayScale.scaleInt(FRET_SPACING) - 10));
 		painter.closePath();
 
-		painter.drawString(Integer.toString(getFret()), FRET_SPACING - 25,STRING_SPACING);
+		painter.drawString(Integer.toString(getFret()), TGDisplayScale.scaleInt(FRET_SPACING) - 25,TGDisplayScale.scaleInt(STRING_SPACING));
 
 		// dibujo las cuerdas
 		painter.initPath();
 		painter.setAntialias(false);
 		for (int i = 0; i < this.strings.length; i++) {
-			painter.moveTo(this.strings[i], FRET_SPACING);
-			painter.lineTo(this.strings[i], FRET_SPACING + this.height);
+			painter.moveTo(this.strings[i], TGDisplayScale.scaleInt(FRET_SPACING));
+			painter.lineTo(this.strings[i], TGDisplayScale.scaleInt(FRET_SPACING) + this.height);
 		}
 		painter.closePath();
 
@@ -189,8 +190,8 @@ public class TGChordEditor {
 		painter.initPath();
 		painter.setAntialias(false);
 		for (int i = 0; i < this.frets.length; i++) {
-			painter.moveTo(STRING_SPACING, this.frets[i]);
-			painter.lineTo(STRING_SPACING + this.width, this.frets[i]);
+			painter.moveTo(TGDisplayScale.scaleInt(STRING_SPACING), this.frets[i]);
+			painter.lineTo(TGDisplayScale.scaleInt(STRING_SPACING) + this.width, this.frets[i]);
 		}
 		painter.closePath();
 
@@ -199,7 +200,7 @@ public class TGChordEditor {
 
 		for(UIPosition point : this.points) {
 			painter.initPath(UIPainter.PATH_FILL);
-			painter.addCircle(point.getX(), point.getY() + (FRET_SPACING / 2), noteSize);
+			painter.addCircle(point.getX(), point.getY() + (TGDisplayScale.scaleInt(FRET_SPACING) / 2), noteSize);
 			painter.closePath();
 		}
 
@@ -228,10 +229,10 @@ public class TGChordEditor {
 		int stringIndex = getStringIndex(x);
 		int fretIndex = getFretIndex(y);
 
-		if (y < FRET_SPACING) {
+		if (y < TGDisplayScale.scaleInt(FRET_SPACING)) {
 			this.firstFrets[stringIndex] = !this.firstFrets[stringIndex];
 			this.removePointsAtStringLine(this.strings[stringIndex]);
-		} else if (y < (FRET_SPACING * TGChordImpl.MAX_FRETS)) {
+		} else if (y < (TGDisplayScale.scaleInt(FRET_SPACING) * TGChordImpl.MAX_FRETS)) {
 			UIPosition point = new UIPosition(this.strings[stringIndex], this.frets[fretIndex]);
 			if (!this.removePoint(point)) {
 				this.firstFrets[stringIndex] = false;
@@ -307,8 +308,8 @@ public class TGChordEditor {
 			if (index < 0) {
 				index = i;
 			} else {
-				float distanceX = Math.abs(y - (this.frets[index] + (FRET_SPACING / 2)));
-				float currDistanceX = Math.abs(y - (this.frets[i] + (FRET_SPACING / 2)));
+				float distanceX = Math.abs(y - (this.frets[index] + (TGDisplayScale.scaleInt(FRET_SPACING) / 2)));
+				float currDistanceX = Math.abs(y - (this.frets[i] + (TGDisplayScale.scaleInt(FRET_SPACING) / 2)));
 				if ( currDistanceX < distanceX) {
 					index = i;
 				}
@@ -340,7 +341,7 @@ public class TGChordEditor {
 		if (value < 0) {
 			for(UIPosition point : this.points) {
 				if (string == (this.maxStrings - getStringIndex(point.getX()))) {
-					value = (getFretIndex(point.getY() + (FRET_SPACING / 2)) + 1);
+					value = (getFretIndex(point.getY() + (TGDisplayScale.scaleInt(FRET_SPACING) / 2)) + 1);
 					value += (getFret() - 1);
 				}
 			}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordList.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordList.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.graphics.control.TGChordImpl;
 import app.tuxguitar.graphics.control.TGLayout;
 import app.tuxguitar.graphics.control.TGResourceBuffer;
@@ -99,10 +100,10 @@ public class TGChordList {
 				redraw();
 			}
 		});
-		scrollBarLayout.set(this.canvas, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, null, MIN_HEIGHT, 0f);
+		scrollBarLayout.set(this.canvas, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, null, TGDisplayScale.scale(MIN_HEIGHT), 0f);
 
 		final UIScrollBar uiScrollBar = this.control.getVScroll();
-		uiScrollBar.setIncrement(SCROLL_INCREMENT);
+		uiScrollBar.setIncrement(TGDisplayScale.scaleInt(SCROLL_INCREMENT));
 		uiScrollBar.addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				redraw();
@@ -146,10 +147,10 @@ public class TGChordList {
 			chord.setColor(color);
 			chord.setNoteColor(color);
 			chord.setTonicColor(this.dialog.getColor(TGChordStyleAdapter.COLOR_TONIC));
-			chord.setFirstFretSpacing(CHORD_FIRST_FRET_SPACING);
-			chord.setStringSpacing(CHORD_STRING_SPACING);
-			chord.setFretSpacing(CHORD_FRET_SPACING);
-			chord.setNoteSize(CHORD_NOTE_SIZE);
+			chord.setFirstFretSpacing(TGDisplayScale.scale(CHORD_FIRST_FRET_SPACING));
+			chord.setStringSpacing(TGDisplayScale.scale(CHORD_STRING_SPACING));
+			chord.setFretSpacing(TGDisplayScale.scale(CHORD_FRET_SPACING));
+			chord.setNoteSize(TGDisplayScale.scale(CHORD_NOTE_SIZE));
 			chord.setLineWidth(CHORD_LINE_WIDTH);
 			chord.setFirstFretFont(getFont());
 			chord.setStyle(TGLayout.DISPLAY_CHORD_DIAGRAM);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/fretboard/TGFretBoard.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/fretboard/TGFretBoard.java
@@ -9,6 +9,7 @@ import app.tuxguitar.app.action.impl.caret.TGGoRightAction;
 import app.tuxguitar.app.action.impl.caret.TGMoveToAction;
 import app.tuxguitar.app.action.impl.tools.TGOpenScaleDialogAction;
 import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.transport.TGTransport;
 import app.tuxguitar.app.ui.TGApplication;
@@ -320,11 +321,11 @@ public class TGFretBoard {
 	}
 
 	private void initStrings(int count) {
-		int fromY = TOP_SPACING;
+		int fromY = TGDisplayScale.scaleInt(TOP_SPACING);
 		this.strings = new int[count];
 
 		for (int i = 0; i < this.strings.length; i++) {
-			this.strings[i] = fromY + (this.stringSpacing * i);
+			this.strings[i] = fromY + (TGDisplayScale.scaleInt(this.stringSpacing) * i);
 		}
 	}
 
@@ -367,7 +368,7 @@ public class TGFretBoard {
 			UIFactory factory = getUIFactory();
 			UIRectangle area = this.control.getChildArea();
 
-			this.fretBoard = factory.createImage(area.getWidth(), (this.stringSpacing * (this.strings.length - 1)) + TOP_SPACING + BOTTOM_SPACING);
+			this.fretBoard = factory.createImage(area.getWidth(), (TGDisplayScale.scaleInt(this.stringSpacing) * (this.strings.length - 1)) + TGDisplayScale.scaleInt(TOP_SPACING) + TGDisplayScale.scaleInt(BOTTOM_SPACING));
 
 			UIPainter painterBuffer = this.fretBoard.createPainter();
 
@@ -420,8 +421,8 @@ public class TGFretBoard {
 			if (fret == 0) {
 				int size = getOvalSize();
 				int x = this.frets[fretIndex] + ((this.frets[fretIndex + 1] - this.frets[fretIndex]) / 2);
-				int y1 = this.strings[0] + ((this.strings[this.strings.length - 1] - this.strings[0]) / 2) - this.stringSpacing;
-				int y2 = this.strings[0] + ((this.strings[this.strings.length - 1] - this.strings[0]) / 2) + this.stringSpacing;
+				int y1 = this.strings[0] + ((this.strings[this.strings.length - 1] - this.strings[0]) / 2) - TGDisplayScale.scaleInt(this.stringSpacing);
+				int y2 = this.strings[0] + ((this.strings[this.strings.length - 1] - this.strings[0]) / 2) + TGDisplayScale.scaleInt(this.stringSpacing);
 				painter.initPath(UIPainter.PATH_FILL);
 				painter.addCircle(x, y1, size);
 				painter.addCircle(x, y2, size);
@@ -521,7 +522,7 @@ public class TGFretBoard {
 
 			float fmWidth = painter.getFMWidth(text);
 			float fmHeight = painter.getFMHeight();
-			int ovalSize = (int)Math.max(fmWidth, fmHeight) + this.stringSpacing/10;
+			int ovalSize = (int)Math.max(fmWidth, fmHeight) + TGDisplayScale.scaleInt(this.stringSpacing)/10;
 			ovalSize = Math.min(ovalSize, this.getMaxOvalSize());
 			this.paintKeyOval(painter, background, x, y, ovalSize);
 			painter.drawString(text, x - (fmWidth / 2f),y + painter.getFMMiddleLine());
@@ -630,11 +631,13 @@ public class TGFretBoard {
 	}
 
 	private int getOvalSize(){
-		return ((this.stringSpacing / 2) + (this.stringSpacing / 10));
+		int scaled = TGDisplayScale.scaleInt(this.stringSpacing);
+		return ((scaled / 2) + (scaled / 10));
 	}
 
 	private int getMaxOvalSize() {
-		return (this.stringSpacing - this.stringSpacing/10);
+		int scaled = TGDisplayScale.scaleInt(this.stringSpacing);
+		return (scaled - scaled/10);
 	}
 
 	private void addNote(int fret, int string) {
@@ -739,7 +742,7 @@ public class TGFretBoard {
 	}
 
 	public void computePackedSize() {
-		this.control.getLayout().set(this.fretBoardComposite, UITableLayout.PACKED_HEIGHT, Float.valueOf((this.stringSpacing * (this.strings.length - 1)) + TOP_SPACING + BOTTOM_SPACING));
+		this.control.getLayout().set(this.fretBoardComposite, UITableLayout.PACKED_HEIGHT, Float.valueOf((TGDisplayScale.scaleInt(this.stringSpacing) * (this.strings.length - 1)) + TGDisplayScale.scaleInt(TOP_SPACING) + TGDisplayScale.scaleInt(BOTTOM_SPACING)));
 		this.control.computePackedSize(null, null);
 	}
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/fretboard/TGFretBoardConfig.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/fretboard/TGFretBoardConfig.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.fretboard;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.config.TGConfigDefaults;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.config.TGConfigKeys;
 import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.ui.TGApplication;
@@ -209,7 +210,7 @@ public class TGFretBoardConfig {
 		directionCombo.addItem(new UISelectItem<Integer>(TuxGuitar.getProperty("fretboard.right-mode"), DIRECTION_RIGHT));
 		directionCombo.addItem(new UISelectItem<Integer>(TuxGuitar.getProperty("fretboard.left-mode"), DIRECTION_LEFT));
 		directionCombo.setSelectedItem(new UISelectItem<Integer>(null, this.direction));
-		groupLayout.set(directionCombo, groupRow, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		groupLayout.set(directionCombo, groupRow, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 
 		// ----------------------------------------------------------------------
 		groupLayout = new UITableLayout();
@@ -245,7 +246,7 @@ public class TGFretBoardConfig {
 				applyChanges();
 			}
 		});
-		buttonsLayout.set(buttonDefaults, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonDefaults, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		final UIButton buttonOK = factory.createButton(buttons);
 		buttonOK.setDefaultButton();
@@ -267,7 +268,7 @@ public class TGFretBoardConfig {
 				applyChanges();
 			}
 		});
-		buttonsLayout.set(buttonOK, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonOK, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		final UIButton buttonCancel = factory.createButton(buttons);
 		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -276,7 +277,7 @@ public class TGFretBoardConfig {
 				window.dispose();
 			}
 		});
-		buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 		buttonsLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
 
 		TGDialogUtil.openDialog(window, TGDialogUtil.OPEN_STYLE_CENTER | TGDialogUtil.OPEN_STYLE_PACK);
@@ -303,7 +304,7 @@ public class TGFretBoardConfig {
 
 		ButtonColor button = new ButtonColor(window, parent, TuxGuitar.getProperty("choose"));
 		button.loadColor(new UIColorModel(rgb.getRed(), rgb.getGreen(), rgb.getBlue()));
-		layout.set(button.getControl(), row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		layout.set(button.getControl(), row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 
 		return button.getValue();
 	}
@@ -335,7 +336,7 @@ public class TGFretBoardConfig {
 				});
 			}
 		});
-		layout.set(button, row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		layout.set(button, row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 
 		return selection;
 	}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/harmonic/TGHarmonicDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/harmonic/TGHarmonicDialog.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.controller.TGViewContext;
 import app.tuxguitar.app.view.util.TGDialogUtil;
 import app.tuxguitar.document.TGDocumentContextAttributes;
@@ -60,7 +61,7 @@ public class TGHarmonicDialog {
 			UILegendPanel group = uiFactory.createLegendPanel(dialog);
 			group.setLayout(groupLayout);
 			group.setText(TuxGuitar.getProperty("effects.harmonic.type-of-harmonic"));
-			dialogLayout.set(group, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, null, null, WIDTH, null, null);
+			dialogLayout.set(group, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, null, null, TGDisplayScale.scale(WIDTH), null, null);
 
 			this.typeButtons = new UIRadioButton[5];
 			UISelectionListener listener = new UISelectionListener() {
@@ -109,7 +110,7 @@ public class TGHarmonicDialog {
 					dialog.dispose();
 				}
 			});
-			buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+			buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 
 			UIButton buttonClean = uiFactory.createButton(buttons);
 			buttonClean.setText(TuxGuitar.getProperty("clean"));
@@ -126,7 +127,7 @@ public class TGHarmonicDialog {
 					dialog.dispose();
 				}
 			});
-			buttonsLayout.set(buttonClean, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+			buttonsLayout.set(buttonClean, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 
 			UIButton buttonCancel = uiFactory.createButton(buttons);
 			buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -135,7 +136,7 @@ public class TGHarmonicDialog {
 					dialog.dispose();
 				}
 			});
-			buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+			buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 			buttonsLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
 
 			this.initDefaults(noteRange);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/info/TGSongInfoDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/info/TGSongInfoDialog.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.info;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.controller.TGViewContext;
 import app.tuxguitar.app.view.util.TGDialogUtil;
 import app.tuxguitar.document.TGDocumentContextAttributes;
@@ -39,7 +40,7 @@ public class TGSongInfoDialog {
 		UILegendPanel group = uiFactory.createLegendPanel(dialog);
 		group.setText(TuxGuitar.getProperty("composition.properties"));
 		group.setLayout(groupLayout);
-		dialogLayout.set(group, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, GROUP_WIDTH, null, null);
+		dialogLayout.set(group, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(GROUP_WIDTH), null, null);
 
 		//-------NAME------------------------------------
 		UILabel nameLabel = uiFactory.createLabel(group);
@@ -139,7 +140,7 @@ public class TGSongInfoDialog {
 				dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 
 		UIButton buttonCancel = uiFactory.createButton(buttons);
 		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -148,7 +149,7 @@ public class TGSongInfoDialog {
 				dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonCancel, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonCancel, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 		buttonsLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
 
 		TGDialogUtil.openDialog(dialog,TGDialogUtil.OPEN_STYLE_CENTER | TGDialogUtil.OPEN_STYLE_PACK);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/lyric/TGLyricEditor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/lyric/TGLyricEditor.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.action.TGActionProcessorListener;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.action.impl.track.TGGoNextTrackAction;
 import app.tuxguitar.app.action.impl.track.TGGoPreviousTrackAction;
 import app.tuxguitar.app.system.icons.TGIconManager;
@@ -98,7 +99,7 @@ public class TGLyricEditor implements TGEventListener {
 
 		this.dialog = uiFactory.createWindow(TGWindow.getInstance(this.context).getWindow(), false, true);
 		this.dialog.setLayout(new UITableLayout(0f));
-		this.dialog.setBounds(new UIRectangle(0, 0, EDITOR_WIDTH, EDITOR_HEIGHT));
+		this.dialog.setBounds(new UIRectangle(0, 0, TGDisplayScale.scale(EDITOR_WIDTH), TGDisplayScale.scale(EDITOR_HEIGHT)));
 		this.dialog.addDisposeListener(new UIDisposeListener() {
 			public void onDispose(UIDisposeEvent event) {
 				TGLyricEditor.this.onDispose();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/marker/TGMarkerEditor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/marker/TGMarkerEditor.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.marker;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.action.impl.marker.TGModifyMarkerAction;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.ui.TGApplication;
 import app.tuxguitar.app.view.controller.TGViewContext;
 import app.tuxguitar.app.view.util.TGDialogUtil;
@@ -84,7 +85,7 @@ public class TGMarkerEditor {
 				}
 			}
 		});
-		groupLayout.set(this.measureSpinner, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		groupLayout.set(this.measureSpinner, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 
 		// Title
 		UILabel titleLabel = uiFactory.createLabel(group);
@@ -93,7 +94,7 @@ public class TGMarkerEditor {
 
 		this.titleText = uiFactory.createTextField(group);
 		this.titleText.setText(this.marker.getTitle());
-		groupLayout.set(this.titleText, 2, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		groupLayout.set(this.titleText, 2, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 		this.titleText.setFocus();
 		this.titleText.selectAll();
 
@@ -132,7 +133,7 @@ public class TGMarkerEditor {
 			}
 		});
 		this.setButtonColor(uiFactory);
-		groupLayout.set(this.colorButton, 3, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		groupLayout.set(this.colorButton, 3, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 
 		// ------------------BUTTONS--------------------------
 		UITableLayout buttonsLayout = new UITableLayout(0f);
@@ -149,7 +150,7 @@ public class TGMarkerEditor {
 				TGMarkerEditor.this.dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		UIButton buttonCancel = uiFactory.createButton(buttons);
 		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -158,7 +159,7 @@ public class TGMarkerEditor {
 				TGMarkerEditor.this.dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonCancel, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonCancel, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 		buttonsLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
 
 		TGDialogUtil.openDialog(this.dialog,TGDialogUtil.OPEN_STYLE_CENTER | TGDialogUtil.OPEN_STYLE_PACK);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/matrix/TGMatrixConfig.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/matrix/TGMatrixConfig.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.matrix;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.config.TGConfigDefaults;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.config.TGConfigKeys;
 import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.ui.TGApplication;
@@ -214,7 +215,7 @@ public class TGMatrixConfig {
 				applyChanges();
 			}
 		});
-		buttonsLayout.set(buttonDefaults, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonDefaults, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		final UIButton buttonOK = factory.createButton(buttons);
 		buttonOK.setDefaultButton();
@@ -226,7 +227,7 @@ public class TGMatrixConfig {
 				applyChanges();
 			}
 		});
-		buttonsLayout.set(buttonOK, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonOK, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		final UIButton buttonCancel = factory.createButton(buttons);
 		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -235,7 +236,7 @@ public class TGMatrixConfig {
 				window.dispose();
 			}
 		});
-		buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 		buttonsLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
 
 		TGDialogUtil.openDialog(window, TGDialogUtil.OPEN_STYLE_CENTER | TGDialogUtil.OPEN_STYLE_PACK);
@@ -279,7 +280,7 @@ public class TGMatrixConfig {
 				});
 			}
 		});
-		layout.set(button, row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		layout.set(button, row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 
 		return selection;
 	}
@@ -294,7 +295,7 @@ public class TGMatrixConfig {
 
 		ButtonColor button = new ButtonColor(window, parent, TuxGuitar.getProperty("choose"));
 		button.loadColor(new UIColorModel(rgb.getRed(), rgb.getGreen(), rgb.getBlue()));
-		layout.set(button.getControl(), row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		layout.set(button.getControl(), row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 
 		return button.getValue();
 	}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/matrix/TGMatrixEditor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/matrix/TGMatrixEditor.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.action.TGActionProcessorListener;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.action.impl.caret.TGGoLeftAction;
 import app.tuxguitar.app.action.impl.caret.TGGoRightAction;
 import app.tuxguitar.app.action.impl.caret.TGMoveToAction;
@@ -128,7 +129,7 @@ public class TGMatrixEditor implements TGEventListener {
 		this.dialog = getUIFactory().createWindow(TGWindow.getInstance(this.context).getWindow(), false, true);
 		this.dialog.setText(TuxGuitar.getProperty("matrix.editor"));
 		this.dialog.setImage(TuxGuitar.getInstance().getIconManager().getAppIcon());
-		this.dialog.setBounds(new UIRectangle(new UISize(DEFAULT_WIDTH, DEFAULT_HEIGHT)));
+		this.dialog.setBounds(new UIRectangle(new UISize(TGDisplayScale.scale(DEFAULT_WIDTH), TGDisplayScale.scale(DEFAULT_HEIGHT))));
 		this.dialog.addDisposeListener(new DisposeListenerImpl());
 		this.bufferDisposer = new BufferDisposer();
 
@@ -293,14 +294,14 @@ public class TGMatrixEditor implements TGEventListener {
 		this.editor.addMouseExitListener(mouseListener);
 		this.editor.addMouseMoveListener(mouseListener);
 
-		this.canvasPanel.getHScroll().setIncrement(SCROLL_INCREMENT);
+		this.canvasPanel.getHScroll().setIncrement(TGDisplayScale.scaleInt(SCROLL_INCREMENT));
 		this.canvasPanel.getHScroll().addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				redraw();
 			}
 		});
 
-		this.canvasPanel.getVScroll().setIncrement(SCROLL_INCREMENT);
+		this.canvasPanel.getVScroll().setIncrement(TGDisplayScale.scaleInt(SCROLL_INCREMENT));
 		this.canvasPanel.getVScroll().addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				redraw();
@@ -323,11 +324,11 @@ public class TGMatrixEditor implements TGEventListener {
 	}
 
 	private int getValueAt(float y){
-		if(this.clientArea == null || (y - BORDER_HEIGHT) < 0 || y + BORDER_HEIGHT > this.clientArea.getHeight()){
+		if(this.clientArea == null || (y - TGDisplayScale.scaleInt(BORDER_HEIGHT)) < 0 || y + TGDisplayScale.scaleInt(BORDER_HEIGHT) > this.clientArea.getHeight()){
 			return -1;
 		}
 		int scroll = this.canvasPanel.getVScroll().getValue();
-		int value = (this.maxNote -  ((int)(  (y + scroll - BORDER_HEIGHT)  / this.lineHeight)) );
+		int value = (this.maxNote -  ((int)(  (y + scroll - TGDisplayScale.scaleInt(BORDER_HEIGHT))  / this.lineHeight)) );
 		return value;
 	}
 
@@ -345,17 +346,17 @@ public class TGMatrixEditor implements TGEventListener {
 			UIImage buffer = getBuffer();
 
 			this.width = this.bufferWidth;
-			this.height = (this.bufferHeight + (BORDER_HEIGHT *2));
+			this.height = (this.bufferHeight + (TGDisplayScale.scaleInt(BORDER_HEIGHT) *2));
 
 			this.updateScroll();
 			int scrollX = this.canvasPanel.getHScroll().getValue();
 			int scrollY = this.canvasPanel.getVScroll().getValue();
 
-			painter.drawImage(buffer,-scrollX,(BORDER_HEIGHT - scrollY));
-			this.paintMeasure(painter,(-scrollX), (BORDER_HEIGHT - scrollY) );
+			painter.drawImage(buffer,-scrollX,(TGDisplayScale.scaleInt(BORDER_HEIGHT) - scrollY));
+			this.paintMeasure(painter,(-scrollX), (TGDisplayScale.scaleInt(BORDER_HEIGHT) - scrollY) );
 			this.paintBorders(painter,(-scrollX),0);
 			this.paintPosition(painter,(-scrollX),0);
-			this.paintSelection(painter, (-scrollX), (BORDER_HEIGHT - scrollY) );
+			this.paintSelection(painter, (-scrollX), (TGDisplayScale.scaleInt(BORDER_HEIGHT) - scrollY) );
 		}
 	}
 
@@ -413,7 +414,7 @@ public class TGMatrixEditor implements TGEventListener {
 				int rows = (this.maxNote - this.minNote);
 
 				this.leftSpacing = minimumNameWidth + 10;
-				this.lineHeight = Math.max(minimumNameHeight,( (this.clientArea.getHeight() - (BORDER_HEIGHT * 2.0f))/ (rows + 1.0f)));
+				this.lineHeight = Math.max(minimumNameHeight,( (this.clientArea.getHeight() - (TGDisplayScale.scaleInt(BORDER_HEIGHT) * 2.0f))/ (rows + 1.0f)));
 				this.timeWidth = Math.max((10 * (TGDuration.SIXTY_FOURTH / measure.getTimeSignature().getDenominator().getValue())),( (this.clientArea.getWidth() - this.leftSpacing) / cols)  );
 				this.bufferWidth = this.leftSpacing + (this.timeWidth * cols);
 				this.bufferHeight = (this.lineHeight * (rows + 1));
@@ -468,8 +469,8 @@ public class TGMatrixEditor implements TGEventListener {
 
 	private void paintBeat(UIPainter painter,TGMeasure measure,TGBeat beat,float fromX, float fromY){
 		if( this.clientArea != null ){
-			float minimumY = BORDER_HEIGHT;
-			float maximumY = (this.clientArea.getHeight() - BORDER_HEIGHT);
+			float minimumY = TGDisplayScale.scaleInt(BORDER_HEIGHT);
+			float maximumY = (this.clientArea.getHeight() - TGDisplayScale.scaleInt(BORDER_HEIGHT));
 			TGSongManager songManager = TGDocumentManager.getInstance(this.context).getSongManager();
 
 			for( int v = 0; v < beat.countVoices(); v ++ ){
@@ -505,8 +506,8 @@ public class TGMatrixEditor implements TGEventListener {
 			painter.setBackground(this.config.getColorBorder());
 			painter.initPath(UIPainter.PATH_FILL);
 			painter.setAntialias(false);
-			painter.addRectangle(fromX,fromY,this.bufferWidth ,BORDER_HEIGHT);
-			painter.addRectangle(fromX,fromY + (this.clientArea.getHeight() - BORDER_HEIGHT),this.bufferWidth ,BORDER_HEIGHT);
+			painter.addRectangle(fromX,fromY,this.bufferWidth ,TGDisplayScale.scaleInt(BORDER_HEIGHT));
+			painter.addRectangle(fromX,fromY + (this.clientArea.getHeight() - TGDisplayScale.scaleInt(BORDER_HEIGHT)),this.bufferWidth ,TGDisplayScale.scaleInt(BORDER_HEIGHT));
 			painter.closePath();
 
 			painter.initPath();
@@ -527,12 +528,12 @@ public class TGMatrixEditor implements TGEventListener {
 				painter.setBackground(this.config.getColorPosition());
 				painter.initPath(UIPainter.PATH_FILL);
 				painter.setAntialias(false);
-				painter.addRectangle(fromX + (this.leftSpacing + x),fromY , width,BORDER_HEIGHT);
+				painter.addRectangle(fromX + (this.leftSpacing + x),fromY , width,TGDisplayScale.scaleInt(BORDER_HEIGHT));
 				painter.closePath();
 
 				painter.initPath(UIPainter.PATH_FILL);
 				painter.setAntialias(false);
-				painter.addRectangle(fromX + (this.leftSpacing + x),fromY + (this.clientArea.getHeight() - BORDER_HEIGHT), width,BORDER_HEIGHT);
+				painter.addRectangle(fromX + (this.leftSpacing + x),fromY + (this.clientArea.getHeight() - TGDisplayScale.scaleInt(BORDER_HEIGHT)), width,TGDisplayScale.scaleInt(BORDER_HEIGHT));
 				painter.closePath();
 			}
 		}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/piano/TGPiano.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/piano/TGPiano.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.action.TGActionProcessorListener;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.action.impl.caret.TGGoLeftAction;
 import app.tuxguitar.app.action.impl.caret.TGGoRightAction;
 import app.tuxguitar.app.action.impl.tools.TGOpenScaleDialogAction;
@@ -99,8 +100,8 @@ public class TGPiano {
 		UITableLayout uiLayout = new UITableLayout(0f);
 		uiLayout.set(this.toolComposite, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, false);
 		uiLayout.set(this.canvas, 2, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false);
-		uiLayout.set(this.canvas, UITableLayout.PACKED_WIDTH, Float.valueOf(NATURAL_WIDTH * (MAX_OCTAVES * NATURAL_NOTES)));
-		uiLayout.set(this.canvas, UITableLayout.PACKED_HEIGHT, Float.valueOf(NATURAL_HEIGHT));
+		uiLayout.set(this.canvas, UITableLayout.PACKED_WIDTH, Float.valueOf(TGDisplayScale.scaleInt(NATURAL_WIDTH) * (MAX_OCTAVES * NATURAL_NOTES)));
+		uiLayout.set(this.canvas, UITableLayout.PACKED_HEIGHT, Float.valueOf(TGDisplayScale.scaleInt(NATURAL_HEIGHT)));
 
 		this.control.setLayout(uiLayout);
 	}
@@ -221,7 +222,7 @@ public class TGPiano {
 	 */
 	private UIImage makePianoImage(){
 		UIFactory factory = getUIFactory();
-		UIImage image = factory.createImage((NATURAL_WIDTH * (MAX_OCTAVES * NATURAL_NOTES)), NATURAL_HEIGHT);
+		UIImage image = factory.createImage((TGDisplayScale.scaleInt(NATURAL_WIDTH) * (MAX_OCTAVES * NATURAL_NOTES)), TGDisplayScale.scaleInt(NATURAL_HEIGHT));
 		UIPainter painter = image.createPainter();
 		painter.setFont(this.config.getFont());
 
@@ -229,7 +230,7 @@ public class TGPiano {
 		final int y = 0;
 		painter.setBackground(this.config.getColorNatural());
 		painter.initPath(UIPainter.PATH_FILL);
-		painter.addRectangle(x,y,(NATURAL_WIDTH * (MAX_OCTAVES * NATURAL_NOTES) ),NATURAL_HEIGHT);
+		painter.addRectangle(x,y,(TGDisplayScale.scaleInt(NATURAL_WIDTH) * (MAX_OCTAVES * NATURAL_NOTES) ),TGDisplayScale.scaleInt(NATURAL_HEIGHT));
 		painter.closePath();
 		for(int i = MIN_NOTE; i < MAX_NOTE; i ++){
 
@@ -237,7 +238,7 @@ public class TGPiano {
 				painter.setForeground(this.config.getColorNotNatural());
 				painter.initPath();
 				painter.setAntialias(false);
-				painter.addRectangle(x,y,NATURAL_WIDTH,NATURAL_HEIGHT);
+				painter.addRectangle(x,y,TGDisplayScale.scaleInt(NATURAL_WIDTH),TGDisplayScale.scaleInt(NATURAL_HEIGHT));
 				painter.closePath();
 
 				// If it is a C key, the number of the octave is written.
@@ -249,7 +250,7 @@ public class TGPiano {
 						float fmTopLine = painter.getFMTopLine();
 						final float verticalOffset = 2;
 
-						int   availableSpace = NATURAL_WIDTH - SHARP_WIDTH/2;
+						int   availableSpace = TGDisplayScale.scaleInt(NATURAL_WIDTH) - TGDisplayScale.scaleInt(SHARP_WIDTH)/2;
 						float textWidth = painter.getFMWidth(octaveText);
 						float horizontalOffset = ((float)availableSpace - textWidth) / 2.0f;
 						final float minimalHOffset = 1.0f;
@@ -260,12 +261,12 @@ public class TGPiano {
 					}
 				}
 
-				x += NATURAL_WIDTH;
+				x += TGDisplayScale.scaleInt(NATURAL_WIDTH);
 			}else{
 				painter.setBackground(this.config.getColorNotNatural());
 				painter.initPath(UIPainter.PATH_FILL);
 				painter.setAntialias(false);
-				painter.addRectangle(x - (SHARP_WIDTH / 2),y,SHARP_WIDTH,SHARP_HEIGHT);
+				painter.addRectangle(x - (TGDisplayScale.scaleInt(SHARP_WIDTH) / 2),y,TGDisplayScale.scaleInt(SHARP_WIDTH),TGDisplayScale.scaleInt(SHARP_HEIGHT));
 				painter.closePath();
 			}
 		}
@@ -289,33 +290,33 @@ public class TGPiano {
 			int width = 0;
 
 			if(TYPE_NOTES[i % TYPE_NOTES.length]){
-				width = NATURAL_WIDTH;
+				width = TGDisplayScale.scaleInt(NATURAL_WIDTH);
 				if(i > 0 && !TYPE_NOTES[(i - 1)  % TYPE_NOTES.length]){
-					width -= ((SHARP_WIDTH / 2));
+					width -= ((TGDisplayScale.scaleInt(SHARP_WIDTH) / 2));
 				}
 				if(!TYPE_NOTES[(i + 1)  % TYPE_NOTES.length]){
-					width -= ((SHARP_WIDTH / 2));
+					width -= ((TGDisplayScale.scaleInt(SHARP_WIDTH) / 2));
 				}
 			}else{
-				width = SHARP_WIDTH;
+				width = TGDisplayScale.scaleInt(SHARP_WIDTH);
 			}
 
 			if(TuxGuitar.getInstance().getScaleManager().getScale().getNote(i)){
 				if(TYPE_NOTES[i % TYPE_NOTES.length] ){
 					int x = posX;
 					if(i > 0 && !TYPE_NOTES[(i - 1)  % TYPE_NOTES.length]){
-						x -= ((SHARP_WIDTH / 2));
+						x -= ((TGDisplayScale.scaleInt(SHARP_WIDTH) / 2));
 					}
 
-					int size = SHARP_WIDTH;
+					int size = TGDisplayScale.scaleInt(SHARP_WIDTH);
 					painter.initPath(UIPainter.PATH_FILL);
 					painter.setAntialias(false);
-					painter.addRectangle( (x + 1 + (((NATURAL_WIDTH - size) / 2))) ,(NATURAL_HEIGHT - size - (((NATURAL_WIDTH - size) / 2))),size,size);
+					painter.addRectangle( (x + 1 + (((TGDisplayScale.scaleInt(NATURAL_WIDTH) - size) / 2))) ,(TGDisplayScale.scaleInt(NATURAL_HEIGHT) - size - (((TGDisplayScale.scaleInt(NATURAL_WIDTH) - size) / 2))),size,size);
 					painter.closePath();
 				}else{
 					painter.initPath(UIPainter.PATH_FILL);
 					painter.setAntialias(false);
-					painter.addRectangle(posX + 1, SHARP_HEIGHT - SHARP_WIDTH + 1,SHARP_WIDTH - 2,SHARP_WIDTH - 2);
+					painter.addRectangle(posX + 1, TGDisplayScale.scaleInt(SHARP_HEIGHT) - TGDisplayScale.scaleInt(SHARP_WIDTH) + 1,TGDisplayScale.scaleInt(SHARP_WIDTH) - 2,TGDisplayScale.scaleInt(SHARP_WIDTH) - 2);
 					painter.closePath();
 				}
 			}
@@ -341,33 +342,33 @@ public class TGPiano {
 			int width = 0;
 
 			if(TYPE_NOTES[i % TYPE_NOTES.length]){
-				width = NATURAL_WIDTH;
+				width = TGDisplayScale.scaleInt(NATURAL_WIDTH);
 				if(i > 0 && !TYPE_NOTES[(i - 1)  % TYPE_NOTES.length]){
-					width -= ((SHARP_WIDTH / 2));
+					width -= ((TGDisplayScale.scaleInt(SHARP_WIDTH) / 2));
 				}
 				if(!TYPE_NOTES[(i + 1)  % TYPE_NOTES.length]){
-					width -= ((SHARP_WIDTH / 2));
+					width -= ((TGDisplayScale.scaleInt(SHARP_WIDTH) / 2));
 				}
 			}else{
-				width = SHARP_WIDTH;
+				width = TGDisplayScale.scaleInt(SHARP_WIDTH);
 			}
 
 			if(i == value){
 				if(TYPE_NOTES[i % TYPE_NOTES.length]){
 					painter.initPath(UIPainter.PATH_FILL);
 					painter.setAntialias(false);
-					painter.addRectangle(posX + 1,y + 1,width - 1,SHARP_HEIGHT);
+					painter.addRectangle(posX + 1,y + 1,width - 1,TGDisplayScale.scaleInt(SHARP_HEIGHT));
 
 					int x = posX;
 					if(i > 0 && !TYPE_NOTES[(i - 1)  % TYPE_NOTES.length]){
-						x -= ((SHARP_WIDTH / 2));
+						x -= ((TGDisplayScale.scaleInt(SHARP_WIDTH) / 2));
 					}
-					painter.addRectangle(x + 1,(y + SHARP_HEIGHT) + 1,NATURAL_WIDTH - 1,(NATURAL_HEIGHT - SHARP_HEIGHT) - 1);
+					painter.addRectangle(x + 1,(y + TGDisplayScale.scaleInt(SHARP_HEIGHT)) + 1,TGDisplayScale.scaleInt(NATURAL_WIDTH) - 1,(TGDisplayScale.scaleInt(NATURAL_HEIGHT) - TGDisplayScale.scaleInt(SHARP_HEIGHT)) - 1);
 					painter.closePath();
 				}else{
 					painter.initPath(UIPainter.PATH_FILL);
 					painter.setAntialias(false);
-					painter.addRectangle(posX + 1,y + 1,width - 1,SHARP_HEIGHT - 1);
+					painter.addRectangle(posX + 1,y + 1,width - 1,TGDisplayScale.scaleInt(SHARP_HEIGHT) - 1);
 					painter.closePath();
 				}
 				return;
@@ -415,10 +416,10 @@ public class TGPiano {
 		
 		for (int i = MIN_NOTE; i < MAX_NOTE; i ++) {
 			if (TYPE_NOTES[i % TYPE_NOTES.length]) { // it is a natural key?
-				if (x>=posX && x<posX+NATURAL_WIDTH) {
+				if (x>=posX && x<posX+TGDisplayScale.scaleInt(NATURAL_WIDTH)) {
 					return i;
 				}
-				posX += NATURAL_WIDTH;
+				posX += TGDisplayScale.scaleInt(NATURAL_WIDTH);
 			}
 		}
 
@@ -433,21 +434,21 @@ public class TGPiano {
 		for (int i = MIN_NOTE; i < MAX_NOTE; i ++) {
 			float width = 0f;
 			boolean isSharp = false;
-			
+
 			if (TYPE_NOTES[i % TYPE_NOTES.length]) { // is a natural key?
-				width = NATURAL_WIDTH;
+				width = TGDisplayScale.scaleInt(NATURAL_WIDTH);
 				if(i > 0 && !TYPE_NOTES[(i - 1)  % TYPE_NOTES.length]){
-					width -= ((SHARP_WIDTH / 2));
+					width -= ((TGDisplayScale.scaleInt(SHARP_WIDTH) / 2));
 				}
 				if(!TYPE_NOTES[(i + 1)  % TYPE_NOTES.length]){
-					width -= ((SHARP_WIDTH / 2));
+					width -= ((TGDisplayScale.scaleInt(SHARP_WIDTH) / 2));
 				}
 			} else { // is sharp
-				width = SHARP_WIDTH;
+				width = TGDisplayScale.scaleInt(SHARP_WIDTH);
 				isSharp = true;
 			}
 
-			if (x>=posX && x<posX+width && isSharp && y<SHARP_HEIGHT) {
+			if (x>=posX && x<posX+width && isSharp && y<TGDisplayScale.scaleInt(SHARP_HEIGHT)) {
 				return i;
 			}
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/piano/TGPianoConfig.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/piano/TGPianoConfig.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.piano;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.config.TGConfigDefaults;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.config.TGConfigKeys;
 import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.ui.TGApplication;
@@ -166,7 +167,7 @@ public class TGPianoConfig {
 				applyChanges();
 			}
 		});
-		buttonsLayout.set(buttonDefaults, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonDefaults, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		final UIButton buttonOK = factory.createButton(buttons);
 		buttonOK.setDefaultButton();
@@ -179,7 +180,7 @@ public class TGPianoConfig {
 				applyChanges();
 			}
 		});
-		buttonsLayout.set(buttonOK, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonOK, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		final UIButton buttonCancel = factory.createButton(buttons);
 		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -188,7 +189,7 @@ public class TGPianoConfig {
 				window.dispose();
 			}
 		});
-		buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 		buttonsLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
 
 		TGDialogUtil.openDialog(window, TGDialogUtil.OPEN_STYLE_CENTER | TGDialogUtil.OPEN_STYLE_PACK);
@@ -211,7 +212,7 @@ public class TGPianoConfig {
 
 		ButtonColor button = new ButtonColor(window, parent, TuxGuitar.getProperty("choose"));
 		button.loadColor(new UIColorModel(rgb.getRed(), rgb.getGreen(), rgb.getBlue()));
-		layout.set(button.getControl(), row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_CONTROL_WIDTH, null, null);
+		layout.set(button.getControl(), row, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_CONTROL_WIDTH), null, null);
 
 		return button.getValue();
 	}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/plugin/TGPluginListDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/plugin/TGPluginListDialog.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.action.impl.view.TGOpenViewAction;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.plugins.TGPluginSettingsManager;
 import app.tuxguitar.app.ui.TGApplication;
 import app.tuxguitar.app.view.controller.TGViewContext;
@@ -62,8 +63,8 @@ public class TGPluginListDialog {
 		table.setColumnName(1, TuxGuitar.getProperty("plugin.column.name"));
 
 		dialogLayout.set(table, 2, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true);
-		dialogLayout.set(table, UITableLayout.PACKED_WIDTH, TABLE_WIDTH);
-		dialogLayout.set(table, UITableLayout.PACKED_HEIGHT, TABLE_HEIGHT);
+		dialogLayout.set(table, UITableLayout.PACKED_WIDTH, TGDisplayScale.scale(TABLE_WIDTH));
+		dialogLayout.set(table, UITableLayout.PACKED_HEIGHT, TGDisplayScale.scale(TABLE_HEIGHT));
 
 		this.updateTableItems(context.getContext());
 
@@ -84,7 +85,7 @@ public class TGPluginListDialog {
 				}
 			}
 		});
-		buttonsLayout.set(buttonSetup, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonSetup, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 
 		final UIButton buttonInfo = uiFactory.createButton(buttons);
 		buttonInfo.setText(TuxGuitar.getProperty("info"));
@@ -98,7 +99,7 @@ public class TGPluginListDialog {
 				}
 			}
 		});
-		buttonsLayout.set(buttonInfo, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonInfo, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 
 		UIButton buttonClose = uiFactory.createButton(buttons);
 		buttonClose.setText(TuxGuitar.getProperty("close"));
@@ -107,7 +108,7 @@ public class TGPluginListDialog {
 				dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonClose, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonClose, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 		buttonsLayout.set(buttonClose, UITableLayout.MARGIN_RIGHT, 0f);
 
 		table.addSelectionListener(new UISelectionListener() {

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/printer/TGPrintPreviewDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/printer/TGPrintPreviewDialog.java
@@ -8,6 +8,7 @@ import app.tuxguitar.app.system.icons.TGColorManager;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.system.icons.TGColorManager.TGSkinnableColor;
 import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.controller.TGViewContext;
 import app.tuxguitar.app.view.util.TGDialogUtil;
 import app.tuxguitar.ui.UIFactory;
@@ -187,7 +188,7 @@ public class TGPrintPreviewDialog{
 		previewLayout.set(this.pageComposite, UITableLayout.PACKED_WIDTH, this.size.getWidth());
 		previewLayout.set(this.pageComposite, UITableLayout.PACKED_HEIGHT, this.size.getHeight());
 
-		this.previewComposite.getVScroll().setIncrement(SCROLL_INCREMENT);
+		this.previewComposite.getVScroll().setIncrement(TGDisplayScale.scaleInt(SCROLL_INCREMENT));
 		this.previewComposite.getVScroll().addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				TGPrintPreviewDialog.this.pageComposite.redraw();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/settings/items/SkinOption.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/settings/items/SkinOption.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.icons.TGSkinManager;
 import app.tuxguitar.app.util.TGFileUtils;
 import app.tuxguitar.app.view.dialog.settings.TGSettingsEditor;
@@ -97,8 +98,8 @@ public class SkinOption extends TGSettingsOption{
 			}
 		});
 		skinPreviewLayout.set(this.previewArea, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, false);
-		skinPreviewLayout.set(this.previewArea, UITableLayout.PACKED_WIDTH, PREVIEW_WIDTH);
-		skinPreviewLayout.set(this.previewArea, UITableLayout.PACKED_HEIGHT, PREVIEW_HEIGHT);
+		skinPreviewLayout.set(this.previewArea, UITableLayout.PACKED_WIDTH, TGDisplayScale.scale(PREVIEW_WIDTH));
+		skinPreviewLayout.set(this.previewArea, UITableLayout.PACKED_HEIGHT, TGDisplayScale.scale(PREVIEW_HEIGHT));
 
 		this.loadConfig();
 	}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/settings/items/StylesOption.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/settings/items/StylesOption.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.settings.items;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.dialog.settings.TGSettingsEditor;
 import app.tuxguitar.ui.UIFactory;
 import app.tuxguitar.ui.chooser.UIColorChooser;
@@ -145,7 +146,7 @@ public class StylesOption extends TGSettingsOption {
 		UIColorButton button = new UIColorButton(getWindow(), parent, text);
 
 		UITableLayout uiLayout = (UITableLayout) parent.getLayout();
-		uiLayout.set(button.getControl(), row, col, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, BUTTON_WIDTH, null, null);
+		uiLayout.set(button.getControl(), row, col, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(BUTTON_WIDTH), null, null);
 
 		return button;
 	}
@@ -155,7 +156,7 @@ public class StylesOption extends TGSettingsOption {
 		uiButton.setText("-");
 
 		UITableLayout uiLayout = (UITableLayout) parent.getLayout();
-		uiLayout.set(uiButton, row, col, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, BUTTON_WIDTH, null, null);
+		uiLayout.set(uiButton, row, col, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(BUTTON_WIDTH), null, null);
 
 		this.addFontButtonListeners(uiButton, fontModel);
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/settings/items/TGSettingsOption.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/settings/items/TGSettingsOption.java
@@ -1,6 +1,7 @@
 package app.tuxguitar.app.view.dialog.settings.items;
 
 import app.tuxguitar.app.system.config.TGConfigManager;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.component.tab.TablatureEditor;
 import app.tuxguitar.app.view.controller.TGViewContext;
 import app.tuxguitar.app.view.dialog.settings.TGSettingsEditor;
@@ -129,7 +130,7 @@ public abstract class TGSettingsOption implements UISelectionListener {
 	}
 
 	protected void indent(UIControl control, int row, int col, int alignX, int alignY, boolean fillX, boolean fillY){
-		this.indent(control, row, col, alignX, alignY, fillX, fillY, DEFAULT_INDENT);
+		this.indent(control, row, col, alignX, alignY, fillX, fillY, TGDisplayScale.scale(DEFAULT_INDENT));
 	}
 
 	protected void indent(UIControl control, int row, int col, int alignX, int alignY, boolean fillX, boolean fillY, float indent){

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/stroke/TGStrokeDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/stroke/TGStrokeDialog.java
@@ -2,6 +2,7 @@ package app.tuxguitar.app.view.dialog.stroke;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.controller.TGViewContext;
 import app.tuxguitar.app.view.util.TGDialogUtil;
 import app.tuxguitar.document.TGDocumentContextAttributes;
@@ -112,7 +113,7 @@ public class TGStrokeDialog {
 				dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonOK, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 
 		UIButton buttonClean = uiFactory.createButton(buttons);
 		buttonClean.setText(TuxGuitar.getProperty("clean"));
@@ -122,7 +123,7 @@ public class TGStrokeDialog {
 				dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonClean, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonClean, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 
 		UIButton buttonCancel = uiFactory.createButton(buttons);
 		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -131,7 +132,7 @@ public class TGStrokeDialog {
 				dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 80f, 25f, null);
+		buttonsLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(80f), TGDisplayScale.scale(25f), null);
 		buttonsLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
 
 		TGDialogUtil.openDialog(dialog, TGDialogUtil.OPEN_STYLE_CENTER | TGDialogUtil.OPEN_STYLE_PACK);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/toolbar/TGMainToolBarDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/toolbar/TGMainToolBarDialog.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.ui.TGApplication;
@@ -265,7 +266,7 @@ public class TGMainToolBarDialog {
 			}
 		});
 		layout.set(buttonDefaults, 1, 1, UITableLayout.ALIGN_RIGHT, UITableLayout.ALIGN_FILL, false, false);
-		layout.set(buttonDefaults, UITableLayout.MINIMUM_PACKED_WIDTH, MINIMUM_BUTTON_WIDTH);
+		layout.set(buttonDefaults, UITableLayout.MINIMUM_PACKED_WIDTH, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH));
 
 		UIButton buttonApply = uiFactory.createButton(panel);
 		buttonApply.setText(TuxGuitar.getProperty("apply"));
@@ -276,7 +277,7 @@ public class TGMainToolBarDialog {
 			}
 		});
 		layout.set(buttonApply, 1, 2, UITableLayout.ALIGN_RIGHT, UITableLayout.ALIGN_FILL, false, false);
-		layout.set(buttonApply, UITableLayout.MINIMUM_PACKED_WIDTH, MINIMUM_BUTTON_WIDTH);
+		layout.set(buttonApply, UITableLayout.MINIMUM_PACKED_WIDTH, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH));
 
 		UIButton buttonOK = uiFactory.createButton(panel);
 		buttonOK.setText(TuxGuitar.getProperty("ok"));
@@ -289,7 +290,7 @@ public class TGMainToolBarDialog {
 			}
 		});
 		layout.set(buttonOK, 1, 3, UITableLayout.ALIGN_RIGHT, UITableLayout.ALIGN_FILL, false, false);
-		layout.set(buttonOK, UITableLayout.MINIMUM_PACKED_WIDTH, MINIMUM_BUTTON_WIDTH);
+		layout.set(buttonOK, UITableLayout.MINIMUM_PACKED_WIDTH, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH));
 
 		UIButton buttonCancel = uiFactory.createButton(panel);
 		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -300,7 +301,7 @@ public class TGMainToolBarDialog {
 			}
 		});
 		layout.set(buttonCancel, 1, 4, UITableLayout.ALIGN_RIGHT, UITableLayout.ALIGN_FILL, false, false);
-		layout.set(buttonCancel, UITableLayout.MINIMUM_PACKED_WIDTH, MINIMUM_BUTTON_WIDTH);
+		layout.set(buttonCancel, UITableLayout.MINIMUM_PACKED_WIDTH, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH));
 	}
 
 	private void addDropDownSelectionListeners() {

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/track/TGTrackPropertiesDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/track/TGTrackPropertiesDialog.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.action.TGActionProcessorListener;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.action.impl.track.TGOpenTrackTuningDialogAction;
 import app.tuxguitar.app.action.impl.view.TGOpenViewAction;
 import app.tuxguitar.app.action.impl.view.TGToggleChannelsDialogAction;
@@ -138,7 +139,7 @@ public class TGTrackPropertiesDialog implements TGEventListener {
 			}
 		});
 
-		legendLayout.set(this.nameText, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_LEFT_CONTROLS_WIDTH, null, null);
+		legendLayout.set(this.nameText, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_LEFT_CONTROLS_WIDTH), null, null);
 
 		//-----------------------COLOR---------------------------------
 		UILabel colorLabel = factory.createLabel(legendPanel);
@@ -172,7 +173,7 @@ public class TGTrackPropertiesDialog implements TGEventListener {
 				TGTrackPropertiesDialog.this.disposeColorButtonBackground();
 			}
 		});
-		legendLayout.set(this.colorButton, 2, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, MINIMUM_LEFT_CONTROLS_WIDTH, null, null);
+		legendLayout.set(this.colorButton, 2, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_LEFT_CONTROLS_WIDTH), null, null);
 
 		//------------Instrument Combo-------------------------------------
 		UILabel instrumentLabel = factory.createLabel(legendPanel);
@@ -244,7 +245,7 @@ public class TGTrackPropertiesDialog implements TGEventListener {
 				TGTrackPropertiesDialog.this.dialog.dispose();
 			}
 		});
-		buttonsLayout.set(buttonClose, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		buttonsLayout.set(buttonClose, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 		buttonsLayout.set(buttonClose, UITableLayout.MARGIN_RIGHT, 0f);
 	}
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/track/TGTrackTuningDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/track/TGTrackTuningDialog.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.icons.TGIconManager;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.ui.TGApplication;
 import app.tuxguitar.app.util.TGMessageDialogUtil;
 import app.tuxguitar.app.view.controller.TGViewContext;
@@ -487,7 +488,7 @@ public class TGTrackTuningDialog {
 				}).process();
 			}
 		});
-		parentLayout.set(buttonApply, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		parentLayout.set(buttonApply, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		UIButton buttonOK = factory.createButton(parent);
 		buttonOK.setText(TuxGuitar.getProperty("ok"));
@@ -503,7 +504,7 @@ public class TGTrackTuningDialog {
 				}).process();
 			}
 		});
-		parentLayout.set(buttonOK, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		parentLayout.set(buttonOK, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 
 		UIButton buttonCancel = factory.createButton(parent);
 		buttonCancel.setText(TuxGuitar.getProperty("cancel"));
@@ -512,7 +513,7 @@ public class TGTrackTuningDialog {
 				TGTrackTuningDialog.this.dialog.dispose();
 			}
 		});
-		parentLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, MINIMUM_BUTTON_WIDTH, MINIMUM_BUTTON_HEIGHT, null);
+		parentLayout.set(buttonCancel, 1, 3, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, TGDisplayScale.scale(MINIMUM_BUTTON_WIDTH), TGDisplayScale.scale(MINIMUM_BUTTON_HEIGHT), null);
 		parentLayout.set(buttonCancel, UITableLayout.MARGIN_RIGHT, 0f);
 	}
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/transport/TGTransportDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/transport/TGTransportDialog.java
@@ -8,6 +8,7 @@ import java.util.TreeSet;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.action.TGActionProcessorListener;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.action.impl.measure.TGGoFirstMeasureAction;
 import app.tuxguitar.app.action.impl.measure.TGGoLastMeasureAction;
 import app.tuxguitar.app.action.impl.measure.TGGoNextMeasureAction;
@@ -169,7 +170,7 @@ public class TGTransportDialog implements TGEventListener {
 		this.metronome
 				.addSelectionListener(new TGActionProcessorListener(this.context, TGTransportMetronomeAction.NAME));
 		compositeLayout.set(this.metronome, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, false, true);
-		compositeLayout.set(this.metronome, UITableLayout.MINIMUM_PACKED_WIDTH, 100f);
+		compositeLayout.set(this.metronome, UITableLayout.MINIMUM_PACKED_WIDTH, TGDisplayScale.scale(100f));
 
 		this.mode = factory.createButton(composite);
 		this.mode.addSelectionListener(

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/tremolobar/TGTremoloBarDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/tremolobar/TGTremoloBarDialog.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.system.icons.TGColorManager;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.system.icons.TGColorManager.TGSkinnableColor;
 import app.tuxguitar.app.ui.TGApplication;
 import app.tuxguitar.app.view.controller.TGViewContext;
@@ -69,15 +70,15 @@ public class TGTremoloBarDialog{
 	private void init(){
 		this.x = new int[X_LENGTH];
 		this.y = new int[Y_LENGTH];
-		this.width = ((X_SPACING * X_LENGTH) - X_SPACING);
-		this.height = ((Y_SPACING * Y_LENGTH) - Y_SPACING);
+		this.width = ((TGDisplayScale.scaleInt(X_SPACING) * X_LENGTH) - TGDisplayScale.scaleInt(X_SPACING));
+		this.height = ((TGDisplayScale.scaleInt(Y_SPACING) * Y_LENGTH) - TGDisplayScale.scaleInt(Y_SPACING));
 		this.points = new ArrayList<UIPosition>();
 
 		for(int i = 0;i < this.x.length;i++){
-			this.x[i] = ((i + 1) * X_SPACING);
+			this.x[i] = ((i + 1) * TGDisplayScale.scaleInt(X_SPACING));
 		}
 		for(int i = 0;i < this.y.length;i++){
-			this.y[i] = ((i + 1) * Y_SPACING);
+			this.y[i] = ((i + 1) * TGDisplayScale.scaleInt(Y_SPACING));
 		}
 	}
 
@@ -136,7 +137,7 @@ public class TGTremoloBarDialog{
 					TGTremoloBarDialog.this.editor.redraw();
 				}
 			});
-			leftCompositeLayout.set(this.editor, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, getWidth() + (X_SPACING * 2f), getHeight() + (Y_SPACING * 2f), null);
+			leftCompositeLayout.set(this.editor, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, getWidth() + (TGDisplayScale.scaleInt(X_SPACING) * 2f), getHeight() + (TGDisplayScale.scaleInt(Y_SPACING) * 2f), null);
 
 			//-------------DEFAULT BEND LIST---------------------------------------------------
 			final List<UISelectItem<TGEffectTremoloBar>> presetItems = this.createPresetItems();
@@ -212,16 +213,16 @@ public class TGTremoloBarDialog{
 			this.setStyleX(painter,i);
 			painter.initPath();
 			painter.setAntialias(false);
-			painter.moveTo(this.x[i], Y_SPACING);
-			painter.lineTo(this.x[i], Y_SPACING + this.height);
+			painter.moveTo(this.x[i], TGDisplayScale.scaleInt(Y_SPACING));
+			painter.lineTo(this.x[i], TGDisplayScale.scaleInt(Y_SPACING) + this.height);
 			painter.closePath();
 		}
 		for(int i = 0;i < this.y.length;i++){
 			this.setStyleY(painter,i);
 			painter.initPath();
 			painter.setAntialias(false);
-			painter.moveTo(X_SPACING, this.y[i]);
-			painter.lineTo(X_SPACING + this.width, this.y[i]);
+			painter.moveTo(TGDisplayScale.scaleInt(X_SPACING), this.y[i]);
+			painter.lineTo(TGDisplayScale.scaleInt(X_SPACING) + this.width, this.y[i]);
 			painter.closePath();
 		}
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/main/TGWindow.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/main/TGWindow.java
@@ -8,6 +8,7 @@ import app.tuxguitar.app.system.icons.TGSkinEvent;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.system.icons.TGSkinManager;
 import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.component.tabfolder.TGTabFolder;
 import app.tuxguitar.app.view.component.table.TGTableViewer;
 import app.tuxguitar.app.view.dialog.fretboard.TGFretBoardEditor;
@@ -56,6 +57,8 @@ public class TGWindow implements TGEventListener {
 
 		this.window = uiFactory.createWindow();
 		this.window.addCloseListener(new TGActionProcessorListener(this.context, TGDisposeAction.NAME));
+
+		TGDisplayScale.init(TGApplication.getInstance(this.context).getApplication().getDisplayScale());
 
 		this.createShellComposites(uiFactory);
 		this.createShellListeners();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/edit/TGEditToolBar.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/edit/TGEditToolBar.java
@@ -1,6 +1,7 @@
 package app.tuxguitar.app.view.toolbar.edit;
 
 import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.app.view.component.tabfolder.TGTabFolder;
 import app.tuxguitar.app.view.toolbar.model.TGToolBarModel;
 import app.tuxguitar.ui.UIFactory;
@@ -36,7 +37,7 @@ public class TGEditToolBar extends TGToolBarModel implements UIFocusGainedListen
 		this.control.setVisible(visible);
 		this.control.setLayout(new UIScrollBarPanelLayout(false, true, false, false, false, false));
 		this.control.addFocusGainedListener(this);
-		this.control.getVScroll().setIncrement(SCROLL_INCREMENT);
+		this.control.getVScroll().setIncrement(TGDisplayScale.scaleInt(SCROLL_INCREMENT));
 		this.control.getVScroll().addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
 				TGEditToolBar.this.getControl().layout();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarItemTimeCounter.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarItemTimeCounter.java
@@ -15,6 +15,7 @@ import app.tuxguitar.app.system.icons.TGColorManager;
 import app.tuxguitar.app.system.icons.TGColorManager.TGSkinnableColor;
 import app.tuxguitar.app.system.icons.TGIconManager;
 import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.app.util.TGDisplayScale;
 import app.tuxguitar.editor.event.TGRedrawEvent;
 import app.tuxguitar.editor.util.TGSyncProcessLocked;
 import app.tuxguitar.event.TGEvent;
@@ -217,14 +218,14 @@ public class TGMainToolBarItemTimeCounter extends TGMainToolBarItem implements T
 		// performance optimization: recalculate dimensions only if they change or were
 		// never computed
 		if (this.fontChanged || (size.getWidth() < TIMESTAMP_MIN_WIDTH + 2f)) {
-			newWidth = painter.getFMWidth(time) + 2f * TIMESTAMP_H_MARGIN;
+			newWidth = painter.getFMWidth(time) + 2f * TGDisplayScale.scale(TIMESTAMP_H_MARGIN);
 			newHeight = this.font.getHeight() * TIMESTAMP_V_MARGIN_FACTOR;
 			boolean doLayout = false;
 			boolean doWindowLayout = false;
 			if (newWidth != size.getWidth()) {
 				this.parentPanel.getLayout().set(this.timestampCanvas, UITableLayout.PACKED_WIDTH, newWidth);
 				// warning, font may not be monospaced, avoid permanent layout
-				if ((newWidth - size.getWidth()) > TIMESTAMP_H_MARGIN) {
+				if ((newWidth - size.getWidth()) > TGDisplayScale.scale(TIMESTAMP_H_MARGIN)) {
 					doLayout = true;
 				}
 			}
@@ -251,7 +252,7 @@ public class TGMainToolBarItemTimeCounter extends TGMainToolBarItem implements T
 		painter.addRectangle(0f, 0f, newWidth, newHeight);
 		painter.closePath();
 		painter.setForeground(this.foregroundColor);
-		painter.drawString(time, TIMESTAMP_H_MARGIN, this.yTimestamp);
+		painter.drawString(time, TGDisplayScale.scale(TIMESTAMP_H_MARGIN), this.yTimestamp);
 	}
 
 }

--- a/desktop/build-scripts/common-resources/common-macosx/Contents/MacOS/dist/tuxguitar-shortcuts.xml
+++ b/desktop/build-scripts/common-resources/common-macosx/Contents/MacOS/dist/tuxguitar-shortcuts.xml
@@ -75,4 +75,6 @@
 	<shortcut keys="F9" action="action.gui.open-transport-mode-dialog"/>
 	<shortcut keys="Space" action="action.transport.play"/>
 	<shortcut keys="Command t" action="action.gui.toggle-transport-dialog"/>
+	<shortcut keys="Command =" action="action.view.layout-increment-scale"/>
+	<shortcut keys="Command -" action="action.view.layout-decrement-scale"/>
 </shortcuts>


### PR DESCRIPTION
## Summary

The tablature/score area is unreadably small on high-resolution displays. On my LG 38WK95C-W (3840x1600) with macOS "More Space" at maximum, the default 5-8pt fonts are microscopic. There are also no keyboard shortcuts for zoom -- only the View menu and Ctrl+MouseWheel -- and the zoom preference resets to 1.0x on every launch.

This PR adds:

- **DPI auto-detection for the tablature area** -- a new `getDisplayScale()` method on the `UIApplication` interface, with platform-specific implementations:
  - **SWT**: Multi-signal detection using `Display.getDPI()` against platform reference DPI (72 macOS, 96 Windows/Linux), with a resolution-based heuristic fallback for non-HiDPI external monitors (catches macOS "More Space" on ultrawide displays). Includes a Retina guard to avoid double-scaling when SWT already handles 2x pixel doubling.
  - **JavaFX**: Uses `Screen.getPrimary().getOutputScaleX()`
  - **Qt**: Returns 1.0 (experimental toolkit)
- **Zoom keyboard shortcuts** -- `Ctrl+=` / `Ctrl+-` (SWT), `Command+=` / `Command+-` (macOS JFX)
- **Zoom persistence** -- the user's zoom level is saved to `layout.scale` in config and restored on startup
- **Raised zoom ceiling** -- from 2.0x to 3.0x for more headroom on high-DPI displays

The effective tablature scale is `displayScale * userZoom`. The DPI baseline is cached once at startup. The user's manual zoom range (0.5x-3.0x) operates relative to this baseline, so "1.0x" means "comfortable for this display."

### Scope

This PR only affects the tablature/score rendering area. It does not change menus, toolbars, dialogs, or other UI elements.

### Example

On an LG 38WK95C-W at 3840x1600 with macOS "More Space" maxed out, the resolution heuristic computes sqrt(3840*1600) / sqrt(1920*1080) = ~1.72 as the DPI baseline. The tablature renders at 1.72x by default instead of 1.0x -- dramatically more readable without any manual adjustment needed.

On a standard 1080p display, all signals return ~1.0 and behavior is identical to before this change.

## Test plan

- [ ] Build and launch on macOS with SWT (`desktop/build-scripts/tuxguitar-macosx-swt-cocoa`)
- [ ] Verify Cmd+= zooms in and Cmd+- zooms out on the tablature area
- [ ] Verify zoom level persists after quitting and relaunching
- [ ] Verify on a standard resolution display that tablature renders the same as before (no regression)
- [ ] Verify on a high-DPI display (Retina MacBook, Windows with scaling > 100%, or ultrawide with "More Space") that tablature auto-scales to a readable size
