### PR TITLE
don't show tuning in pdf or printed output if tablature is hidden

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/print/TGPrintLayout.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/print/TGPrintLayout.java
@@ -230,7 +230,7 @@ public class TGPrintLayout extends TGLayout {
 				headerOffset += 20.0f * getScale();
 			}
 
-			if (!track.isPercussion()) {
+			if (!track.isPercussion() && ((getStyle() & DISPLAY_TABLATURE) != 0)) {
 				String tuningLabel = getStringsTuningLabel(track);
 				if (tuningLabel != null && !tuningLabel.isEmpty()) {
 					String tuningLine = TGMessagesManager.getProperty("tuning") + ": " + tuningLabel;


### PR DESCRIPTION
If only score is visible, it makes no sense to show the tuning. Typical use case: one track is *not* a guitar track