### PR TITLE
fix "paste measure" action

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/helpers/TGSongSegmentHelper.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/helpers/TGSongSegmentHelper.java
@@ -135,8 +135,8 @@ public class TGSongSegmentHelper {
 			long nextStart =  (replace.getStart() + replace.getLength());
 			while(nextHeaders.hasNext()){
 				TGMeasureHeader next = nextHeaders.next();
-				this.sm.moveMeasureComponents(song, next, (nextStart - next.getStart() ));
 				this.sm.moveMeasureHeader(next, (nextStart - next.getStart() ) , 0);
+				this.sm.moveMeasureComponents(song, next, (nextStart - next.getStart() ));
 				nextStart = (next.getStart() + next.getLength());
 			}
 			measureHeaders.add(replace);


### PR DESCRIPTION
should fix issue #1050

When measures from all tracks are copied then pasted with 'replace' option active, need to update precise start of measure header BEFORE updating precise start of corresponding measures' contents