### PR TITLE
improve midi import

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/models/TGDuration.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/models/TGDuration.java
@@ -281,18 +281,30 @@ public abstract class TGDuration implements Comparable<TGDuration> {
 		if (timeToSplit == 0) {
 			return new ArrayList<TGDuration>();
 		}
-		long shortest = (maxDurationValue == null ? TGDuration.SHORTEST : maxDurationValue);
 
+		// try to split exactly, then approximately, and take the "best" solution
+		List<TGDuration> exactSplit = splitPreciseDuration(timeToSplit, max, factory, maxDurationValue, maxDivision);
+		List<TGDuration> approximateSplit = null;
+
+		long shortest = (maxDurationValue == null ? TGDuration.SHORTEST : maxDurationValue);
 		// look for a single duration with an acceptable error
 		long bestError = -1;
 		TGDuration bestDuration = null;
+		// is zero acceptable?
+		if (timeToSplit <= TGDuration.WHOLE_PRECISE_DURATION / shortest) {
+			bestError = timeToSplit;
+			approximateSplit = new ArrayList<TGDuration>();
+		}
+		
 		for (TGDuration d : durationMap.values()) {
 			// exclude double-dotted: purely arbitrary criterion
 			if ((d.getValue() <= shortest) && ((maxDivision == null) || (d.getDivision().getEnters() <= maxDivision)) && !d.isDoubleDotted()) {
-				long maxError = TGDuration.WHOLE_PRECISE_DURATION * d.getDivision().getTimes() / shortest / d.getDivision().getEnters() / 2;
+				long maxError = TGDuration.WHOLE_PRECISE_DURATION * d.getDivision().getTimes() / shortest / d.getDivision().getEnters();
 				long error = Math.abs(d.getPreciseTime() - timeToSplit);
 				if ((error <= maxError) &&
-						((bestError < 0) || (error < bestError) || ((error == bestError) && (!d.isDotted())))) {
+						((bestError < 0)
+						 || (d.moreComplexThan(bestDuration) < 0)
+						 || ((d.moreComplexThan(bestDuration) == 0) && (error < bestError || bestError < 0)))) {
 					bestDuration = d;
 					bestError = error;
 				}
@@ -300,56 +312,86 @@ public abstract class TGDuration implements Comparable<TGDuration> {
 		}
 		if (bestDuration != null) {
 			// found
-			List<TGDuration> list = new ArrayList<TGDuration>();
-			list.add(bestDuration.clone(factory));
-			return(list);
+			approximateSplit = new ArrayList<TGDuration>();
+			approximateSplit.add(bestDuration.clone(factory));
 		}
 
 		// if no single duration found, try a combination of several
-		List<TGDuration> bestList = null;
-		bestError = 0;
-
-		// max: power of 2, no longer than a whole
-		max = Math.min(max, TGDuration.WHOLE_PRECISE_DURATION);
-		long maxBase = TGDuration.WHOLE_PRECISE_DURATION;
-		while (max < maxBase) {
-			maxBase /= 2;
-		}
-		// look for all division types, starting with longest divisions, except excluded ones
-		for (TGDivisionType dt : divisionTypes) {
-			if ((maxDivision == null) || (dt.getEnters() <= maxDivision)) {
-				List<TGDuration> list = new ArrayList<TGDuration>();
-				if ((maxDivision==null || dt.getEnters()<=maxDivision)) {
-					long base = TGDuration.WHOLE_PRECISE_DURATION * dt.getTimes() / (dt.getEnters() * shortest);  // shortest possible duration for this time division
-					if (base > maxBase)  {
-						break;
-					}
-					// number of occurrences of base duration (rounded)
-					// apply -1 offset, because Math.round(1.5)==2, and 1 is preferred
-					// (better a bit too short than too long)
-					long nBase = Math.round((float)(timeToSplit-1) / (float)base);
-					long n = 1;
-					// merge powers of 2
-					while ((nBase != 0) && (nBase % 2 == 0) && (n*2*base <= max)) {
-						n *= 2;
-						nBase /= 2;
-					}
-					long listPreciseDuration = 0;
-					for (int i=0; i<nBase; i++) {
-						TGDuration duration = factory.newDuration();
-						duration.setPreciseValue(n* base);
-						list.add(duration);
-						listPreciseDuration += duration.getPreciseTime();
-					}
-					long error = Math.abs(timeToSplit - listPreciseDuration);
-					if ((bestList == null) || (error <= bestError)) {
-						bestList = list;
-						bestError = error;
+		if (approximateSplit == null) {
+			approximateSplit = new ArrayList<TGDuration>();
+			bestError = 0;
+	
+			// max: power of 2, no longer than a whole
+			max = Math.min(max, TGDuration.WHOLE_PRECISE_DURATION);
+			long maxBase = TGDuration.WHOLE_PRECISE_DURATION;
+			while (max < maxBase) {
+				maxBase /= 2;
+			}
+			// look for all division types, starting with longest divisions, except excluded ones
+			for (TGDivisionType dt : divisionTypes) {
+				if ((maxDivision == null) || (dt.getEnters() <= maxDivision)) {
+					List<TGDuration> list = new ArrayList<TGDuration>();
+					if ((maxDivision==null || dt.getEnters()<=maxDivision)) {
+						long base = TGDuration.WHOLE_PRECISE_DURATION * dt.getTimes() / (dt.getEnters() * shortest);  // shortest possible duration for this time division
+						if (base > maxBase)  {
+							break;
+						}
+						// number of occurrences of base duration (rounded)
+						// apply -1 offset, because Math.round(1.5)==2, and 1 is preferred
+						// (better a bit too short than too long)
+						long nBase = Math.round((float)(timeToSplit-1) / (float)base);
+						long n = 1;
+						// merge powers of 2
+						while ((nBase != 0) && (nBase % 2 == 0) && (n*2*base <= max)) {
+							n *= 2;
+							nBase /= 2;
+						}
+						long listPreciseDuration = 0;
+						for (int i=0; i<nBase; i++) {
+							TGDuration duration = factory.newDuration();
+							duration.setPreciseValue(n* base);
+							list.add(duration);
+							listPreciseDuration += duration.getPreciseTime();
+						}
+						long error = Math.abs(timeToSplit - listPreciseDuration);
+						if ((approximateSplit.size() == 0) || (error <= bestError)) {
+							approximateSplit = list;
+							bestError = error;
+						}
 					}
 				}
+			}
 		}
+		// compare exact split with approximate (arbitrary criteria)
+		if (exactSplit == null) {
+			return approximateSplit;
 		}
-		return bestList;
+		boolean heterogeneousDivision = false;
+		for (TGDuration d : exactSplit) {
+			heterogeneousDivision |= (!d.getDivision().isEqual(exactSplit.get(0).getDivision()));
+		}
+		if (heterogeneousDivision || (approximateSplit.size() < exactSplit.size())) {
+			return approximateSplit;
+		}
+		return exactSplit;
+	}
+
+	// arbitrary complexity criteria
+	// returns a positive value if more complex, negative if less complex, zero if equivalent
+	private int moreComplexThan(TGDuration d) {
+		if (d == null) {
+			// zero duration is "as simple as" no dotted, no time division
+			if (this.dotted || this.doubleDotted || !this.getDivision().isEqual(TGDivisionType.NORMAL)) {
+				return 1;
+			}
+			return 0;
+		}
+		if (this.isDoubleDotted() && !d.isDoubleDotted()) return 1;
+		if (this.getDivision().getEnters() != d.getDivision().getEnters()) {
+			return this.getDivision().getEnters() > d.getDivision().getEnters() ? 1 : -1;
+		}
+		if (this.isDotted() && !d.isDotted()) return 1;
+		return 0;
 	}
 
 	private static long gcd(long a, long b) {

--- a/common/TuxGuitar-lib/src/test/java/app/tuxguitar/song/models/TestTGDuration.java
+++ b/common/TuxGuitar-lib/src/test/java/app/tuxguitar/song/models/TestTGDuration.java
@@ -327,15 +327,6 @@ public class TestTGDuration {
 			assertEquals(division, d.getDivision().getEnters());
 		}
 		
-		// a basic 8th triplet, with the minimum possible error
-		toSplit = TGDuration.WHOLE_PRECISE_DURATION*2/3/8 + 1;
-		list = TGDuration.splitPreciseDurationApproximately(toSplit, TGDuration.WHOLE_PRECISE_DURATION, factory,
-				16, 3);
-		assertNotNull(list);
-		assertEquals(1, list.size());
-		assertEquals(8, list.get(0).getValue());
-		assertEquals(2, list.get(0).getDivision().getTimes());
-		assertEquals(3, list.get(0).getDivision().getEnters());
 	}
 
 	// get sum of notes list duration, and check max (if specified)

--- a/common/TuxGuitar-midi/src/main/java/app/tuxguitar/io/midi/MidiSongReader.java
+++ b/common/TuxGuitar-midi/src/main/java/app/tuxguitar/io/midi/MidiSongReader.java
@@ -241,8 +241,10 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 		int value = (length > 1)?(data[1] & 0xFF):0;
 
 		TempNote tempNote = getTempNote(channel, value);
-		createTempNotesBefore(tick, track);
-		this.tempNotes.remove(tempNote);
+		if (tempNote != null) {
+			createTempNotesBefore(tick, track);
+			this.tempNotes.remove(tempNote);
+		}
 	}
 
 	private void parseProgramChange(byte[] data){
@@ -448,25 +450,11 @@ public class MidiSongReader extends MidiFileFormat implements TGSongReader {
 			long measureEnd = measure.getStart() + measure.getLength();
 			long coarseTimeToFill = Math.min(nEnd, measureEnd) - this.lastBeatEnd;
 			long preciseTimeToFill = TGDuration.toPreciseTime(coarseTimeToFill);
-			// try to split exactly
-			List<TGDuration> durationList = TGDuration.splitPreciseDuration(preciseTimeToFill, measure.getPreciseLength(), factory,
+			
+			List<TGDuration> durationList = TGDuration.splitPreciseDurationApproximately(preciseTimeToFill, measure.getPreciseLength(), factory,
 					MidiSongReader.this.settings.getMaxDurationValue(),
 					MidiSongReader.this.settings.getMaxDivision());
-			boolean heterogeneousDivision = false;
-			if (durationList != null) {
-				for (TGDuration d : durationList) {
-					heterogeneousDivision |= (!d.getDivision().isEqual(durationList.get(0).getDivision()));
-				}
-			}
-			// if it failed, or if divisions are not homogeneous, try to split approximately
-			if ((durationList == null) || heterogeneousDivision) {
-				List<TGDuration> approximativeDurationList = TGDuration.splitPreciseDurationApproximately(preciseTimeToFill, measure.getPreciseLength(), factory,
-					MidiSongReader.this.settings.getMaxDurationValue(),
-					MidiSongReader.this.settings.getMaxDivision());
-				if (approximativeDurationList != null) {
-					durationList = approximativeDurationList;
-				}
-			}
+
 			for (TGDuration duration : durationList) {
 				long beatEnd = this.lastBeatEnd + duration.getTime();
 				if (beatEnd <= measureEnd) {


### PR DESCRIPTION
still playing with the same trade-off: fidelity vs. readability
When allocating note's duration, sometimes a perfect fit is not the best solution.

Also : ignore noteOff events for notes not currently playing (seen in some midi files)