### PR TITLE
Cleanup some Javadocs in TuxGuitar module

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/keybindings/xml/KeyBindingReader.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/keybindings/xml/KeyBindingReader.java
@@ -97,8 +97,8 @@ public class KeyBindingReader {
 	/**
 	 * Read shortcuts from xml file
 	 *
-	 * @param shortcutsNode
-	 * @return
+	 * @param shortcutsNode XML node to read data from.
+	 * @return Shortcuts list.
 	 */
 	private static List<KeyBindingAction> getBindings(Node shortcutsNode){
 		List<KeyBindingAction> list = new ArrayList<KeyBindingAction>();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/keybindings/xml/KeyBindingWriter.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/keybindings/xml/KeyBindingWriter.java
@@ -76,8 +76,8 @@ public class KeyBindingWriter {
 	/**
 	 * Write shortcuts to xml file
 	 *
-	 * @param shortcutsNode
-	 * @return
+	 * @param userKeyBindingsList A list of keybindings to write.
+	 * @param document XML document to write into.
 	 */
 	private static void setBindings(List<KeyBindingAction> userKeyBindingsList,Document document){
 		Node shortcutsNode = document.createElement(SHORTCUT_ROOT);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordCreatorUtil.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordCreatorUtil.java
@@ -263,7 +263,7 @@ public class TGChordCreatorUtil {
 	/**
 	 * Creates the TGChord ArrayList out of StringValue's ArrayLists
 	 *
-	 * @param Highest rated StringValues
+	 * @param top Highest rated StringValues
 	 * @return TGChord collection
 	 */
 	private List<TGChord> createChords(List<List<StringValue>> top) {
@@ -294,12 +294,8 @@ public class TGChordCreatorUtil {
 	}
 
 	/**
-	 *
 	 * If string/fret combination is needed for the chord formation, add it into
 	 * List
-	 *
-	 * @return true if the note is needed for chord formation
-	 *
 	 */
 	private void find(int stringTone, int stringIndex, int fret,List<StringValue> stringList){
 		if(!isValidProcess()){
@@ -473,7 +469,7 @@ public class TGChordCreatorUtil {
 	/**
 	 * Makes a combination of string indices
 	 *
-	 * @param lastLevelCombination
+	 * @param lastLevelCombinationRef
 	 *            structure to be expanded by current level
 	 *
 	 * @return structure of stringCombination is AL { AL(0), AL(0,1),

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordRecognizer.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/TGChordRecognizer.java
@@ -121,9 +121,9 @@ public class TGChordRecognizer {
 		} ).start();
 	}
 
-	/** Fills the component's list with alternative names
+	/**
+	 * Fills the component's list with alternative names
 	 * @param chord TGChord to be recognized
-	 * @return parameters for adjustWidgets and getChordName methods
 	 */
 	protected void makeProposals(long processId, TGChord chord, boolean sharp, boolean redecorate, boolean setChordName) {
 		List<int[]> proposalParameters = new ArrayList<int[]>();
@@ -471,7 +471,6 @@ public class TGChordRecognizer {
 	 * -- a little adopted
 	 * @param a List of Proposals, unsorted
 	 * @param sortIndex 1 to sort by don'tHaveGrade, 2 to sort by unusualGrade
-	 * @return sorted list by selected criteria
 	 */
 	public void shellsort( List<Proposal> a, int sortIndex ){
 		int length = a.size();

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/xml/TGChordXMLReader.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/chord/xml/TGChordXMLReader.java
@@ -58,8 +58,8 @@ public class TGChordXMLReader {
 	/**
 	 * Read shortcuts from xml file
 	 *
-	 * @param shortcutsNode
-	 * @return
+	 * @param chordsNode XML node to read from.
+	 * @param chords A collection that will contain results. Should be empty.
 	 */
 	private static void loadChords(Node chordsNode,List<TGChord> chords){
 		try{

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/piano/TGPiano.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/piano/TGPiano.java
@@ -217,7 +217,7 @@ public class TGPiano {
 	/**
 	 * Crea la imagen del piano
 	 *
-	 * @return
+	 * @return Piano image object.
 	 */
 	private UIImage makePianoImage(){
 		UIFactory factory = getUIFactory();
@@ -277,8 +277,7 @@ public class TGPiano {
 	/**
 	 * Pinta la nota a partir del indice
 	 *
-	 * @param gc
-	 * @param value
+	 * @param painter Painter of user interface.
 	 */
 	private void paintScale(UIPainter painter){
 		painter.setBackground(this.config.getColorScale());
@@ -327,8 +326,9 @@ public class TGPiano {
 	/**
 	 * Pinta la nota a partir del indice
 	 *
-	 * @param gc
-	 * @param value
+	 * @param painter Painter of user interface.
+	 * @param value Note value.
+	 * @param playable Is note playable.
 	 */
 	protected void paintNote(UIPainter painter,int value, boolean playable){
 		if (value < 0)


### PR DESCRIPTION
This patch addresses "Declaration has problems with Javadoc references" and "Javadoc declaration problems" results of Intellij Idea code inspections within TuxGuitar module.

While there may be similar warnings in other modules, I've decided to limit the scope of changes to a single module. This should simplify code review.

The key goal of my activity is to gradually clean project's code from various warnings highlighted by IDE. In my experience, such warnings may create distractions during the development process and hide more severe issues. By cleaning code, we can make development process more smooth, fast and joyful.