### PR TITLE
Fix issue 865: panning and mixing not power conservative

### DIFF
--- a/desktop/TuxGuitar-synth/src/app/tuxguitar/midi/synth/TGAudioBuffer.java
+++ b/desktop/TuxGuitar-synth/src/app/tuxguitar/midi/synth/TGAudioBuffer.java
@@ -111,13 +111,20 @@ public class TGAudioBuffer {
 			short maxValue = Short.MAX_VALUE;
 			short minValue = Short.MIN_VALUE;
 
+			// Constant-power mix: mix() stores the running average (sum/N).
+			// Multiplying back by sqrt(N) gives sum/sqrt(N), which keeps the
+			// total output power constant as instruments are added regardless
+			// of N (for uncorrelated sources).  The previous factor of N
+			// reconstructed the raw sum, whose amplitude grew linearly with N.
+			float sqrtN = (float) Math.sqrt(this.buffers);
+
 			for (int i = 0; i < ( BUFFER_SIZE / 2 ); i++) {
 				for (int j = 0; j < CHANNELS; j++) {
 					sampleValue = 0;
 					for( int n = 0; n < 2; n ++){
 						sampleValue |= ((this.buffer[(index + n)] & 0xff) << ( 8 * (BIGENDIAN ? 1 - n : n)));
 					}
-					ampValue = (short) (Math.max(Math.min(sampleValue * this.buffers, maxValue), minValue) & 0xFFFF);
+					ampValue = (short) (Math.max(Math.min(Math.round(sampleValue * sqrtN), (int) maxValue), (int) minValue) & 0xFFFF);
 
 					this.buffer[index++] = (byte) ((BIGENDIAN ? ((ampValue & 0xFF00) >> 8) : ((ampValue & 0x00FF) >> 0) ) & 0xFF);
 					this.buffer[index++] = (byte) ((BIGENDIAN ? ((ampValue & 0x00FF) >> 0) : ((ampValue & 0xFF00) >> 8) ) & 0xFF);

--- a/desktop/TuxGuitar-synth/src/app/tuxguitar/midi/synth/TGSynthChannelProcessor.java
+++ b/desktop/TuxGuitar-synth/src/app/tuxguitar/midi/synth/TGSynthChannelProcessor.java
@@ -217,11 +217,17 @@ public class TGSynthChannelProcessor {
 
 	public void balance(TGAudioBuffer buffer, int volume, int balance) {
 		synchronized (this.lock) {
+			// Constant-power panning law: use sine/cosine so that the total
+			// power (left² + right²) remains constant across all pan positions.
+			// At center (balance=63.5) both channels get cos(π/4) ≈ 0.707,
+			// whereas a linear law would give 0.5 — a 3 dB centre-hole.
+			float pan = (balance / 127f) * ((float) Math.PI / 2f);
+			float gain = volume / 127f;
 			buffer.balance(new float[] {
 				// left channel
-				(volume / 127f) * ((127 - balance) / 127f),
+				gain * (float) Math.cos(pan),
 				// right channel
-				(volume / 127f) * ((balance) / 127f)
+				gain * (float) Math.sin(pan)
 			});
 		}
 	}


### PR DESCRIPTION
Fix some issues with the mixing:
- the panning law is not power conservative: when a track is centered, the level of the track is reduced by -3db. I used cos / sin to compute the balance
- the mixing is not power conservative: the more you add track, the quieter the main signal become. I divided the sum of tracks by sqrt(N) instead of N.