### PR TITLE
Android: display effective BPM in toolbar (tempo * percent / 100)

### DIFF
--- a/android/TuxGuitar-android/res/layout/view_tempo_menu_item.xml
+++ b/android/TuxGuitar-android/res/layout/view_tempo_menu_item.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical">
+
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/ic_music_note_white_24dp"/>
+
+    <TextView
+        android:id="@+id/tempo_display_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="= --"
+        android:textColor="@android:color/white"/>
+
+</LinearLayout>

--- a/android/TuxGuitar-android/res/menu/menu_main.xml
+++ b/android/TuxGuitar-android/res/menu/menu_main.xml
@@ -14,6 +14,11 @@
         android:title="@string/action_transport_play"
         app:showAsAction="always"/>
     <item
+        android:id="@+id/action_tempo_display"
+        android:title="= --"
+        app:actionLayout="@layout/view_tempo_menu_item"
+        app:showAsAction="always"/>
+    <item
         android:id="@+id/action_menu_edit"
         android:title="@string/action_menu_edit"/>
     <item

--- a/android/TuxGuitar-android/src/app/tuxguitar/android/menu/controller/impl/fragment/TGMainMenu.java
+++ b/android/TuxGuitar-android/src/app/tuxguitar/android/menu/controller/impl/fragment/TGMainMenu.java
@@ -2,6 +2,7 @@ package app.tuxguitar.android.menu.controller.impl.fragment;
 
 import android.view.Menu;
 import android.view.MenuInflater;
+import android.view.MenuItem;
 
 import app.tuxguitar.android.R;
 import app.tuxguitar.android.action.TGActionProcessorListener;
@@ -26,6 +27,10 @@ import app.tuxguitar.android.menu.controller.impl.contextual.TGVelocityMenu;
 import app.tuxguitar.android.menu.controller.impl.contextual.TGViewMenu;
 import app.tuxguitar.android.menu.util.TGToggleStyledIconHandler;
 import app.tuxguitar.android.menu.util.TGToggleStyledIconHelper;
+import app.tuxguitar.android.view.dialog.TGDialogContext;
+import app.tuxguitar.android.view.dialog.tempo.TGTempoDialogController;
+import app.tuxguitar.android.view.tablature.TGSongViewController;
+import app.tuxguitar.document.TGDocumentContextAttributes;
 import app.tuxguitar.player.base.MidiPlayer;
 import app.tuxguitar.util.TGContext;
 import app.tuxguitar.util.singleton.TGSingletonFactory;
@@ -35,7 +40,7 @@ public class TGMainMenu implements TGMenuController {
 
 	private TGContext context;
 	private TGToggleStyledIconHelper styledIconHelper;
-
+	private MenuItem tempoDisplayItem;
 	private TGMainMenu(TGContext context) {
 		this.context = context;
 		this.styledIconHelper = new TGToggleStyledIconHelper(context);
@@ -62,6 +67,46 @@ public class TGMainMenu implements TGMenuController {
 		menu.findItem(R.id.action_menu_effects).setOnMenuItemClickListener(createContextMenuActionProcessor(new TGEffectMenu(getActivity())));
 		menu.findItem(R.id.action_menu_transport).setOnMenuItemClickListener(createContextMenuActionProcessor(new TGTransportMenu(getActivity())));
 		menu.findItem(R.id.action_menu_settings).setOnMenuItemClickListener(createFragmentActionProcessor(new TGPreferencesFragmentController()));
+		this.tempoDisplayItem = menu.findItem(R.id.action_tempo_display);
+		try {
+			this.updateTempoDisplay();
+		} catch (Exception e) {
+			// not yet ready
+		}
+		android.view.View actionView = this.tempoDisplayItem.getActionView();
+		if (actionView != null) {
+			actionView.setOnClickListener(new android.view.View.OnClickListener() {
+				@Override
+				public void onClick(android.view.View v) {
+					TGSongViewController songView = TGSongViewController.getInstance(getContext());
+					TGDialogContext dialogContext = new TGDialogContext();
+					dialogContext.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_SONG, songView.getCaret().getMeasure().getHeader().getSong());
+					dialogContext.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_HEADER, songView.getCaret().getMeasure().getHeader());
+					new TGTempoDialogController().showDialog(getActivity(), dialogContext);
+				}
+			});
+		}
+	}
+
+	public void updateTempoDisplay() {
+		if (this.tempoDisplayItem == null) return;
+		MidiPlayer midiPlayer = MidiPlayer.getInstance(this.context);
+		int tempoValue;
+		int tempoPercent = midiPlayer.getMode().getCurrentPercent();
+
+		if ((midiPlayer.isRunning() && (midiPlayer.getCurrentTempo() != null))) {
+			tempoValue = midiPlayer.getCurrentTempo().getRawValue() * tempoPercent / 100;
+		} else {
+			tempoValue = TGSongViewController.getInstance(getContext()).getCaret().getMeasure().getTempo().getRawValue() * tempoPercent / 100;
+		}
+		String label = "= " + tempoValue;
+		android.view.View actionView = this.tempoDisplayItem.getActionView();
+		if (actionView != null) {
+			android.widget.TextView textView = actionView.findViewById(R.id.tempo_display_text);
+			if (textView != null) {
+				textView.setText(label);
+			}
+		}
 	}
 
 	public void fillStyledIconHandlers() {
@@ -116,3 +161,4 @@ public class TGMainMenu implements TGMenuController {
 		});
 	}
 }
+

--- a/android/TuxGuitar-android/src/app/tuxguitar/android/view/dialog/transport/TGTransportModeDialog.java
+++ b/android/TuxGuitar-android/src/app/tuxguitar/android/view/dialog/transport/TGTransportModeDialog.java
@@ -21,6 +21,8 @@ import android.graphics.Color;
 
 import app.tuxguitar.android.R;
 import app.tuxguitar.android.action.impl.caret.TGMoveToAction;
+import app.tuxguitar.android.menu.controller.TGMenuController;
+import app.tuxguitar.android.menu.controller.impl.fragment.TGMainMenu;
 import app.tuxguitar.android.view.dialog.fragment.TGModalFragment;
 import app.tuxguitar.document.TGDocumentContextAttributes;
 import app.tuxguitar.editor.action.TGActionProcessor;
@@ -109,7 +111,9 @@ public class TGTransportModeDialog extends TGModalFragment {
 				mode.setCustomPercentIncrement((int) customIncrement.getSelectedItem());
 				mode.setLoopSHeader(loopSHeader);
 				mode.setLoopEHeader(loopEHeader);
-
+				// update of the current Tempo on the menu
+				mode.reset();
+				TGMainMenu.getInstance(findContext()).updateTempoDisplay();
 				TGTransportModeDialog.this.close();
 
 				return true;

--- a/android/TuxGuitar-android/src/app/tuxguitar/android/view/tablature/TGSongViewEventListener.java
+++ b/android/TuxGuitar-android/src/app/tuxguitar/android/view/tablature/TGSongViewEventListener.java
@@ -9,6 +9,9 @@ import app.tuxguitar.editor.event.TGUpdateMeasuresEvent;
 import app.tuxguitar.event.TGEvent;
 import app.tuxguitar.event.TGEventListener;
 import app.tuxguitar.util.TGAbstractContext;
+import app.tuxguitar.android.menu.controller.impl.fragment.TGMainMenu;
+import app.tuxguitar.android.activity.TGActivity;
+import app.tuxguitar.android.activity.TGActivityController;
 
 public class TGSongViewEventListener implements TGEventListener {
 
@@ -46,8 +49,26 @@ public class TGSongViewEventListener implements TGEventListener {
 		int type = ((Integer)event.getAttribute(TGRedrawEvent.PROPERTY_REDRAW_MODE)).intValue();
 		if( type == TGRedrawEvent.NORMAL ){
 			this.songView.redraw();
+			TGActivity activity = TGActivityController.getInstance(this.songView.getContext()).getActivity();
+			if (activity != null) {
+				activity.runOnUiThread(new Runnable() {
+					@Override
+					public void run() {
+						TGMainMenu.getInstance(TGSongViewEventListener.this.songView.getContext()).updateTempoDisplay();
+					}
+				});
+			}
 		}else if( type == TGRedrawEvent.PLAYING_NEW_BEAT ){
 			this.songView.redrawPlayingMode();
+			TGActivity activity = TGActivityController.getInstance(this.songView.getContext()).getActivity();
+			if (activity != null) {
+				activity.runOnUiThread(new Runnable() {
+					@Override
+					public void run() {
+						TGMainMenu.getInstance(TGSongViewEventListener.this.songView.getContext()).updateTempoDisplay();
+					}
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
Implements feature request #1006

When a tempo percentage is set, the toolbar now displays the effective BPM (base BPM × tempo% / 100), matching the behavior already present in the desktop version.