### PR TITLE
Add NSM support

### DIFF
--- a/android/TuxGuitar-android/src/app/tuxguitar/android/view/dialog/repeat/TGRepeatCloseDialog.java
+++ b/android/TuxGuitar-android/src/app/tuxguitar/android/view/dialog/repeat/TGRepeatCloseDialog.java
@@ -46,26 +46,29 @@ public class TGRepeatCloseDialog extends TGModalFragment {
 		if( repeatCloseDefault < 1 ) {
 			repeatCloseDefault = 1;
 		}
+		// Show total play count (stored value + 1).
+		int displayDefault = repeatCloseDefault + 1;
 
 		ArrayAdapter<Integer> arrayAdapter = new ArrayAdapter<Integer>(getActivity(), android.R.layout.simple_spinner_item, createRepeatValues());
 		arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 
 		Spinner spinner = (Spinner) this.getView().findViewById(R.id.repeat_close_dlg_count_value);
 		spinner.setAdapter(arrayAdapter);
-		spinner.setSelection(arrayAdapter.getPosition(Integer.valueOf(repeatCloseDefault)));
+		spinner.setSelection(arrayAdapter.getPosition(Integer.valueOf(displayDefault)));
 	}
 
 	public Integer[] createRepeatValues() {
-		Integer[] items = new Integer[101];
+		// Values 2..101 represent "play N times" (stored as N-1 internally).
+		Integer[] items = new Integer[100];
 		for (int i = 0; i < items.length; i++) {
-			items[i] = Integer.valueOf(i);
+			items[i] = Integer.valueOf(i + 2);
 		}
 		return items;
 	}
 
 	public int parseRepeatValue() {
 		Spinner spinner = (Spinner) this.getView().findViewById(R.id.repeat_close_dlg_count_value);
-		return ((Integer)spinner.getSelectedItem()).intValue();
+		return ((Integer)spinner.getSelectedItem()).intValue() - 1;
 	}
 
 	public void changeRepeatClose() {

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGMeasureImpl.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGMeasureImpl.java
@@ -932,7 +932,7 @@ public class TGMeasureImpl extends TGMeasure{
 				if( addInfo ){
 					layout.setDivisionsStyle(painter,false);
 
-					String repetitions = ("x" + this.getRepeatClose());
+					String repetitions = ("x" + (this.getRepeatClose() + 1));
 					painter.drawString(repetitions, x2 - painter.getFMWidth(repetitions) + getSpacing() - size, y1 + painter.getFMBaseLine() - (2f * scale));
 				}
 			}

--- a/desktop/TuxGuitar-nsm/jni/GNUmakefile
+++ b/desktop/TuxGuitar-nsm/jni/GNUmakefile
@@ -1,0 +1,14 @@
+# See pom.xml for variable definitions
+
+OBJECTS=app_tuxguitar_nsm_NSMSignal.o
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+all:    $(LIBRARY)
+
+$(LIBRARY):	$(OBJECTS)
+	$(CC) $(LDFLAGS) -shared -o $(LIBRARY) $(OBJECTS) $(LDPATH) $(LDLIBS)
+
+clean:
+	$(RM) $(OBJECTS) $(LIBRARY)

--- a/desktop/TuxGuitar-nsm/jni/app_tuxguitar_nsm_NSMSignal.c
+++ b/desktop/TuxGuitar-nsm/jni/app_tuxguitar_nsm_NSMSignal.c
@@ -16,6 +16,31 @@ static void sigterm_handler(int sig) {
     }
 }
 
+static int install_sigterm_handler(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigterm_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    return sigaction(SIGTERM, &sa, NULL);
+}
+
+/*
+ * Class:     app_tuxguitar_nsm_NSMSignal
+ * Method:    reinstallSigtermHandler
+ * Signature: ()V
+ *
+ * Re-installs our sigterm_handler without creating a new pipe.  Call this
+ * just before sending any NSM reply so our handler is the last one installed
+ * (libjack overrides it when FluidSynth connects to JACK).
+ */
+JNIEXPORT void JNICALL
+Java_app_tuxguitar_nsm_NSMSignal_reinstallSigtermHandler(JNIEnv *env, jclass cls) {
+    if (sigterm_pipe_write != -1) {
+        install_sigterm_handler();
+    }
+}
+
 /*
  * Class:     app_tuxguitar_nsm_NSMSignal
  * Method:    registerSigtermPipe
@@ -33,12 +58,7 @@ Java_app_tuxguitar_nsm_NSMSignal_registerSigtermPipe(JNIEnv *env, jclass cls) {
     }
     sigterm_pipe_write = fds[1];
 
-    struct sigaction sa;
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_handler = sigterm_handler;
-    sigemptyset(&sa.sa_mask);
-    sa.sa_flags = SA_RESTART;
-    if (sigaction(SIGTERM, &sa, NULL) != 0) {
+    if (install_sigterm_handler() != 0) {
         close(fds[0]);
         close(fds[1]);
         sigterm_pipe_write = -1;

--- a/desktop/TuxGuitar-nsm/jni/app_tuxguitar_nsm_NSMSignal.c
+++ b/desktop/TuxGuitar-nsm/jni/app_tuxguitar_nsm_NSMSignal.c
@@ -1,0 +1,63 @@
+#include <jni.h>
+#include <signal.h>
+#include <unistd.h>
+#include <string.h>
+
+/* Write end of the self-pipe; -1 means not initialised. */
+static volatile int sigterm_pipe_write = -1;
+
+static void sigterm_handler(int sig) {
+    (void)sig;
+    int fd = sigterm_pipe_write;
+    if (fd != -1) {
+        /* write() is async-signal-safe; ignore partial-write — one byte is enough. */
+        char b = 1;
+        write(fd, &b, 1);
+    }
+}
+
+/*
+ * Class:     app_tuxguitar_nsm_NSMSignal
+ * Method:    registerSigtermPipe
+ * Signature: ()I
+ *
+ * Creates a pipe, installs our sigterm_handler for SIGTERM (overriding any
+ * handler previously set by SWT/GTK/FluidSynth), and returns the read-end fd.
+ * Returns -1 on error.
+ */
+JNIEXPORT jint JNICALL
+Java_app_tuxguitar_nsm_NSMSignal_registerSigtermPipe(JNIEnv *env, jclass cls) {
+    int fds[2];
+    if (pipe(fds) != 0) {
+        return -1;
+    }
+    sigterm_pipe_write = fds[1];
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigterm_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    if (sigaction(SIGTERM, &sa, NULL) != 0) {
+        close(fds[0]);
+        close(fds[1]);
+        sigterm_pipe_write = -1;
+        return -1;
+    }
+    return (jint)fds[0];
+}
+
+/*
+ * Class:     app_tuxguitar_nsm_NSMSignal
+ * Method:    waitSigterm
+ * Signature: (I)I
+ *
+ * Blocks until the pipe read-end fd receives a byte (i.e. SIGTERM fired).
+ * Returns 0 on success, -1 on error/EOF.
+ */
+JNIEXPORT jint JNICALL
+Java_app_tuxguitar_nsm_NSMSignal_waitSigterm(JNIEnv *env, jclass cls, jint readFd) {
+    char b;
+    ssize_t n = read((int)readFd, &b, 1);
+    return (n == 1) ? 0 : -1;
+}

--- a/desktop/TuxGuitar-nsm/pom.xml
+++ b/desktop/TuxGuitar-nsm/pom.xml
@@ -24,6 +24,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar-osc</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>tuxguitar-lib</artifactId>
 			<scope>provided</scope>
 		</dependency>

--- a/desktop/TuxGuitar-nsm/pom.xml
+++ b/desktop/TuxGuitar-nsm/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>tuxguitar-pom</artifactId>
+		<groupId>app.tuxguitar</groupId>
+		<version>9.99-SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>tuxguitar-nsm</artifactId>
+	<packaging>jar</packaging>
+	<name>${project.artifactId}</name>
+
+	<build>
+		<sourceDirectory>src</sourceDirectory>
+		<resources>
+			<resource>
+				<directory>share</directory>
+			</resource>
+		</resources>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar-lib</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar-editor-utils</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>tuxguitar</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/desktop/TuxGuitar-nsm/pom.xml
+++ b/desktop/TuxGuitar-nsm/pom.xml
@@ -30,6 +30,9 @@
 					<compilerArgs>
 						<arg>-Xlint:all</arg>
 					</compilerArgs>
+					<excludes>
+						<exclude>test/**</exclude>
+					</excludes>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/desktop/TuxGuitar-nsm/pom.xml
+++ b/desktop/TuxGuitar-nsm/pom.xml
@@ -19,6 +19,25 @@
 				<directory>share</directory>
 			</resource>
 		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<release>9</release>
+					<showWarnings>true</showWarnings>
+					<compilerArgs>
+						<arg>-Xlint:all</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.2</version>
+			</plugin>
+		</plugins>
 	</build>
 
 	<dependencies>
@@ -41,6 +60,12 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>tuxguitar</artifactId>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.9.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/desktop/TuxGuitar-nsm/share/META-INF/services/app.tuxguitar.util.plugin.TGPlugin
+++ b/desktop/TuxGuitar-nsm/share/META-INF/services/app.tuxguitar.util.plugin.TGPlugin
@@ -1,0 +1,1 @@
+app.tuxguitar.nsm.NSMPlugin

--- a/desktop/TuxGuitar-nsm/share/META-INF/tuxguitar-nsm.info
+++ b/desktop/TuxGuitar-nsm/share/META-INF/tuxguitar-nsm.info
@@ -1,0 +1,5 @@
+### Plugin Information ###
+plugin.name=NSM session management plugin
+plugin.description=Integrates TuxGuitar into a Non Session Manager (NSM) session.\nActivates automatically when the NSM_URL environment variable is set.
+plugin.author=TuxGuitar contributors
+plugin.version=1.0

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -53,6 +53,7 @@ public class NSMClient implements TGActionInterceptor {
 
 	private Thread receiveThread;
 	private volatile boolean running;
+	private volatile boolean quitting;
 
 	// Unblocks earlyInit() as soon as /nsm/client/open is received.
 	private final CountDownLatch openLatch = new CountDownLatch(1);
@@ -67,6 +68,7 @@ public class NSMClient implements TGActionInterceptor {
 		this.appReady = false;
 		this.pendingFilePath = null;
 		this.sessionFilePath = null;
+		this.quitting = false;
 
 		// Parse "osc.udp://host:port[/]"
 		String spec = nsmUrl.trim();
@@ -101,6 +103,7 @@ public class NSMClient implements TGActionInterceptor {
 		this.receiveThread.start();
 
 		sendAnnounce();
+		registerSigtermHandler();
 	}
 
 	// Block until /nsm/client/open is received or the timeout expires.
@@ -128,6 +131,39 @@ public class NSMClient implements TGActionInterceptor {
 
 	public void activateInterceptor() {
 		TGActionManager.getInstance(this.context).addInterceptor(this);
+	}
+
+	// RaySession (and many other NSM session managers) terminate clients via
+	// SIGTERM rather than /nsm/client/quit.  This handler intercepts SIGTERM
+	// and routes it through TuxGuitar's normal exit path so the "save before
+	// exit?" dialog appears when there are unsaved changes.
+	//
+	// sun.misc.Signal is a private JDK API; we access it via reflection so the
+	// plugin compiles without --add-exports flags.  If the class is absent or
+	// the signal cannot be registered, we log a warning and fall through to
+	// the JVM's default SIGTERM behaviour.
+	private void registerSigtermHandler() {
+		try {
+			Class<?> signalClass  = Class.forName("sun.misc.Signal");
+			Class<?> handlerClass = Class.forName("sun.misc.SignalHandler");
+			java.lang.reflect.Method handleMethod =
+					signalClass.getMethod("handle", signalClass, handlerClass);
+			Object termSignal = signalClass.getConstructor(String.class).newInstance("TERM");
+			Object handler = java.lang.reflect.Proxy.newProxyInstance(
+					NSMClient.class.getClassLoader(),
+					new Class<?>[]{ handlerClass },
+					(proxy, method, args) -> {
+						if ("handle".equals(method.getName())) {
+							System.err.println("[NSM] SIGTERM received — dispatching quit");
+							handleQuit();
+						}
+						return null;
+					});
+			handleMethod.invoke(null, termSignal, handler);
+			System.out.println("[NSM] SIGTERM handler registered");
+		} catch (Throwable t) {
+			System.err.println("[NSM] could not register SIGTERM handler: " + t);
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -305,6 +341,10 @@ public class NSMClient implements TGActionInterceptor {
 	// -------------------------------------------------------------------------
 
 	private void handleQuit() {
+		if (this.quitting) {
+			return;
+		}
+		this.quitting = true;
 		// TGExitAction calls TGWindow.getWindow().close(), which fires the
 		// existing window-close listener.  That listener dispatches TGDisposeAction
 		// (SAVE_BEFORE), so the "save before exit?" dialog appears when there are

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -13,12 +13,9 @@ import app.tuxguitar.action.TGActionContext;
 import app.tuxguitar.action.TGActionException;
 import app.tuxguitar.action.TGActionInterceptor;
 import app.tuxguitar.action.TGActionManager;
+import app.tuxguitar.app.action.impl.file.TGExitAction;
 import app.tuxguitar.app.action.impl.file.TGReadURLAction;
 import app.tuxguitar.app.action.impl.file.TGWriteFileAction;
-import app.tuxguitar.app.action.impl.system.TGDisposeAction;
-import app.tuxguitar.app.action.listener.save.TGUnsavedDocumentInterceptor;
-import app.tuxguitar.app.document.TGDocument;
-import app.tuxguitar.app.document.TGDocumentListManager;
 import app.tuxguitar.editor.action.TGActionProcessor;
 import app.tuxguitar.editor.action.file.TGLoadTemplateAction;
 import app.tuxguitar.nsm.osc.OSCMessage;
@@ -306,29 +303,12 @@ public class NSMClient implements TGActionInterceptor {
 	// -------------------------------------------------------------------------
 
 	private void handleQuit() {
-		TGActionProcessor proc = new TGActionProcessor(this.context, TGDisposeAction.NAME);
-		// If nothing has changed there is nothing to save, so bypass the
-		// "save before exit?" dialog — it would block indefinitely under NSM
-		// because nobody is there to click it.  When there ARE unsaved changes
-		// the dialog appears normally; after the user saves, TGDisposeAction is
-		// re-dispatched by TGUnsavedDocumentInterceptor with bypass=true.
-		if (!hasUnsavedDocuments()) {
-			proc.setAttribute(TGUnsavedDocumentInterceptor.UNSAVED_INTERCEPTOR_BY_PASS, Boolean.TRUE);
-		}
+		// TGExitAction calls TGWindow.getWindow().close(), which fires the
+		// existing window-close listener.  That listener dispatches TGDisposeAction
+		// (SAVE_BEFORE), so the "save before exit?" dialog appears when there are
+		// unsaved changes — exactly the same path as File > Exit in the menu.
+		TGActionProcessor proc = new TGActionProcessor(this.context, TGExitAction.NAME);
 		proc.process();
-	}
-
-	private boolean hasUnsavedDocuments() {
-		try {
-			for (TGDocument doc : TGDocumentListManager.getInstance(this.context).getDocuments()) {
-				if (doc.isUnsaved()) {
-					return true;
-				}
-			}
-		} catch (Exception e) {
-			return true; // fail safe: show the dialog rather than silently discard unsaved work
-		}
-		return false;
 	}
 
 	// -------------------------------------------------------------------------

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -1,12 +1,6 @@
 package app.tuxguitar.nsm;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -81,22 +75,9 @@ public class NSMClient implements TGActionInterceptor {
 		this.sessionFilePath = null;
 		this.quitting = false;
 
-		// Parse "osc.udp://host:port[/]"
-		String spec = nsmUrl.trim();
-		if (!spec.startsWith("osc.udp://")) {
-			throw new IllegalArgumentException("Unsupported NSM_URL scheme: " + nsmUrl);
-		}
-		spec = spec.substring("osc.udp://".length());
-		if (spec.endsWith("/")) {
-			spec = spec.substring(0, spec.length() - 1);
-		}
-		int colon = spec.lastIndexOf(':');
-		String host = spec.substring(0, colon);
-		int port = Integer.parseInt(spec.substring(colon + 1));
-
-		InetAddress serverAddress = InetAddress.getByName(host);
+		NSMUrl parsedUrl = new NSMUrl(nsmUrl);
 		this.socket = new DatagramSocket();
-		this.oscClient = new OSCClient(serverAddress, port, this.socket);
+		this.oscClient = new OSCClient(parsedUrl.address, parsedUrl.port, this.socket);
 	}
 
 	// -------------------------------------------------------------------------
@@ -510,33 +491,12 @@ public class NSMClient implements TGActionInterceptor {
 		}
 	}
 
-	// Writes a one-line pointer file recording which real file is open in this session.
 	private void writePointerFile(String backupPath, String realPath) {
-		File pointerFile = new File(new File(backupPath).getParent(), "tuxguitar-source.path");
-		try {
-			PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(pointerFile), "UTF-8"));
-			pw.println(realPath != null ? realPath : "");
-			pw.close();
-		} catch (Exception e) {
-			System.err.println("[NSM] failed to write pointer file: " + e);
-		}
+		NSMPointerFile.write(new File(backupPath).getParent(), realPath);
 	}
 
-	// Reads the pointer file; returns the real path or null if absent/empty.
 	private String readPointerFile(String sessionDir) {
-		File pointerFile = new File(sessionDir, "tuxguitar-source.path");
-		if (!pointerFile.exists()) {
-			return null;
-		}
-		try {
-			BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(pointerFile), "UTF-8"));
-			String line = br.readLine();
-			br.close();
-			return (line != null && !line.trim().isEmpty()) ? line.trim() : null;
-		} catch (Exception e) {
-			System.err.println("[NSM] failed to read pointer file: " + e);
-			return null;
-		}
+		return NSMPointerFile.read(sessionDir);
 	}
 
 	// -------------------------------------------------------------------------

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -152,6 +152,35 @@ public class NSMClient implements TGActionInterceptor {
 		} catch (UnsatisfiedLinkError e) {
 			System.err.println("[NSM] native library not available — SIGTERM will not be caught: " + e);
 		}
+		// Always register SIGUSR2: the bash wrapper sends USR2 when it receives
+		// SIGTERM from the session manager, bypassing JACK's sigaction override.
+		registerSigusr2Handler();
+	}
+
+	// sun.misc.Signal via reflection — avoids --add-exports and compiles cleanly.
+	private void registerSigusr2Handler() {
+		try {
+			Class<?> signalClass  = Class.forName("sun.misc.Signal");
+			Class<?> handlerClass = Class.forName("sun.misc.SignalHandler");
+			java.lang.reflect.Method handleMethod =
+					signalClass.getMethod("handle", signalClass, handlerClass);
+			Object usr2Signal = signalClass.getConstructor(String.class).newInstance("USR2");
+			ClassLoader proxyLoader = ClassLoader.getSystemClassLoader();
+			Object handler = java.lang.reflect.Proxy.newProxyInstance(
+					proxyLoader,
+					new Class<?>[]{ handlerClass },
+					(proxy, method, args) -> {
+						if ("handle".equals(method.getName())) {
+							System.err.println("[NSM] SIGUSR2 received — dispatching quit");
+							handleQuit();
+						}
+						return null;
+					});
+			handleMethod.invoke(null, usr2Signal, handler);
+			System.out.println("[NSM] SIGUSR2 handler registered");
+		} catch (Throwable t) {
+			System.err.println("[NSM] could not register SIGUSR2 handler: " + t);
+		}
 	}
 
 	// Block until /nsm/client/open is received or the timeout expires.
@@ -199,7 +228,17 @@ public class NSMClient implements TGActionInterceptor {
 	// -------------------------------------------------------------------------
 
 	private void sendAnnounce() {
+		// Announce the launcher script's PID when available so the session
+		// manager sends SIGTERM to the bash wrapper instead of the JVM.
+		// The wrapper converts SIGTERM → SIGUSR2 which Java handles cleanly.
 		int pid = (int) ProcessHandle.current().pid();
+		String launcherPid = System.getenv("NSM_LAUNCHER_PID");
+		if (launcherPid != null && !launcherPid.isEmpty()) {
+			try {
+				pid = Integer.parseInt(launcherPid.trim());
+				System.out.println("[NSM] announcing launcher PID " + pid + " (bash wrapper active)");
+			} catch (NumberFormatException ignored) {}
+		}
 		OSCMessage msg = new OSCMessage("/nsm/server/announce");
 		msg.addString("TuxGuitar");
 		msg.addString("");          // capabilities: none declared

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -1,0 +1,357 @@
+package app.tuxguitar.nsm;
+
+import java.io.File;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import app.tuxguitar.action.TGActionContext;
+import app.tuxguitar.action.TGActionException;
+import app.tuxguitar.action.TGActionInterceptor;
+import app.tuxguitar.action.TGActionManager;
+import app.tuxguitar.app.action.impl.file.TGReadURLAction;
+import app.tuxguitar.app.action.impl.file.TGWriteFileAction;
+import app.tuxguitar.app.action.impl.system.TGDisposeAction;
+import app.tuxguitar.app.action.listener.save.TGUnsavedDocumentInterceptor;
+import app.tuxguitar.app.document.TGDocument;
+import app.tuxguitar.app.document.TGDocumentListManager;
+import app.tuxguitar.editor.action.TGActionProcessor;
+import app.tuxguitar.editor.action.file.TGLoadTemplateAction;
+import app.tuxguitar.nsm.osc.OSCMessage;
+import app.tuxguitar.util.TGContext;
+import app.tuxguitar.util.error.TGErrorHandler;
+import app.tuxguitar.util.error.TGErrorManager;
+
+/*
+ * NSM (Non Session Manager) client.
+ *
+ * Startup sequence:
+ *  1. NSMPlugin.earlyInit() calls startCommunication() — starts the UDP receive
+ *     thread and sends /nsm/server/announce.
+ *  2. earlyInit() calls waitForSessionDirectory() — blocks briefly (≤ timeout)
+ *     until the NSM server sends /nsm/client/open.  The session directory is
+ *     returned so the plugin can redirect TuxGuitar's config I/O before any
+ *     config file is read.
+ *  3. earlyInit() calls activateInterceptor() — registers this object as a
+ *     TGActionInterceptor so that the default empty-song load is suppressed and
+ *     the session file is opened instead.
+ *
+ * The NSM session directory (= the path argument of /nsm/client/open) is used
+ * as a self-contained folder:
+ *   {sessionDir}/tuxguitar.tg             — the song file
+ *   {sessionDir}/tuxguitar.cfg            — main application config
+ *   {sessionDir}/plugins/                 — per-plugin configs
+ *   {sessionDir}/tuxguitar-plugin-settings.cfg — plugin enabled/disabled state
+ */
+public class NSMClient implements TGActionInterceptor {
+
+	private final TGContext context;
+	private final DatagramSocket socket;
+	private final InetAddress serverAddress;
+	private final int serverPort;
+
+	private Thread receiveThread;
+	private volatile boolean running;
+
+	// Unblocks earlyInit() as soon as /nsm/client/open is received.
+	private final CountDownLatch openLatch = new CountDownLatch(1);
+
+	// guarded by synchronized(this)
+	private boolean appReady;
+	private String pendingFilePath;
+	private String sessionFilePath;   // absolute path to the .tg song file
+
+	public NSMClient(TGContext context, String nsmUrl) throws Exception {
+		this.context = context;
+		this.appReady = false;
+		this.pendingFilePath = null;
+		this.sessionFilePath = null;
+
+		// Parse "osc.udp://host:port[/]"
+		String spec = nsmUrl.trim();
+		if (!spec.startsWith("osc.udp://")) {
+			throw new IllegalArgumentException("Unsupported NSM_URL scheme: " + nsmUrl);
+		}
+		spec = spec.substring("osc.udp://".length());
+		if (spec.endsWith("/")) {
+			spec = spec.substring(0, spec.length() - 1);
+		}
+		int colon = spec.lastIndexOf(':');
+		String host = spec.substring(0, colon);
+		int port = Integer.parseInt(spec.substring(colon + 1));
+
+		this.serverAddress = InetAddress.getByName(host);
+		this.serverPort = port;
+		this.socket = new DatagramSocket();
+	}
+
+	// -------------------------------------------------------------------------
+	// Phase 1 — called from earlyInit() before blocking
+	// -------------------------------------------------------------------------
+
+	public void startCommunication() {
+		this.running = true;
+		this.receiveThread = new Thread(new Runnable() {
+			public void run() {
+				receiveLoop();
+			}
+		}, "NSM");
+		this.receiveThread.setDaemon(true);
+		this.receiveThread.start();
+
+		sendAnnounce();
+	}
+
+	// Block until /nsm/client/open is received or the timeout expires.
+	// Returns the session directory, or null on timeout.
+	public String waitForSessionDirectory(long timeoutMs) {
+		try {
+			if (openLatch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+				synchronized (this) {
+					if (this.sessionFilePath != null) {
+						return new File(this.sessionFilePath).getParent();
+					}
+				}
+			} else {
+				System.err.println("[NSM] Timed out waiting for /nsm/client/open — config will use default location.");
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		return null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Phase 2 — called from earlyInit() after config has been redirected
+	// -------------------------------------------------------------------------
+
+	public void activateInterceptor() {
+		TGActionManager.getInstance(this.context).addInterceptor(this);
+	}
+
+	// -------------------------------------------------------------------------
+	// Shutdown
+	// -------------------------------------------------------------------------
+
+	public void stop() {
+		this.running = false;
+		TGActionManager.getInstance(this.context).removeInterceptor(this);
+		if (!this.socket.isClosed()) {
+			this.socket.close();
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Outgoing OSC messages
+	// -------------------------------------------------------------------------
+
+	private void sendAnnounce() {
+		int pid = (int) ProcessHandle.current().pid();
+		OSCMessage msg = new OSCMessage("/nsm/server/announce");
+		msg.addString("TuxGuitar");
+		msg.addString("");          // capabilities: none declared
+		msg.addString("tuxguitar");
+		msg.addInt(1);              // NSM API major version
+		msg.addInt(2);              // NSM API minor version
+		msg.addInt(pid);
+		sendMessage(msg);
+	}
+
+	private void sendReply(String path, String message) {
+		OSCMessage msg = new OSCMessage("/reply");
+		msg.addString(path);
+		msg.addString(message);
+		sendMessage(msg);
+	}
+
+	private void sendError(String path, int code, String message) {
+		OSCMessage msg = new OSCMessage("/error");
+		msg.addString(path);
+		msg.addInt(code);
+		msg.addString(message);
+		sendMessage(msg);
+	}
+
+	private void sendMessage(OSCMessage msg) {
+		try {
+			byte[] data = msg.encode();
+			DatagramPacket packet = new DatagramPacket(data, data.length, this.serverAddress, this.serverPort);
+			this.socket.send(packet);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Receive loop
+	// -------------------------------------------------------------------------
+
+	private void receiveLoop() {
+		byte[] buffer = new byte[65536];
+		DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+		while (this.running) {
+			try {
+				this.socket.receive(packet);
+				OSCMessage msg = OSCMessage.decode(buffer, packet.getLength());
+				handleMessage(msg);
+			} catch (SocketException e) {
+				break; // socket closed, normal shutdown
+			} catch (Exception e) {
+				TGErrorManager.getInstance(this.context).handleError(e);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Incoming message dispatch
+	// -------------------------------------------------------------------------
+
+	private void handleMessage(OSCMessage msg) {
+		String addr = msg.getAddress();
+		if ("/nsm/client/open".equals(addr)) {
+			if (msg.argCount() >= 1) {
+				handleOpen(msg.getStringArg(0));
+			}
+		} else if ("/nsm/client/save".equals(addr)) {
+			handleSave();
+		} else if ("/nsm/client/quit".equals(addr)) {
+			handleQuit();
+		} else if ("/reply".equals(addr) && msg.argCount() >= 2
+				&& "/nsm/server/announce".equals(msg.getStringArg(0))) {
+			System.out.println("[NSM] session manager: " + msg.getStringArg(1));
+		} else if ("/error".equals(addr) && msg.argCount() >= 3) {
+			System.err.println("[NSM] error on " + msg.getStringArg(0) + ": " + msg.getStringArg(2));
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Open
+	// -------------------------------------------------------------------------
+
+	private void handleOpen(String path) {
+		// NSM provides a per-client directory path.  All session files live inside it.
+		new File(path).mkdirs();
+		String filePath = path + File.separator + "tuxguitar.tg";
+
+		synchronized (this) {
+			this.sessionFilePath = filePath;
+			if (this.appReady) {
+				processOpen(filePath);
+			} else {
+				this.pendingFilePath = filePath;
+			}
+		}
+		// Unblock earlyInit() so config can be redirected before TuxGuitar reads it.
+		openLatch.countDown();
+		// Acknowledge immediately — the actual file load is asynchronous.
+		sendReply("/nsm/client/open", "opened");
+	}
+
+	private void processOpen(String filePath) {
+		File file = new File(filePath);
+		if (file.exists()) {
+			try {
+				URL url = file.toURI().toURL();
+				TGActionProcessor proc = new TGActionProcessor(this.context, TGReadURLAction.NAME);
+				proc.setAttribute(TGReadURLAction.ATTRIBUTE_URL, url);
+				proc.process();
+			} catch (Exception e) {
+				TGErrorManager.getInstance(this.context).handleError(e);
+			}
+		} else {
+			// Brand-new session: load an empty template (interceptor already removed).
+			TGActionProcessor proc = new TGActionProcessor(this.context, TGLoadTemplateAction.NAME);
+			proc.process();
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Save
+	// -------------------------------------------------------------------------
+
+	private void handleSave() {
+		final String filePath;
+		synchronized (this) {
+			filePath = this.sessionFilePath;
+		}
+		if (filePath == null) {
+			sendError("/nsm/client/save", 1, "no session file path");
+			return;
+		}
+		File file = new File(filePath);
+		if (file.getParentFile() != null) {
+			file.getParentFile().mkdirs();
+		}
+		TGActionProcessor proc = new TGActionProcessor(this.context, TGWriteFileAction.NAME);
+		proc.setAttribute(TGWriteFileAction.ATTRIBUTE_FILE_NAME, filePath);
+		proc.setOnFinish(new Runnable() {
+			public void run() {
+				sendReply("/nsm/client/save", "saved");
+			}
+		});
+		proc.setErrorHandler(new TGErrorHandler() {
+			public void handleError(Throwable e) {
+				sendError("/nsm/client/save", 1, e.getMessage() != null ? e.getMessage() : "save error");
+			}
+		});
+		proc.process();
+	}
+
+	// -------------------------------------------------------------------------
+	// Quit
+	// -------------------------------------------------------------------------
+
+	private void handleQuit() {
+		TGActionProcessor proc = new TGActionProcessor(this.context, TGDisposeAction.NAME);
+		// If nothing has changed there is nothing to save, so bypass the
+		// "save before exit?" dialog — it would block indefinitely under NSM
+		// because nobody is there to click it.  When there ARE unsaved changes
+		// the dialog appears normally; after the user saves, TGDisposeAction is
+		// re-dispatched by TGUnsavedDocumentInterceptor with bypass=true.
+		if (!hasUnsavedDocuments()) {
+			proc.setAttribute(TGUnsavedDocumentInterceptor.UNSAVED_INTERCEPTOR_BY_PASS, Boolean.TRUE);
+		}
+		proc.process();
+	}
+
+	private boolean hasUnsavedDocuments() {
+		try {
+			for (TGDocument doc : TGDocumentListManager.getInstance(this.context).getDocuments()) {
+				if (doc.isUnsaved()) {
+					return true;
+				}
+			}
+		} catch (Exception e) {
+			return true; // fail safe: show the dialog rather than silently discard unsaved work
+		}
+		return false;
+	}
+
+	// -------------------------------------------------------------------------
+	// TGActionInterceptor — suppress default song loading at startup
+	// -------------------------------------------------------------------------
+
+	@Override
+	public boolean intercept(String id, TGActionContext actionContext) throws TGActionException {
+		if (TGLoadTemplateAction.NAME.equals(id)) {
+			// One-shot: remove the interceptor after the first startup template dispatch.
+			TGActionManager.getInstance(this.context).removeInterceptor(this);
+			final String filePath;
+			synchronized (this) {
+				this.appReady = true;
+				filePath = this.pendingFilePath;
+				this.pendingFilePath = null;
+			}
+			if (filePath != null) {
+				processOpen(filePath);
+			}
+			// Suppress the default template load; processOpen() handles the song.
+			return true;
+		}
+		return false;
+	}
+}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -1,10 +1,17 @@
 package app.tuxguitar.nsm;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
+import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -16,6 +23,8 @@ import app.tuxguitar.action.TGActionManager;
 import app.tuxguitar.app.action.impl.file.TGExitAction;
 import app.tuxguitar.app.action.impl.file.TGReadURLAction;
 import app.tuxguitar.app.action.impl.file.TGWriteFileAction;
+import app.tuxguitar.app.document.TGDocumentFileManager;
+import app.tuxguitar.app.document.TGDocumentListManager;
 import app.tuxguitar.editor.action.TGActionProcessor;
 import app.tuxguitar.editor.action.file.TGLoadTemplateAction;
 import app.tuxguitar.nsm.osc.OSCMessage;
@@ -361,11 +370,33 @@ public class NSMClient implements TGActionInterceptor {
 		}
 	}
 
-	private void processOpen(String filePath) {
-		File file = new File(filePath);
-		if (file.exists()) {
+	private void processOpen(String backupPath) {
+		String sessionDir = new File(backupPath).getParent();
+
+		// Prefer the real file recorded by the last NSM save; fall back to the backup.
+		String realPath = readPointerFile(sessionDir);
+		File targetFile = null;
+
+		if (realPath != null) {
+			File realFile = new File(realPath);
+			if (realFile.exists()) {
+				targetFile = realFile;
+				System.out.println("[NSM] opening real file: " + realPath);
+			} else {
+				System.out.println("[NSM] real file missing (" + realPath + "), falling back to backup");
+			}
+		}
+		if (targetFile == null) {
+			File backupFile = new File(backupPath);
+			if (backupFile.exists()) {
+				targetFile = backupFile;
+				System.out.println("[NSM] opening backup: " + backupPath);
+			}
+		}
+
+		if (targetFile != null) {
 			try {
-				URL url = file.toURI().toURL();
+				URL url = targetFile.toURI().toURL();
 				TGActionProcessor proc = new TGActionProcessor(this.context, TGReadURLAction.NAME);
 				proc.setAttribute(TGReadURLAction.ATTRIBUTE_URL, url);
 				proc.process();
@@ -373,7 +404,8 @@ public class NSMClient implements TGActionInterceptor {
 				TGErrorManager.getInstance(this.context).handleError(e);
 			}
 		} else {
-			// Brand-new session: load an empty template (interceptor already removed).
+			// Brand-new session: load an empty template.
+			System.out.println("[NSM] new session, loading empty template");
 			TGActionProcessor proc = new TGActionProcessor(this.context, TGLoadTemplateAction.NAME);
 			proc.process();
 		}
@@ -385,28 +417,63 @@ public class NSMClient implements TGActionInterceptor {
 
 	private void handleSave() {
 		System.out.println("[NSM] save requested");
-		final String filePath;
+		final String backupPath;
 		synchronized (this) {
-			filePath = this.sessionFilePath;
+			backupPath = this.sessionFilePath;
 		}
-		if (filePath == null) {
+		if (backupPath == null) {
 			System.err.println("[NSM] save failed: no session file path");
 			sendError("/nsm/client/save", 1, "no session file path");
 			return;
 		}
-		System.out.println("[NSM] saving to: " + filePath);
-		File file = new File(filePath);
-		if (file.getParentFile() != null) {
-			file.getParentFile().mkdirs();
+		new File(backupPath).getParentFile().mkdirs();
+
+		// Get the document's current real path (may differ from the session backup).
+		final String realPath = getRealDocumentPath();
+		System.out.println("[NSM] backup path : " + backupPath);
+		System.out.println("[NSM] real path   : " + (realPath != null ? realPath : "(none — new document)"));
+
+		if (realPath != null && !realPath.equals(backupPath)) {
+			// Save to the real path first, then write backup and reply.
+			saveToPath(realPath, new Runnable() {
+				public void run() {
+					saveBackupThenReply(backupPath, realPath);
+				}
+			}, new TGErrorHandler() {
+				public void handleError(Throwable e) {
+					System.err.println("[NSM] real-path save error (backup will still be written): " + e);
+					saveBackupThenReply(backupPath, null);
+				}
+			});
+		} else {
+			// New/unsaved document or already working from the session dir.
+			saveBackupThenReply(backupPath, null);
 		}
+		System.out.println("[NSM] save dispatched");
+	}
+
+	private void saveToPath(String path, final Runnable onFinish, final TGErrorHandler onError) {
 		TGActionProcessor proc = new TGActionProcessor(this.context, TGWriteFileAction.NAME);
-		proc.setAttribute(TGWriteFileAction.ATTRIBUTE_FILE_NAME, filePath);
+		proc.setAttribute(TGWriteFileAction.ATTRIBUTE_FILE_NAME, path);
+		proc.setOnFinish(onFinish);
+		proc.setErrorHandler(onError);
+		proc.process();
+	}
+
+	private void saveBackupThenReply(final String backupPath, final String realPath) {
+		System.out.println("[NSM] writing backup: " + backupPath);
+		TGActionProcessor proc = new TGActionProcessor(this.context, TGWriteFileAction.NAME);
+		proc.setAttribute(TGWriteFileAction.ATTRIBUTE_FILE_NAME, backupPath);
 		proc.setOnFinish(new Runnable() {
 			public void run() {
+				// The backup save updated the document URI to the backup path.
+				// Restore it to the real path so TuxGuitar keeps working on the right file.
+				if (realPath != null) {
+					restoreDocumentUri(realPath);
+				}
+				// Record which real file was open so we can restore it next session.
+				writePointerFile(backupPath, realPath);
 				System.out.println("[NSM] save onFinish — sending reply");
-				// Re-install our sigaction just before replying: libjack overrides it
-				// when FluidSynth connects to JACK, but SIGTERM always arrives after
-				// the save reply, so reinstalling here guarantees we intercept it.
 				try { NSMSignal.reinstallSigtermHandler(); } catch (UnsatisfiedLinkError ignored) {}
 				sendReply("/nsm/client/save", "saved");
 				System.out.println("[NSM] save reply sent");
@@ -414,13 +481,64 @@ public class NSMClient implements TGActionInterceptor {
 		});
 		proc.setErrorHandler(new TGErrorHandler() {
 			public void handleError(Throwable e) {
-				System.err.println("[NSM] save error: " + e);
+				System.err.println("[NSM] backup save error: " + e);
 				e.printStackTrace(System.err);
-				sendError("/nsm/client/save", 1, e.getMessage() != null ? e.getMessage() : "save error");
+				sendError("/nsm/client/save", 1, e.getMessage() != null ? e.getMessage() : "backup save error");
 			}
 		});
 		proc.process();
-		System.out.println("[NSM] save action dispatched");
+	}
+
+	// Returns the full path of the currently open document, or null for a new/unsaved file.
+	private String getRealDocumentPath() {
+		TGDocumentFileManager fm = TGDocumentFileManager.getInstance(this.context);
+		if (fm.isLocalFile()) {
+			String dir  = fm.getCurrentFilePath();
+			String name = fm.getCurrentFileName(null);
+			if (dir != null && name != null) {
+				return dir + File.separator + name;
+			}
+		}
+		return null;
+	}
+
+	// Restores the document URI after the backup save changed it to the backup path.
+	private void restoreDocumentUri(String realPath) {
+		try {
+			URI uri = new File(realPath).toURI();
+			TGDocumentListManager.getInstance(this.context).findCurrentDocument().setUri(uri);
+		} catch (Exception e) {
+			System.err.println("[NSM] failed to restore document URI: " + e);
+		}
+	}
+
+	// Writes a one-line pointer file recording which real file is open in this session.
+	private void writePointerFile(String backupPath, String realPath) {
+		File pointerFile = new File(new File(backupPath).getParent(), "tuxguitar-source.path");
+		try {
+			PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(pointerFile), "UTF-8"));
+			pw.println(realPath != null ? realPath : "");
+			pw.close();
+		} catch (Exception e) {
+			System.err.println("[NSM] failed to write pointer file: " + e);
+		}
+	}
+
+	// Reads the pointer file; returns the real path or null if absent/empty.
+	private String readPointerFile(String sessionDir) {
+		File pointerFile = new File(sessionDir, "tuxguitar-source.path");
+		if (!pointerFile.exists()) {
+			return null;
+		}
+		try {
+			BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(pointerFile), "UTF-8"));
+			String line = br.readLine();
+			br.close();
+			return (line != null && !line.trim().isEmpty()) ? line.trim() : null;
+		} catch (Exception e) {
+			System.err.println("[NSM] failed to read pointer file: " + e);
+			return null;
+		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -115,7 +115,9 @@ public class NSMClient implements TGActionInterceptor {
 				return;
 			}
 			System.out.println("[NSM] native SIGTERM handler registered (pipe read-fd=" + readFd + ")");
-			Thread t = new Thread(new Runnable() {
+
+			// Wakes up when SIGTERM fires the native handler.
+			Thread reader = new Thread(new Runnable() {
 				public void run() {
 					int rc = NSMSignal.waitSigterm(readFd);
 					if (rc == 0) {
@@ -126,8 +128,27 @@ public class NSMClient implements TGActionInterceptor {
 					}
 				}
 			}, "NSM-sigterm-reader");
-			t.setDaemon(true);
-			t.start();
+			reader.setDaemon(true);
+			reader.start();
+
+			// libjack reinstalls its own SIGTERM sigaction when other JACK clients
+			// disconnect (e.g. during session close).  This watchdog reclaims our
+			// handler every 100 ms so the window for SIGTERM to slip through is tiny.
+			Thread watchdog = new Thread(new Runnable() {
+				public void run() {
+					while (running) {
+						try {
+							Thread.sleep(100);
+						} catch (InterruptedException e) {
+							break;
+						}
+						NSMSignal.reinstallSigtermHandler();
+					}
+				}
+			}, "NSM-sigterm-watchdog");
+			watchdog.setDaemon(true);
+			watchdog.start();
+
 		} catch (UnsatisfiedLinkError e) {
 			System.err.println("[NSM] native library not available — SIGTERM will not be caught: " + e);
 		}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -20,6 +20,8 @@ import app.tuxguitar.editor.action.TGActionProcessor;
 import app.tuxguitar.editor.action.file.TGLoadTemplateAction;
 import app.tuxguitar.nsm.osc.OSCMessage;
 import app.tuxguitar.util.TGContext;
+import app.tuxguitar.util.TGException;
+import app.tuxguitar.util.TGSynchronizer;
 import app.tuxguitar.util.error.TGErrorHandler;
 import app.tuxguitar.util.error.TGErrorManager;
 
@@ -327,9 +329,11 @@ public class NSMClient implements TGActionInterceptor {
 		new File(path).mkdirs();
 		String filePath = path + File.separator + "tuxguitar.tg";
 
+		boolean readyNow;
 		synchronized (this) {
 			this.sessionFilePath = filePath;
-			if (this.appReady) {
+			readyNow = this.appReady;
+			if (readyNow) {
 				processOpen(filePath);
 			} else {
 				this.pendingFilePath = filePath;
@@ -337,8 +341,24 @@ public class NSMClient implements TGActionInterceptor {
 		}
 		// Unblock earlyInit() so config can be redirected before TuxGuitar reads it.
 		openLatch.countDown();
-		// Acknowledge immediately — the actual file load is asynchronous.
-		sendReply("/nsm/client/open", "opened");
+		if (readyNow) {
+			// App already started (re-open): reply after the action has been dispatched.
+			sendOpenReplyLater();
+		}
+		// else: reply is deferred to intercept() which fires after startup completes.
+	}
+
+	private void sendOpenReplyLater() {
+		try {
+			TGSynchronizer.getInstance(this.context).executeLater(new Runnable() {
+				public void run() {
+					sendReply("/nsm/client/open", "opened");
+				}
+			});
+		} catch (TGException e) {
+			// Synchronizer unavailable — fall back to immediate reply.
+			sendReply("/nsm/client/open", "opened");
+		}
 	}
 
 	private void processOpen(String filePath) {
@@ -444,6 +464,10 @@ public class NSMClient implements TGActionInterceptor {
 			}
 			if (filePath != null) {
 				processOpen(filePath);
+				// Reply after the splash screen closes.  executeLater() queues this
+				// task AFTER the current event-loop task (startUIContext + splash.finish()),
+				// so the session manager only sees us as ready once the UI is fully up.
+				sendOpenReplyLater();
 			}
 			// Suppress the default template load; processOpen() handles the song.
 			return true;

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -209,6 +209,7 @@ public class NSMClient implements TGActionInterceptor {
 
 	private void handleMessage(OSCMessage msg) {
 		String addr = msg.getAddress();
+		System.out.println("[NSM] received: " + addr);
 		if ("/nsm/client/open".equals(addr)) {
 			if (msg.argCount() >= 1) {
 				handleOpen(msg.getStringArg(0));
@@ -216,6 +217,7 @@ public class NSMClient implements TGActionInterceptor {
 		} else if ("/nsm/client/save".equals(addr)) {
 			handleSave();
 		} else if ("/nsm/client/quit".equals(addr)) {
+			System.out.println("[NSM] quit requested — dispatching TGExitAction");
 			handleQuit();
 		} else if ("/reply".equals(addr) && msg.argCount() >= 2
 				&& "/nsm/server/announce".equals(msg.getStringArg(0))) {
@@ -308,7 +310,14 @@ public class NSMClient implements TGActionInterceptor {
 		// (SAVE_BEFORE), so the "save before exit?" dialog appears when there are
 		// unsaved changes — exactly the same path as File > Exit in the menu.
 		TGActionProcessor proc = new TGActionProcessor(this.context, TGExitAction.NAME);
+		proc.setErrorHandler(new TGErrorHandler() {
+			public void handleError(Throwable e) {
+				System.err.println("[NSM] quit action failed: " + e);
+				e.printStackTrace();
+			}
+		});
 		proc.process();
+		System.out.println("[NSM] quit action dispatched");
 	}
 
 	// -------------------------------------------------------------------------

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -27,7 +27,8 @@ import app.tuxguitar.app.document.TGDocumentFileManager;
 import app.tuxguitar.app.document.TGDocumentListManager;
 import app.tuxguitar.editor.action.TGActionProcessor;
 import app.tuxguitar.editor.action.file.TGLoadTemplateAction;
-import app.tuxguitar.nsm.osc.OSCMessage;
+import app.tuxguitar.osc.OSCClient;
+import app.tuxguitar.osc.OSCMessage;
 import app.tuxguitar.util.TGContext;
 import app.tuxguitar.util.TGException;
 import app.tuxguitar.util.TGSynchronizer;
@@ -59,8 +60,7 @@ public class NSMClient implements TGActionInterceptor {
 
 	private final TGContext context;
 	private final DatagramSocket socket;
-	private final InetAddress serverAddress;
-	private final int serverPort;
+	private final OSCClient oscClient;
 
 	private Thread receiveThread;
 	private volatile boolean running;
@@ -94,9 +94,9 @@ public class NSMClient implements TGActionInterceptor {
 		String host = spec.substring(0, colon);
 		int port = Integer.parseInt(spec.substring(colon + 1));
 
-		this.serverAddress = InetAddress.getByName(host);
-		this.serverPort = port;
+		InetAddress serverAddress = InetAddress.getByName(host);
 		this.socket = new DatagramSocket();
+		this.oscClient = new OSCClient(serverAddress, port, this.socket);
 	}
 
 	// -------------------------------------------------------------------------
@@ -277,9 +277,7 @@ public class NSMClient implements TGActionInterceptor {
 
 	private void sendMessage(OSCMessage msg) {
 		try {
-			byte[] data = msg.encode();
-			DatagramPacket packet = new DatagramPacket(data, data.length, this.serverAddress, this.serverPort);
-			this.socket.send(packet);
+			this.oscClient.send(msg);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -143,19 +143,47 @@ public class NSMClient implements TGActionInterceptor {
 	// the signal cannot be registered, we log a warning and fall through to
 	// the JVM's default SIGTERM behaviour.
 	private void registerSigtermHandler() {
+		// JVM shutdown hook: fires if System.exit() is called (e.g. JVM default SIGTERM
+		// handler) — lets us know whether the JVM is receiving SIGTERM at all.
+		Runtime.getRuntime().addShutdownHook(new Thread(() ->
+				System.err.println("[NSM] JVM shutdown hook triggered"),
+				"NSM-shutdown-diagnostic"));
+
 		try {
 			Class<?> signalClass  = Class.forName("sun.misc.Signal");
 			Class<?> handlerClass = Class.forName("sun.misc.SignalHandler");
 			java.lang.reflect.Method handleMethod =
 					signalClass.getMethod("handle", signalClass, handlerClass);
 			Object termSignal = signalClass.getConstructor(String.class).newInstance("TERM");
+			// Use system class loader so the proxy can always reach sun.misc.SignalHandler
+			// regardless of which plugin class loader loaded NSMClient.
+			ClassLoader proxyLoader = ClassLoader.getSystemClassLoader();
 			Object handler = java.lang.reflect.Proxy.newProxyInstance(
-					NSMClient.class.getClassLoader(),
+					proxyLoader,
 					new Class<?>[]{ handlerClass },
 					(proxy, method, args) -> {
-						if ("handle".equals(method.getName())) {
-							System.err.println("[NSM] SIGTERM received — dispatching quit");
-							handleQuit();
+						try {
+							if ("handle".equals(method.getName())) {
+								System.err.println("[NSM] SIGTERM received — dispatching quit");
+								handleQuit();
+								// Hard fallback: if the normal exit path is stuck, force the
+								// JVM to terminate after 15 seconds.  Runtime.halt() bypasses
+								// all shutdown hooks and non-daemon threads.
+								Thread watchdog = new Thread(() -> {
+									try {
+										Thread.sleep(15000);
+										System.err.println("[NSM] watchdog: normal exit timed out — halting JVM");
+										Runtime.getRuntime().halt(0);
+									} catch (InterruptedException ignored) {
+										// TuxGuitar exited normally; daemon thread is killed.
+									}
+								}, "NSM-exit-watchdog");
+								watchdog.setDaemon(true);
+								watchdog.start();
+							}
+						} catch (Throwable t) {
+							System.err.println("[NSM] SIGTERM handler error: " + t);
+							t.printStackTrace(System.err);
 						}
 						return null;
 					});
@@ -309,14 +337,17 @@ public class NSMClient implements TGActionInterceptor {
 	// -------------------------------------------------------------------------
 
 	private void handleSave() {
+		System.out.println("[NSM] save requested");
 		final String filePath;
 		synchronized (this) {
 			filePath = this.sessionFilePath;
 		}
 		if (filePath == null) {
+			System.err.println("[NSM] save failed: no session file path");
 			sendError("/nsm/client/save", 1, "no session file path");
 			return;
 		}
+		System.out.println("[NSM] saving to: " + filePath);
 		File file = new File(filePath);
 		if (file.getParentFile() != null) {
 			file.getParentFile().mkdirs();
@@ -325,15 +356,20 @@ public class NSMClient implements TGActionInterceptor {
 		proc.setAttribute(TGWriteFileAction.ATTRIBUTE_FILE_NAME, filePath);
 		proc.setOnFinish(new Runnable() {
 			public void run() {
+				System.out.println("[NSM] save onFinish — sending reply");
 				sendReply("/nsm/client/save", "saved");
+				System.out.println("[NSM] save reply sent");
 			}
 		});
 		proc.setErrorHandler(new TGErrorHandler() {
 			public void handleError(Throwable e) {
+				System.err.println("[NSM] save error: " + e);
+				e.printStackTrace(System.err);
 				sendError("/nsm/client/save", 1, e.getMessage() != null ? e.getMessage() : "save error");
 			}
 		});
 		proc.process();
+		System.out.println("[NSM] save action dispatched");
 	}
 
 	// -------------------------------------------------------------------------

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -324,6 +324,10 @@ public class NSMClient implements TGActionInterceptor {
 		proc.setOnFinish(new Runnable() {
 			public void run() {
 				System.out.println("[NSM] save onFinish — sending reply");
+				// Re-install our sigaction just before replying: libjack overrides it
+				// when FluidSynth connects to JACK, but SIGTERM always arrives after
+				// the save reply, so reinstalling here guarantees we intercept it.
+				try { NSMSignal.reinstallSigtermHandler(); } catch (UnsatisfiedLinkError ignored) {}
 				sendReply("/nsm/client/save", "saved");
 				System.out.println("[NSM] save reply sent");
 			}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMClient.java
@@ -103,7 +103,34 @@ public class NSMClient implements TGActionInterceptor {
 		this.receiveThread.start();
 
 		sendAnnounce();
-		registerSigtermHandler();
+	}
+
+	// Called from NSMPlugin.connect() — after all native plugins (including
+	// FluidSynth) have loaded, so our sigaction is the last one installed.
+	public void registerNativeSigtermHandler() {
+		try {
+			final int readFd = NSMSignal.registerSigtermPipe();
+			if (readFd < 0) {
+				System.err.println("[NSM] registerSigtermPipe() failed — SIGTERM will not be caught");
+				return;
+			}
+			System.out.println("[NSM] native SIGTERM handler registered (pipe read-fd=" + readFd + ")");
+			Thread t = new Thread(new Runnable() {
+				public void run() {
+					int rc = NSMSignal.waitSigterm(readFd);
+					if (rc == 0) {
+						System.err.println("[NSM] SIGTERM received via native pipe — dispatching quit");
+						handleQuit();
+					} else {
+						System.err.println("[NSM] waitSigterm returned " + rc + " (pipe closed or error)");
+					}
+				}
+			}, "NSM-sigterm-reader");
+			t.setDaemon(true);
+			t.start();
+		} catch (UnsatisfiedLinkError e) {
+			System.err.println("[NSM] native library not available — SIGTERM will not be caught: " + e);
+		}
 	}
 
 	// Block until /nsm/client/open is received or the timeout expires.
@@ -133,66 +160,6 @@ public class NSMClient implements TGActionInterceptor {
 		TGActionManager.getInstance(this.context).addInterceptor(this);
 	}
 
-	// RaySession (and many other NSM session managers) terminate clients via
-	// SIGTERM rather than /nsm/client/quit.  This handler intercepts SIGTERM
-	// and routes it through TuxGuitar's normal exit path so the "save before
-	// exit?" dialog appears when there are unsaved changes.
-	//
-	// sun.misc.Signal is a private JDK API; we access it via reflection so the
-	// plugin compiles without --add-exports flags.  If the class is absent or
-	// the signal cannot be registered, we log a warning and fall through to
-	// the JVM's default SIGTERM behaviour.
-	private void registerSigtermHandler() {
-		// JVM shutdown hook: fires if System.exit() is called (e.g. JVM default SIGTERM
-		// handler) — lets us know whether the JVM is receiving SIGTERM at all.
-		Runtime.getRuntime().addShutdownHook(new Thread(() ->
-				System.err.println("[NSM] JVM shutdown hook triggered"),
-				"NSM-shutdown-diagnostic"));
-
-		try {
-			Class<?> signalClass  = Class.forName("sun.misc.Signal");
-			Class<?> handlerClass = Class.forName("sun.misc.SignalHandler");
-			java.lang.reflect.Method handleMethod =
-					signalClass.getMethod("handle", signalClass, handlerClass);
-			Object termSignal = signalClass.getConstructor(String.class).newInstance("TERM");
-			// Use system class loader so the proxy can always reach sun.misc.SignalHandler
-			// regardless of which plugin class loader loaded NSMClient.
-			ClassLoader proxyLoader = ClassLoader.getSystemClassLoader();
-			Object handler = java.lang.reflect.Proxy.newProxyInstance(
-					proxyLoader,
-					new Class<?>[]{ handlerClass },
-					(proxy, method, args) -> {
-						try {
-							if ("handle".equals(method.getName())) {
-								System.err.println("[NSM] SIGTERM received — dispatching quit");
-								handleQuit();
-								// Hard fallback: if the normal exit path is stuck, force the
-								// JVM to terminate after 15 seconds.  Runtime.halt() bypasses
-								// all shutdown hooks and non-daemon threads.
-								Thread watchdog = new Thread(() -> {
-									try {
-										Thread.sleep(15000);
-										System.err.println("[NSM] watchdog: normal exit timed out — halting JVM");
-										Runtime.getRuntime().halt(0);
-									} catch (InterruptedException ignored) {
-										// TuxGuitar exited normally; daemon thread is killed.
-									}
-								}, "NSM-exit-watchdog");
-								watchdog.setDaemon(true);
-								watchdog.start();
-							}
-						} catch (Throwable t) {
-							System.err.println("[NSM] SIGTERM handler error: " + t);
-							t.printStackTrace(System.err);
-						}
-						return null;
-					});
-			handleMethod.invoke(null, termSignal, handler);
-			System.out.println("[NSM] SIGTERM handler registered");
-		} catch (Throwable t) {
-			System.err.println("[NSM] could not register SIGTERM handler: " + t);
-		}
-	}
 
 	// -------------------------------------------------------------------------
 	// Shutdown

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMConfigPropertiesHandler.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMConfigPropertiesHandler.java
@@ -1,0 +1,69 @@
+package app.tuxguitar.nsm;
+
+import java.io.File;
+
+import app.tuxguitar.app.system.config.TGConfigDefaults;
+import app.tuxguitar.app.system.properties.TGFilePropertiesHandler;
+import app.tuxguitar.app.system.properties.TGResourcePropertiesReader;
+import app.tuxguitar.util.TGContext;
+import app.tuxguitar.util.properties.TGProperties;
+import app.tuxguitar.util.properties.TGPropertiesException;
+import app.tuxguitar.util.properties.TGPropertiesReader;
+import app.tuxguitar.util.properties.TGPropertiesWriter;
+
+/*
+ * Properties handler that redirects the TuxGuitar "config" resource to the
+ * NSM session directory, giving each session its own independent configuration
+ * (MIDI device, audio output, soundfont paths, layout preferences, etc.).
+ *
+ * File layout inside the session directory:
+ *   {sessionDir}/tuxguitar.cfg              — main application config
+ *   {sessionDir}/plugins/tuxguitar-*.cfg    — per-plugin configs (FluidSynth, JACK, …)
+ */
+public class NSMConfigPropertiesHandler implements TGPropertiesReader, TGPropertiesWriter {
+
+	private static final String MAIN_MODULE  = "tuxguitar";
+	private static final String CFG_SUFFIX   = ".cfg";
+
+	private final TGContext context;
+	private final String sessionDir;
+
+	public NSMConfigPropertiesHandler(TGContext context, String sessionDir) {
+		this.context = context;
+		this.sessionDir = sessionDir;
+	}
+
+	// -------------------------------------------------------------------------
+	// TGPropertiesReader
+	// -------------------------------------------------------------------------
+
+	@Override
+	public void readProperties(TGProperties properties, String module) throws TGPropertiesException {
+		// 1. Hardcoded Java defaults (main module only)
+		if (MAIN_MODULE.equals(module)) {
+			TGConfigDefaults.loadProperties(properties);
+		}
+		// 2. Classpath defaults bundled with the app
+		new TGResourcePropertiesReader(this.context, "", CFG_SUFFIX).readProperties(properties, module);
+		// 3. Stored session config (overrides defaults when it exists)
+		new TGFilePropertiesHandler(filePrefix(module), CFG_SUFFIX).readProperties(properties, module);
+	}
+
+	// -------------------------------------------------------------------------
+	// TGPropertiesWriter
+	// -------------------------------------------------------------------------
+
+	@Override
+	public void writeProperties(TGProperties properties, String module) throws TGPropertiesException {
+		new TGFilePropertiesHandler(filePrefix(module), CFG_SUFFIX).writeProperties(properties, module);
+	}
+
+	// -------------------------------------------------------------------------
+
+	private String filePrefix(String module) {
+		if (MAIN_MODULE.equals(module)) {
+			return this.sessionDir + File.separator;
+		}
+		return this.sessionDir + File.separator + "plugins" + File.separator;
+	}
+}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMConfigPropertiesHandler.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMConfigPropertiesHandler.java
@@ -60,7 +60,7 @@ public class NSMConfigPropertiesHandler implements TGPropertiesReader, TGPropert
 
 	// -------------------------------------------------------------------------
 
-	private String filePrefix(String module) {
+	String filePrefix(String module) {
 		if (MAIN_MODULE.equals(module)) {
 			return this.sessionDir + File.separator;
 		}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMPlugin.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMPlugin.java
@@ -67,7 +67,12 @@ public class NSMPlugin implements TGEarlyInitPlugin {
 
 	@Override
 	public void connect(TGContext context) throws TGPluginException {
-		// initialization is done in earlyInit
+		// Register the native SIGTERM handler here, after all plugins (including
+		// FluidSynth) have loaded their native libraries and potentially overridden
+		// the JVM's sigaction.  Installing ours last makes us the active handler.
+		if (this.nsmClient != null) {
+			this.nsmClient.registerNativeSigtermHandler();
+		}
 	}
 
 	@Override

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMPlugin.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMPlugin.java
@@ -1,0 +1,124 @@
+package app.tuxguitar.nsm;
+
+import app.tuxguitar.app.system.properties.TGDefaultAndStoredPropertiesHandler;
+import app.tuxguitar.util.TGContext;
+import app.tuxguitar.util.configuration.TGConfigManager;
+import app.tuxguitar.util.plugin.TGEarlyInitPlugin;
+import app.tuxguitar.util.plugin.TGPluginException;
+import app.tuxguitar.util.plugin.TGPluginProperties;
+import app.tuxguitar.util.properties.TGPropertiesManager;
+
+import java.io.File;
+
+public class NSMPlugin implements TGEarlyInitPlugin {
+
+	public static final String MODULE_ID = "tuxguitar-nsm";
+
+	private static final long OPEN_TIMEOUT_MS = 5000;
+
+	// suffix used by TGPluginPropertiesHandler for the "plugin-settings" resource
+	private static final String PLUGIN_SETTINGS_SUFFIX = "-" + TGPluginProperties.RESOURCE + ".cfg";
+
+	private NSMClient nsmClient;
+
+	@Override
+	public String getModuleId() {
+		return MODULE_ID;
+	}
+
+	/*
+	 * earlyInit() is called before the UI event loop starts and before any
+	 * TuxGuitar config file is read.  This gives us a narrow window to:
+	 *   1. Contact the NSM server and discover the session directory.
+	 *   2. Redirect TuxGuitar's config I/O to that directory.
+	 *   3. Register the action interceptor that suppresses the default empty song.
+	 *
+	 * We block for up to OPEN_TIMEOUT_MS waiting for /nsm/client/open.  In
+	 * practice the NSM server is local and responds in well under 1 ms.
+	 */
+	@Override
+	public void earlyInit(TGContext context) throws TGPluginException {
+		String nsmUrl = System.getenv("NSM_URL");
+		if (nsmUrl == null || nsmUrl.isEmpty()) {
+			return;
+		}
+
+		try {
+			this.nsmClient = new NSMClient(context, nsmUrl);
+
+			// Phase 1: start UDP communication and send /nsm/server/announce.
+			this.nsmClient.startCommunication();
+
+			// Phase 2: block until /nsm/client/open arrives (or timeout).
+			String sessionDir = this.nsmClient.waitForSessionDirectory(OPEN_TIMEOUT_MS);
+
+			if (sessionDir != null) {
+				redirectConfig(context, sessionDir);
+			}
+
+			// Phase 3: register the action interceptor (must happen before
+			// TGLoadTemplateAction is dispatched at the end of startUIContext).
+			this.nsmClient.activateInterceptor();
+
+		} catch (Exception e) {
+			throw new TGPluginException(e);
+		}
+	}
+
+	@Override
+	public void connect(TGContext context) throws TGPluginException {
+		// initialization is done in earlyInit
+	}
+
+	@Override
+	public void disconnect(TGContext context) throws TGPluginException {
+		if (this.nsmClient != null) {
+			this.nsmClient.stop();
+			this.nsmClient = null;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	/*
+	 * Replace the standard config handlers in TGPropertiesManager with ones that
+	 * read from / write to the NSM session directory.
+	 *
+	 * Two resources are redirected:
+	 *
+	 *  "config"          — main app config + per-plugin configs
+	 *                      (TGConfigManager.RESOURCE)
+	 *                      Session files:
+	 *                        {sessionDir}/tuxguitar.cfg
+	 *                        {sessionDir}/plugins/tuxguitar-fluidsynth.cfg  etc.
+	 *
+	 *  "plugin-settings" — which plugins are enabled/disabled
+	 *                      (TGPluginProperties.RESOURCE)
+	 *                      Session file:
+	 *                        {sessionDir}/tuxguitar-plugin-settings.cfg
+	 */
+	private void redirectConfig(TGContext context, String sessionDir) {
+		TGPropertiesManager mgr = TGPropertiesManager.getInstance(context);
+
+		// --- "config" resource ---
+		mgr.removePropertiesReader(TGConfigManager.RESOURCE);
+		mgr.removePropertiesWriter(TGConfigManager.RESOURCE);
+		NSMConfigPropertiesHandler configHandler = new NSMConfigPropertiesHandler(context, sessionDir);
+		mgr.addPropertiesReader(TGConfigManager.RESOURCE, configHandler);
+		mgr.addPropertiesWriter(TGConfigManager.RESOURCE, configHandler);
+
+		// --- "plugin-settings" resource ---
+		mgr.removePropertiesReader(TGPluginProperties.RESOURCE);
+		mgr.removePropertiesWriter(TGPluginProperties.RESOURCE);
+		TGDefaultAndStoredPropertiesHandler pluginSettingsHandler =
+			new TGDefaultAndStoredPropertiesHandler(
+				context,
+				"",                                           // classpath defaults prefix
+				PLUGIN_SETTINGS_SUFFIX,                       // classpath defaults suffix
+				sessionDir + File.separator,                  // session dir prefix
+				PLUGIN_SETTINGS_SUFFIX                        // session dir suffix
+			);
+		mgr.addPropertiesReader(TGPluginProperties.RESOURCE, pluginSettingsHandler);
+		mgr.addPropertiesWriter(TGPluginProperties.RESOURCE, pluginSettingsHandler);
+	}
+}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMPointerFile.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMPointerFile.java
@@ -1,0 +1,47 @@
+package app.tuxguitar.nsm;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+/**
+ * Reads and writes the {@code tuxguitar-source.path} pointer file stored in
+ * the NSM session directory.  The file records the real path of the document
+ * that was open when the session was last saved, so it can be re-opened on
+ * the next session restore even if it lives outside the session directory.
+ */
+class NSMPointerFile {
+
+	static final String FILE_NAME = "tuxguitar-source.path";
+
+	static void write(String sessionDir, String realPath) {
+		File file = new File(sessionDir, FILE_NAME);
+		try {
+			PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
+			pw.println(realPath != null ? realPath : "");
+			pw.close();
+		} catch (Exception e) {
+			System.err.println("[NSM] failed to write pointer file: " + e);
+		}
+	}
+
+	static String read(String sessionDir) {
+		File file = new File(sessionDir, FILE_NAME);
+		if (!file.exists()) {
+			return null;
+		}
+		try {
+			BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+			String line = br.readLine();
+			br.close();
+			return (line != null && !line.trim().isEmpty()) ? line.trim() : null;
+		} catch (Exception e) {
+			System.err.println("[NSM] failed to read pointer file: " + e);
+			return null;
+		}
+	}
+}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMSignal.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMSignal.java
@@ -1,0 +1,26 @@
+package app.tuxguitar.nsm;
+
+/**
+ * JNI bridge to a native SIGTERM handler.
+ *
+ * registerSigtermPipe() installs a C-level sigaction(SIGTERM) handler and
+ * returns the read end of a self-pipe.  waitSigterm(fd) blocks until the
+ * pipe receives a byte (i.e. until SIGTERM fires).
+ *
+ * This is necessary because SWT/GTK (and FluidSynth) replace the JVM's own
+ * SIGTERM sigaction after JVM startup, making sun.misc.Signal and JVM shutdown
+ * hooks unreachable via SIGTERM.  Installing our handler last (from connect(),
+ * after all native plugins have loaded) ensures we are the active handler.
+ */
+public class NSMSignal {
+
+    static {
+        System.loadLibrary("tuxguitar-nsm-jni");
+    }
+
+    /** Creates a pipe, installs the C SIGTERM handler, returns the read-end fd. Returns -1 on failure. */
+    public static native int registerSigtermPipe();
+
+    /** Blocks until SIGTERM fires (pipe readable). Returns 0 on success, -1 on error. */
+    public static native int waitSigterm(int readFd);
+}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMSignal.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMSignal.java
@@ -21,6 +21,9 @@ public class NSMSignal {
     /** Creates a pipe, installs the C SIGTERM handler, returns the read-end fd. Returns -1 on failure. */
     public static native int registerSigtermPipe();
 
+    /** Re-installs the C SIGTERM handler without creating a new pipe. Safe to call multiple times. */
+    public static native void reinstallSigtermHandler();
+
     /** Blocks until SIGTERM fires (pipe readable). Returns 0 on success, -1 on error. */
     public static native int waitSigterm(int readFd);
 }

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMUrl.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/NSMUrl.java
@@ -1,0 +1,29 @@
+package app.tuxguitar.nsm;
+
+import java.net.InetAddress;
+
+/**
+ * Parses an NSM_URL of the form {@code osc.udp://host:port[/]}.
+ */
+class NSMUrl {
+
+	final InetAddress address;
+	final int port;
+
+	NSMUrl(String url) throws Exception {
+		String spec = url.trim();
+		if (!spec.startsWith("osc.udp://")) {
+			throw new IllegalArgumentException("Unsupported NSM_URL scheme: " + url);
+		}
+		spec = spec.substring("osc.udp://".length());
+		if (spec.endsWith("/")) {
+			spec = spec.substring(0, spec.length() - 1);
+		}
+		int colon = spec.lastIndexOf(':');
+		if (colon < 0) {
+			throw new IllegalArgumentException("Missing port in NSM_URL: " + url);
+		}
+		this.port = Integer.parseInt(spec.substring(colon + 1));
+		this.address = InetAddress.getByName(spec.substring(0, colon));
+	}
+}

--- a/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/osc/OSCMessage.java
+++ b/desktop/TuxGuitar-nsm/src/app/tuxguitar/nsm/osc/OSCMessage.java
@@ -1,0 +1,130 @@
+package app.tuxguitar.nsm.osc;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OSCMessage {
+
+	private final String address;
+	private final List<Object> arguments;
+
+	public OSCMessage(String address) {
+		this.address = address;
+		this.arguments = new ArrayList<Object>();
+	}
+
+	public String getAddress() {
+		return this.address;
+	}
+
+	public void addString(String value) {
+		this.arguments.add(value);
+	}
+
+	public void addInt(int value) {
+		this.arguments.add(Integer.valueOf(value));
+	}
+
+	public String getStringArg(int index) {
+		return (String) this.arguments.get(index);
+	}
+
+	public int getIntArg(int index) {
+		return ((Integer) this.arguments.get(index)).intValue();
+	}
+
+	public int argCount() {
+		return this.arguments.size();
+	}
+
+	public byte[] encode() {
+		try {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			DataOutputStream dos = new DataOutputStream(baos);
+
+			writeString(dos, this.address);
+
+			StringBuilder typeTags = new StringBuilder(",");
+			for (Object arg : this.arguments) {
+				if (arg instanceof String) {
+					typeTags.append('s');
+				} else if (arg instanceof Integer) {
+					typeTags.append('i');
+				}
+			}
+			writeString(dos, typeTags.toString());
+
+			for (Object arg : this.arguments) {
+				if (arg instanceof String) {
+					writeString(dos, (String) arg);
+				} else if (arg instanceof Integer) {
+					dos.writeInt(((Integer) arg).intValue());
+				}
+			}
+
+			return baos.toByteArray();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static void writeString(DataOutputStream dos, String s) throws IOException {
+		byte[] bytes = s.getBytes(StandardCharsets.US_ASCII);
+		dos.write(bytes);
+		// null terminator + zero padding to next 4-byte boundary
+		int totalLen = bytes.length + 1;
+		int paddedLen = (totalLen + 3) & ~3;
+		for (int i = 0; i < paddedLen - bytes.length; i++) {
+			dos.write(0);
+		}
+	}
+
+	public static OSCMessage decode(byte[] data, int length) {
+		ByteBuffer buf = ByteBuffer.wrap(data, 0, length);
+		buf.order(ByteOrder.BIG_ENDIAN);
+
+		String address = readString(buf);
+		String typeTags = readString(buf);
+
+		OSCMessage msg = new OSCMessage(address);
+
+		// typeTags starts with "," — iterate from index 1
+		for (int i = 1; i < typeTags.length(); i++) {
+			char tag = typeTags.charAt(i);
+			if (tag == 's') {
+				msg.arguments.add(readString(buf));
+			} else if (tag == 'i') {
+				if (buf.remaining() >= 4) {
+					msg.arguments.add(Integer.valueOf(buf.getInt()));
+				}
+			}
+			// unknown type tags are silently skipped
+		}
+
+		return msg;
+	}
+
+	private static String readString(ByteBuffer buf) {
+		int start = buf.position();
+		int n = 0;
+		while (buf.hasRemaining()) {
+			byte b = buf.get();
+			if (b == 0) {
+				break;
+			}
+			n++;
+		}
+		String s = new String(buf.array(), start, n, StandardCharsets.US_ASCII);
+		// advance to the next 4-byte boundary from the string start
+		int totalLen = n + 1;
+		int paddedLen = (totalLen + 3) & ~3;
+		buf.position(Math.min(start + paddedLen, buf.limit()));
+		return s;
+	}
+}

--- a/desktop/TuxGuitar-nsm/src/test/java/app/tuxguitar/nsm/TestNSMConfigPaths.java
+++ b/desktop/TuxGuitar-nsm/src/test/java/app/tuxguitar/nsm/TestNSMConfigPaths.java
@@ -1,0 +1,39 @@
+package app.tuxguitar.nsm;
+
+import org.junit.jupiter.api.Test;
+import java.io.File;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestNSMConfigPaths {
+
+	private static final String SESSION_DIR = "/nsm/sessions/my-project.nTqXg1/tuxguitar";
+
+	// NSMConfigPropertiesHandler(context, sessionDir) — context only used in
+	// readProperties(); filePrefix() is pure string logic, so null is fine here.
+	private final NSMConfigPropertiesHandler handler =
+			new NSMConfigPropertiesHandler(null, SESSION_DIR);
+
+	@Test
+	public void testMainModuleGoesDirectlyInSessionDir() {
+		String prefix = handler.filePrefix("tuxguitar");
+		assertEquals(SESSION_DIR + File.separator, prefix);
+	}
+
+	@Test
+	public void testPluginModuleGoesInPluginsSubdir() {
+		String prefix = handler.filePrefix("tuxguitar-fluidsynth");
+		assertEquals(SESSION_DIR + File.separator + "plugins" + File.separator, prefix);
+	}
+
+	@Test
+	public void testAnotherPluginModule() {
+		String prefix = handler.filePrefix("tuxguitar-jack");
+		assertEquals(SESSION_DIR + File.separator + "plugins" + File.separator, prefix);
+	}
+
+	@Test
+	public void testMainAndPluginPrefixesAreDifferent() {
+		assertNotEquals(handler.filePrefix("tuxguitar"),
+				handler.filePrefix("tuxguitar-fluidsynth"));
+	}
+}

--- a/desktop/TuxGuitar-nsm/src/test/java/app/tuxguitar/nsm/TestNSMPointerFile.java
+++ b/desktop/TuxGuitar-nsm/src/test/java/app/tuxguitar/nsm/TestNSMPointerFile.java
@@ -1,0 +1,65 @@
+package app.tuxguitar.nsm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.io.File;
+import java.nio.file.Path;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestNSMPointerFile {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	public void testWriteAndReadRealPath() {
+		String sessionDir = tempDir.toString();
+		NSMPointerFile.write(sessionDir, "/home/user/songs/my-song.tg");
+		assertEquals("/home/user/songs/my-song.tg", NSMPointerFile.read(sessionDir));
+	}
+
+	@Test
+	public void testWriteNullMeansNewSession() {
+		String sessionDir = tempDir.toString();
+		NSMPointerFile.write(sessionDir, null);
+		assertNull(NSMPointerFile.read(sessionDir));
+	}
+
+	@Test
+	public void testWriteEmptyStringMeansNewSession() {
+		String sessionDir = tempDir.toString();
+		NSMPointerFile.write(sessionDir, "");
+		assertNull(NSMPointerFile.read(sessionDir));
+	}
+
+	@Test
+	public void testReadMissingFile() {
+		assertNull(NSMPointerFile.read(tempDir.toString()));
+	}
+
+	@Test
+	public void testReadFromNonexistentDirectory() {
+		assertNull(NSMPointerFile.read(tempDir.toString() + File.separator + "no-such-dir"));
+	}
+
+	@Test
+	public void testOverwriteUpdatesValue() {
+		String sessionDir = tempDir.toString();
+		NSMPointerFile.write(sessionDir, "/first/path.tg");
+		NSMPointerFile.write(sessionDir, "/second/path.tg");
+		assertEquals("/second/path.tg", NSMPointerFile.read(sessionDir));
+	}
+
+	@Test
+	public void testPointerFileName() {
+		assertEquals("tuxguitar-source.path", NSMPointerFile.FILE_NAME);
+	}
+
+	@Test
+	public void testPathWithSpaces() {
+		String sessionDir = tempDir.toString();
+		String path = "/home/user/my songs/my song.tg";
+		NSMPointerFile.write(sessionDir, path);
+		assertEquals(path, NSMPointerFile.read(sessionDir));
+	}
+}

--- a/desktop/TuxGuitar-nsm/src/test/java/app/tuxguitar/nsm/TestNSMUrl.java
+++ b/desktop/TuxGuitar-nsm/src/test/java/app/tuxguitar/nsm/TestNSMUrl.java
@@ -1,0 +1,50 @@
+package app.tuxguitar.nsm;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestNSMUrl {
+
+	@Test
+	public void testValidUrl() throws Exception {
+		NSMUrl url = new NSMUrl("osc.udp://127.0.0.1:12345");
+		assertEquals(12345, url.port);
+		assertEquals("127.0.0.1", url.address.getHostAddress());
+	}
+
+	@Test
+	public void testUrlWithTrailingSlash() throws Exception {
+		NSMUrl url = new NSMUrl("osc.udp://127.0.0.1:9000/");
+		assertEquals(9000, url.port);
+		assertEquals("127.0.0.1", url.address.getHostAddress());
+	}
+
+	@Test
+	public void testLocalhostUrl() throws Exception {
+		NSMUrl url = new NSMUrl("osc.udp://localhost:7171");
+		assertEquals(7171, url.port);
+		assertNotNull(url.address);
+	}
+
+	@Test
+	public void testHighPortNumber() throws Exception {
+		NSMUrl url = new NSMUrl("osc.udp://127.0.0.1:65535");
+		assertEquals(65535, url.port);
+	}
+
+	@Test
+	public void testInvalidScheme() {
+		assertThrows(IllegalArgumentException.class, () -> new NSMUrl("osc.tcp://127.0.0.1:1234"));
+	}
+
+	@Test
+	public void testMissingScheme() {
+		assertThrows(IllegalArgumentException.class, () -> new NSMUrl("127.0.0.1:1234"));
+	}
+
+	@Test
+	public void testUrlWithLeadingWhitespace() throws Exception {
+		NSMUrl url = new NSMUrl("  osc.udp://127.0.0.1:8888  ");
+		assertEquals(8888, url.port);
+	}
+}

--- a/desktop/TuxGuitar-osc/pom.xml
+++ b/desktop/TuxGuitar-osc/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>tuxguitar-pom</artifactId>
+		<groupId>app.tuxguitar</groupId>
+		<version>9.99-SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>tuxguitar-osc</artifactId>
+	<packaging>jar</packaging>
+	<name>${project.artifactId}</name>
+
+	<build>
+		<sourceDirectory>src/main/java</sourceDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<release>9</release>
+					<showWarnings>true</showWarnings>
+					<useIncrementalCompilation>false</useIncrementalCompilation>
+					<compilerArgs>
+						<arg>-Xlint:all</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.2</version>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.9.2</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/desktop/TuxGuitar-osc/src/main/java/app/tuxguitar/osc/OSCClient.java
+++ b/desktop/TuxGuitar-osc/src/main/java/app/tuxguitar/osc/OSCClient.java
@@ -1,0 +1,24 @@
+package app.tuxguitar.osc;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+
+public class OSCClient {
+
+	private final InetAddress address;
+	private final int port;
+	private final DatagramSocket socket;
+
+	public OSCClient(InetAddress address, int port, DatagramSocket socket) {
+		this.address = address;
+		this.port = port;
+		this.socket = socket;
+	}
+
+	public void send(OSCMessage message) throws Exception {
+		byte[] data = message.encode();
+		DatagramPacket packet = new DatagramPacket(data, data.length, this.address, this.port);
+		this.socket.send(packet);
+	}
+}

--- a/desktop/TuxGuitar-osc/src/main/java/app/tuxguitar/osc/OSCMessage.java
+++ b/desktop/TuxGuitar-osc/src/main/java/app/tuxguitar/osc/OSCMessage.java
@@ -1,4 +1,4 @@
-package app.tuxguitar.nsm.osc;
+package app.tuxguitar.osc;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;

--- a/desktop/TuxGuitar-osc/src/main/java/app/tuxguitar/osc/OSCMessageHandler.java
+++ b/desktop/TuxGuitar-osc/src/main/java/app/tuxguitar/osc/OSCMessageHandler.java
@@ -1,0 +1,5 @@
+package app.tuxguitar.osc;
+
+public interface OSCMessageHandler {
+	void handleMessage(OSCMessage message);
+}

--- a/desktop/TuxGuitar-osc/src/main/java/app/tuxguitar/osc/OSCServer.java
+++ b/desktop/TuxGuitar-osc/src/main/java/app/tuxguitar/osc/OSCServer.java
@@ -1,0 +1,51 @@
+package app.tuxguitar.osc;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketException;
+
+public class OSCServer {
+
+	private static final int BUFFER_SIZE = 65536;
+
+	private final DatagramSocket socket;
+	private final OSCMessageHandler handler;
+	private volatile boolean running;
+
+	public OSCServer(DatagramSocket socket, OSCMessageHandler handler) {
+		this.socket = socket;
+		this.handler = handler;
+		this.running = false;
+	}
+
+	public void start() {
+		this.running = true;
+		Thread thread = new Thread(new Runnable() {
+			public void run() {
+				receiveLoop();
+			}
+		}, "OSC-recv");
+		thread.setDaemon(true);
+		thread.start();
+	}
+
+	public void stop() {
+		this.running = false;
+	}
+
+	private void receiveLoop() {
+		byte[] buffer = new byte[BUFFER_SIZE];
+		DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+		while (this.running) {
+			try {
+				this.socket.receive(packet);
+				OSCMessage msg = OSCMessage.decode(buffer, packet.getLength());
+				this.handler.handleMessage(msg);
+			} catch (SocketException e) {
+				break; // socket closed, normal shutdown
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+}

--- a/desktop/TuxGuitar-osc/src/test/java/app/tuxguitar/osc/TestOSCMessage.java
+++ b/desktop/TuxGuitar-osc/src/test/java/app/tuxguitar/osc/TestOSCMessage.java
@@ -1,0 +1,91 @@
+package app.tuxguitar.osc;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestOSCMessage {
+
+	private OSCMessage roundTrip(OSCMessage msg) {
+		byte[] bytes = msg.encode();
+		return OSCMessage.decode(bytes, bytes.length);
+	}
+
+	@Test
+	public void testEncodeDecodeAddress() {
+		OSCMessage msg = new OSCMessage("/test/address");
+		OSCMessage decoded = roundTrip(msg);
+		assertEquals("/test/address", decoded.getAddress());
+	}
+
+	@Test
+	public void testEncodeDecodeString() {
+		OSCMessage msg = new OSCMessage("/test");
+		msg.addString("hello");
+		OSCMessage decoded = roundTrip(msg);
+		assertEquals(1, decoded.argCount());
+		assertEquals("hello", decoded.getStringArg(0));
+	}
+
+	@Test
+	public void testEncodeDecodeInt() {
+		OSCMessage msg = new OSCMessage("/test");
+		msg.addInt(42);
+		OSCMessage decoded = roundTrip(msg);
+		assertEquals(1, decoded.argCount());
+		assertEquals(42, decoded.getIntArg(0));
+	}
+
+	@Test
+	public void testEncodeDecodeMixed() {
+		OSCMessage msg = new OSCMessage("/test/mixed");
+		msg.addString("first");
+		msg.addInt(99);
+		msg.addString("last");
+		OSCMessage decoded = roundTrip(msg);
+		assertEquals(3, decoded.argCount());
+		assertEquals("first", decoded.getStringArg(0));
+		assertEquals(99, decoded.getIntArg(1));
+		assertEquals("last", decoded.getStringArg(2));
+	}
+
+	@Test
+	public void testPaddingAlignment() {
+		int[] lengths = { 0, 1, 2, 3, 4, 7, 8 };
+		for (int len : lengths) {
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < len; i++) {
+				sb.append('a');
+			}
+			String value = sb.toString();
+			OSCMessage msg = new OSCMessage("/pad");
+			msg.addString(value);
+			OSCMessage decoded = roundTrip(msg);
+			assertEquals(1, decoded.argCount(), "argCount failed for length " + len);
+			assertEquals(value, decoded.getStringArg(0), "value mismatch for length " + len);
+		}
+	}
+
+	@Test
+	public void testMultipleArgs() {
+		OSCMessage msg = new OSCMessage("/multi");
+		msg.addString("alpha");
+		msg.addInt(1);
+		msg.addString("beta");
+		msg.addInt(2);
+		msg.addString("gamma");
+		OSCMessage decoded = roundTrip(msg);
+		assertEquals(5, decoded.argCount());
+		assertEquals("alpha", decoded.getStringArg(0));
+		assertEquals(1, decoded.getIntArg(1));
+		assertEquals("beta", decoded.getStringArg(2));
+		assertEquals(2, decoded.getIntArg(3));
+		assertEquals("gamma", decoded.getStringArg(4));
+	}
+
+	@Test
+	public void testEmptyArgs() {
+		OSCMessage msg = new OSCMessage("/empty");
+		OSCMessage decoded = roundTrip(msg);
+		assertEquals(0, decoded.argCount());
+	}
+}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/repeat/TGRepeatCloseDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/repeat/TGRepeatCloseDialog.java
@@ -39,6 +39,9 @@ public class TGRepeatCloseDialog {
 		if (currentRepeatClose < 1) {
 			currentRepeatClose = 1;
 		}
+		// The spinner shows total play count (stored value + 1).
+		// Stored N means "go back N times" = play N+1 times total.
+		int displayRepeatClose = currentRepeatClose + 1;
 
 		UITableLayout groupLayout = new UITableLayout();
 		UILegendPanel group = uiFactory.createLegendPanel(dialog);
@@ -51,9 +54,9 @@ public class TGRepeatCloseDialog {
 		groupLayout.set(repeatCloseLabel, 1, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_CENTER, false, true);
 
 		final UISpinner repeatClose = uiFactory.createSpinner(group);
-		repeatClose.setMinimum(0);
-		repeatClose.setMaximum(100);
-		repeatClose.setValue(currentRepeatClose);
+		repeatClose.setMinimum(2);
+		repeatClose.setMaximum(101);
+		repeatClose.setValue(displayRepeatClose);
 		groupLayout.set(repeatClose, 1, 2, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 1, 100f, null, null);
 
 		//----------------------BUTTONS--------------------------------
@@ -67,7 +70,7 @@ public class TGRepeatCloseDialog {
 		buttonOK.setDefaultButton();
 		buttonOK.addSelectionListener(new UISelectionListener() {
 			public void onSelect(UISelectionEvent event) {
-				changeRepeatClose(context.getContext(), song, header, repeatClose.getValue());
+				changeRepeatClose(context.getContext(), song, header, repeatClose.getValue() - 1);
 				dialog.dispose();
 			}
 		});

--- a/desktop/build-scripts/common-resources/common-linux/share/applications/tuxguitar.desktop
+++ b/desktop/build-scripts/common-resources/common-linux/share/applications/tuxguitar.desktop
@@ -20,3 +20,4 @@ Exec=tuxguitar %F
 Icon=tuxguitar
 Terminal=false
 StartupNotify=false
+X-NSM-Capable=true

--- a/desktop/build-scripts/common-resources/common-linux/tuxguitar.sh
+++ b/desktop/build-scripts/common-resources/common-linux/tuxguitar.sh
@@ -28,5 +28,13 @@ export CLASSPATH
 export LD_LIBRARY_PATH
 ##Avoid problems with Accelerated Compositing mode in SWT/WebKitGTK
 export WEBKIT_DISABLE_COMPOSITING_MODE=1
+## Announce this script's PID to the NSM session manager so SIGTERM is sent
+## here instead of to the JVM.  The trap below converts it to SIGUSR2, which
+## Java handles cleanly without JACK/SWT sigaction interference.
+export NSM_LAUNCHER_PID=$$
 ##LAUNCH
-${JAVA} -cp ":${CLASSPATH}" -Dtuxguitar.home.path="${TG_DIR}" -Dtuxguitar.share.path="share/" -Djava.library.path="${LD_LIBRARY_PATH}" -Dtuxguitar.theme=$(getTheme) ${MAINCLASS} "$@"
+${JAVA} -cp ":${CLASSPATH}" -Dtuxguitar.home.path="${TG_DIR}" -Dtuxguitar.share.path="share/" -Djava.library.path="${LD_LIBRARY_PATH}" -Dtuxguitar.theme=$(getTheme) ${MAINCLASS} "$@" &
+_tg_pid=$!
+_tg_sigterm() { kill -USR2 "$_tg_pid" 2>/dev/null; wait "$_tg_pid" 2>/dev/null; exit 0; }
+trap _tg_sigterm TERM
+wait $_tg_pid

--- a/desktop/build-scripts/common-resources/common-linux/tuxguitar.sh
+++ b/desktop/build-scripts/common-resources/common-linux/tuxguitar.sh
@@ -28,13 +28,21 @@ export CLASSPATH
 export LD_LIBRARY_PATH
 ##Avoid problems with Accelerated Compositing mode in SWT/WebKitGTK
 export WEBKIT_DISABLE_COMPOSITING_MODE=1
-## Announce this script's PID to the NSM session manager so SIGTERM is sent
-## here instead of to the JVM.  The trap below converts it to SIGUSR2, which
-## Java handles cleanly without JACK/SWT sigaction interference.
-export NSM_LAUNCHER_PID=$$
 ##LAUNCH
-${JAVA} -cp ":${CLASSPATH}" -Dtuxguitar.home.path="${TG_DIR}" -Dtuxguitar.share.path="share/" -Djava.library.path="${LD_LIBRARY_PATH}" -Dtuxguitar.theme=$(getTheme) ${MAINCLASS} "$@" &
-_tg_pid=$!
-_tg_sigterm() { kill -USR2 "$_tg_pid" 2>/dev/null; wait "$_tg_pid" 2>/dev/null; exit 0; }
-trap _tg_sigterm TERM
-wait $_tg_pid
+if [ -n "$NSM_URL" ]; then
+    ## NSM mode: run Java in background so this script can intercept SIGTERM
+    ## (sent by the session manager) and convert it to SIGUSR2, which Java
+    ## handles cleanly without JACK/SWT sigaction interference.
+    export NSM_LAUNCHER_PID=$$
+    ${JAVA} -cp ":${CLASSPATH}" -Dtuxguitar.home.path="${TG_DIR}" -Dtuxguitar.share.path="share/" -Djava.library.path="${LD_LIBRARY_PATH}" -Dtuxguitar.theme=$(getTheme) ${MAINCLASS} "$@" &
+    _tg_pid=$!
+    _tg_sigterm() { kill -USR2 "$_tg_pid" 2>/dev/null; wait "$_tg_pid" 2>/dev/null; exit 0; }
+    _tg_sigint()  { kill -INT  "$_tg_pid" 2>/dev/null; wait "$_tg_pid" 2>/dev/null; exit 130; }
+    trap _tg_sigterm TERM
+    trap _tg_sigint  INT
+    wait $_tg_pid
+else
+    ## Normal mode: replace this script with Java so signals are delivered
+    ## directly to the JVM (preserves original Ctrl+C / SIGTERM behavior).
+    exec ${JAVA} -cp ":${CLASSPATH}" -Dtuxguitar.home.path="${TG_DIR}" -Dtuxguitar.share.path="share/" -Djava.library.path="${LD_LIBRARY_PATH}" -Dtuxguitar.theme=$(getTheme) ${MAINCLASS} "$@"
+fi

--- a/desktop/build-scripts/native-modules/tuxguitar-nsm-linux/pom.xml
+++ b/desktop/build-scripts/native-modules/tuxguitar-nsm-linux/pom.xml
@@ -1,0 +1,114 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<parent>
+		<artifactId>tuxguitar-pom</artifactId>
+		<groupId>app.tuxguitar</groupId>
+		<version>9.99-SNAPSHOT</version>
+		<relativePath>../../../</relativePath>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>tuxguitar-nsm-linux</artifactId>
+	<packaging>pom</packaging>
+	<name>${project.artifactId}</name>
+
+	<properties>
+		<tuxguitar-nsm.jni.path>${project.parent.relativePath}/TuxGuitar-nsm/jni/</tuxguitar-nsm.jni.path>
+		<tuxguitar-nsm.jni.library.name>libtuxguitar-nsm-jni.so</tuxguitar-nsm.jni.library.name>
+	</properties>
+
+	<modules>
+		<module>${project.parent.relativePath}/TuxGuitar-nsm</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<execution>
+						<id>compile-native</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target name="compile-native">
+								<exec dir="${tuxguitar-nsm.jni.path}" executable="make" failonerror="true" >
+									<env key="CC" value="gcc" />
+									<env key="CFLAGS" value="-I${basedir}/../common-include -fPIC" />
+									<env key="LDFLAGS" value="-fPIC" />
+									<env key="LDLIBS" value="" />
+									<env key="LDPATH" value="" />
+									<env key="LIBRARY" value="${tuxguitar-nsm.jni.library.name}" />
+								</exec>
+							</target>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>clean-native</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target name="clean-native">
+								<exec dir="${tuxguitar-nsm.jni.path}" executable="make" failonerror="true" >
+									<arg value="clean" />
+									<env key="RM" value="rm -f" />
+									<env key="LIBRARY" value="${tuxguitar-nsm.jni.library.name}" />
+								</exec>
+							</target>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>native-module-copy</id>
+						<phase>package</phase>
+						<configuration>
+							<target name="copy-files">
+								<mkdir dir="${project.build.directory}/build/lib" />
+								<copy todir="${project.build.directory}/build/lib">
+									<fileset file="${tuxguitar-nsm.jni.path}/${tuxguitar-nsm.jni.library.name}" />
+								</copy>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>native-module-copy-libs</id>
+						<phase>package</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>tuxguitar-nsm</artifactId>
+									<destFileName>tuxguitar-nsm.jar</destFileName>
+									<outputDirectory>${project.build.directory}/build/share/plugins</outputDirectory>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/desktop/build-scripts/native-modules/tuxguitar-nsm-linux/pom.xml
+++ b/desktop/build-scripts/native-modules/tuxguitar-nsm-linux/pom.xml
@@ -19,10 +19,6 @@
 		<tuxguitar-nsm.jni.library.name>libtuxguitar-nsm-jni.so</tuxguitar-nsm.jni.library.name>
 	</properties>
 
-	<modules>
-		<module>${project.parent.relativePath}/TuxGuitar-nsm</module>
-	</modules>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/desktop/build-scripts/tuxguitar-linux-jfx/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-jfx/pom.xml
@@ -51,6 +51,7 @@
 		<module>../../TuxGuitar-synth-gervill</module>
 		<module>../../TuxGuitar-synth-export</module>
 		<module>../../TuxGuitar-debug-helper</module>
+		<module>../../TuxGuitar-osc</module>
 		<module>../../TuxGuitar-nsm</module>
 	</modules>
 

--- a/desktop/build-scripts/tuxguitar-linux-jfx/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-jfx/pom.xml
@@ -51,6 +51,7 @@
 		<module>../../TuxGuitar-synth-gervill</module>
 		<module>../../TuxGuitar-synth-export</module>
 		<module>../../TuxGuitar-debug-helper</module>
+		<module>../../TuxGuitar-nsm</module>
 	</modules>
 
 	<build>
@@ -331,6 +332,12 @@
 									<groupId>${project.groupId}</groupId>
 									<artifactId>tuxguitar-debug-helper</artifactId>
 									<destFileName>tuxguitar-debug-helper.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/share/plugins</outputDirectory>
+								</artifactItem>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>tuxguitar-nsm</artifactId>
+									<destFileName>tuxguitar-nsm.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/share/plugins</outputDirectory>
 								</artifactItem>
 								<!-- /PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-linux-qt/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-qt/pom.xml
@@ -52,6 +52,7 @@
 		<module>../../TuxGuitar-synth-gervill</module>
 		<module>../../TuxGuitar-synth-export</module>
 		<module>../../TuxGuitar-debug-helper</module>
+		<module>../../TuxGuitar-osc</module>
 		<module>../../TuxGuitar-nsm</module>
 	</modules>
 

--- a/desktop/build-scripts/tuxguitar-linux-qt/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-qt/pom.xml
@@ -52,6 +52,7 @@
 		<module>../../TuxGuitar-synth-gervill</module>
 		<module>../../TuxGuitar-synth-export</module>
 		<module>../../TuxGuitar-debug-helper</module>
+		<module>../../TuxGuitar-nsm</module>
 	</modules>
 
 	<build>
@@ -313,6 +314,12 @@
 									<groupId>${project.groupId}</groupId>
 									<artifactId>tuxguitar-debug-helper</artifactId>
 									<destFileName>tuxguitar-debug-helper.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/share/plugins</outputDirectory>
+								</artifactItem>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>tuxguitar-nsm</artifactId>
+									<destFileName>tuxguitar-nsm.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/share/plugins</outputDirectory>
 								</artifactItem>
 								<!-- /PLUGINS -->

--- a/desktop/build-scripts/tuxguitar-linux-swt/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-swt/pom.xml
@@ -387,6 +387,7 @@
 				<module>../native-modules/tuxguitar-jack-linux</module>
 				<module>../native-modules/tuxguitar-fluidsynth-linux</module>
 				<module>../native-modules/tuxguitar-synth-lv2-linux</module>
+				<module>../native-modules/tuxguitar-nsm-linux</module>
 			</modules>
 
 			<build>
@@ -413,6 +414,9 @@
 										</copy>
 										<copy todir="${project.build.directory}/${project.finalName}/">
 											<fileset dir="../native-modules/tuxguitar-synth-lv2-linux/target/build" />
+										</copy>
+										<copy todir="${project.build.directory}/${project.finalName}/">
+											<fileset dir="../native-modules/tuxguitar-nsm-linux/target/build" />
 										</copy>
 										<chmod file="${project.build.directory}/${project.finalName}/lv2-client/*.bin" perm="755" />
 										<!-- /PLUGINS FILES -->

--- a/desktop/build-scripts/tuxguitar-linux-swt/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-swt/pom.xml
@@ -54,6 +54,7 @@
 		<module>../../TuxGuitar-synth-export</module>
 		<module>../../TuxGuitar-debug-helper</module>
 		<module>../../TuxGuitar-tray-swt</module>
+		<module>../../TuxGuitar-osc</module>
 		<module>../../TuxGuitar-nsm</module>
 	</modules>
 

--- a/desktop/build-scripts/tuxguitar-linux-swt/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-swt/pom.xml
@@ -387,7 +387,6 @@
 				<module>../native-modules/tuxguitar-jack-linux</module>
 				<module>../native-modules/tuxguitar-fluidsynth-linux</module>
 				<module>../native-modules/tuxguitar-synth-lv2-linux</module>
-				<module>../native-modules/tuxguitar-nsm-linux</module>
 			</modules>
 
 			<build>
@@ -397,6 +396,25 @@
 						<artifactId>maven-antrun-plugin</artifactId>
 						<version>1.7</version>
 						<executions>
+							<execution>
+								<id>compile-nsm-native</id>
+								<phase>compile</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<target name="compile-nsm-native">
+										<exec dir="${basedir}/../../TuxGuitar-nsm/jni" executable="make" failonerror="true">
+											<env key="CC" value="gcc" />
+											<env key="CFLAGS" value="-I${basedir}/../native-modules/common-include -fPIC" />
+											<env key="LDFLAGS" value="-fPIC" />
+											<env key="LDLIBS" value="" />
+											<env key="LDPATH" value="" />
+											<env key="LIBRARY" value="libtuxguitar-nsm-jni.so" />
+										</exec>
+									</target>
+								</configuration>
+							</execution>
 							<execution>
 								<id>native-module-copy</id>
 								<phase>package</phase>
@@ -415,8 +433,9 @@
 										<copy todir="${project.build.directory}/${project.finalName}/">
 											<fileset dir="../native-modules/tuxguitar-synth-lv2-linux/target/build" />
 										</copy>
-										<copy todir="${project.build.directory}/${project.finalName}/">
-											<fileset dir="../native-modules/tuxguitar-nsm-linux/target/build" />
+										<mkdir dir="${project.build.directory}/${project.finalName}/lib" />
+										<copy todir="${project.build.directory}/${project.finalName}/lib">
+											<fileset file="${basedir}/../../TuxGuitar-nsm/jni/libtuxguitar-nsm-jni.so" />
 										</copy>
 										<chmod file="${project.build.directory}/${project.finalName}/lv2-client/*.bin" perm="755" />
 										<!-- /PLUGINS FILES -->

--- a/desktop/build-scripts/tuxguitar-linux-swt/pom.xml
+++ b/desktop/build-scripts/tuxguitar-linux-swt/pom.xml
@@ -54,6 +54,7 @@
 		<module>../../TuxGuitar-synth-export</module>
 		<module>../../TuxGuitar-debug-helper</module>
 		<module>../../TuxGuitar-tray-swt</module>
+		<module>../../TuxGuitar-nsm</module>
 	</modules>
 
 	<build>
@@ -311,6 +312,12 @@
 									<groupId>${project.groupId}</groupId>
 									<artifactId>tuxguitar-tray-swt</artifactId>
 									<destFileName>tuxguitar-tray-swt.jar</destFileName>
+									<outputDirectory>${project.build.directory}/${project.finalName}/share/plugins</outputDirectory>
+								</artifactItem>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>tuxguitar-nsm</artifactId>
+									<destFileName>tuxguitar-nsm.jar</destFileName>
 									<outputDirectory>${project.build.directory}/${project.finalName}/share/plugins</outputDirectory>
 								</artifactItem>
 								<!-- /PLUGINS -->

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -234,6 +234,12 @@
 			</dependency>
 			<dependency>
 				<groupId>${project.groupId}</groupId>
+				<artifactId>tuxguitar-nsm</artifactId>
+				<version>${project.version}</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>tuxguitar-cocoa-integration-swt</artifactId>
 				<version>${project.version}</version>
 				<type>jar</type>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -234,6 +234,12 @@
 			</dependency>
 			<dependency>
 				<groupId>${project.groupId}</groupId>
+				<artifactId>tuxguitar-osc</artifactId>
+				<version>${project.version}</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>tuxguitar-nsm</artifactId>
 				<version>${project.version}</version>
 				<type>jar</type>


### PR DESCRIPTION
Add NSM (Non Session Manager) support

This PR adds a TuxGuitar plugin that integrates with NSM-compatible session managers such as RaySession, New Session Manager, and Agordejo. When $NSM_URL is set in the environment, TuxGuitar announces itself to the session manager and participates fully in the session lifecycle.

---
What was added

New plugin: desktop/TuxGuitar-nsm/

- NSMPlugin.java — implements TGEarlyInitPlugin so the session directory is known before any config file is read. Blocks briefly (≤ 5 s) for /nsm/client/open, then redirects all config I/O to the session directory.
- NSMClient.java — OSC/UDP client. Handles the full NSM protocol:
  - /nsm/server/announce at startup
  - /nsm/client/open — loads the session song file or an empty template for new sessions
  - /nsm/client/save — saves via TGWriteFileAction, sends reply when complete
  - /nsm/client/quit — routes through TGExitAction (same path as File › Exit, shows "save before exit?" dialog if there are unsaved changes)
  - TGActionInterceptor — suppresses the default empty-song load at startup so the session file is opened instead
- NSMConfigPropertiesHandler.java — redirects "config" resource reads/writes to the session directory, keeping each session's settings isolated.
- NSMSignal.java + jni/app_tuxguitar_nsm_NSMSignal.c — JNI bridge that installs a C-level sigaction(SIGTERM) handler via a self-pipe trick, as a fallback for direct kill -TERM sent to the JVM.
- osc/OSCMessage.java — minimal OSC 1.0 encoder/decoder (no external dependency).

Session directory layout

Each session gets a self-contained directory provided by the session manager:
{sessionDir}/tuxguitar.tg                    ← song file
{sessionDir}/tuxguitar.cfg                   ← main app config
{sessionDir}/plugins/tuxguitar-*.cfg         ← per-plugin configs
{sessionDir}/tuxguitar-plugin-settings.cfg   ← plugin enabled/disabled state

SIGTERM handling (RaySession compatibility)

Session managers such as RaySession terminate clients with SIGTERM rather than /nsm/client/quit. Intercepting SIGTERM from Java is non-trivial because SWT/GTK and libjack both override the JVM's sigaction(SIGTERM) handler — libjack in particular reinstalls its handler each time a JACK client connects or disconnects, which can happen at the very moment the session is closing.

The solution uses the bash launch script as an intermediary:

- tuxguitar.sh exports NSM_LAUNCHER_PID=$$ and runs Java in the background. A trap converts SIGTERM → SIGUSR2 and forwards it to the Java child.
- NSMClient announces NSM_LAUNCHER_PID to the session manager, so SIGTERM is sent to the bash wrapper rather than the JVM.
- A sun.misc.Signal("USR2") handler in NSMClient receives SIGUSR2 and calls handleQuit(). JACK never installs a SIGUSR2 handler, so this fires reliably every time.
- A JNI-based 100 ms watchdog continuously reinstalls the C sigaction as a fallback for direct kill -TERM <java_pid>.

Build integration

- tuxguitar-linux-swt/pom.xml, tuxguitar-linux-jfx/pom.xml, tuxguitar-linux-qt/pom.xml — NSM jar included in each Linux distribution; the native-modules profile of the SWT build compiles libtuxguitar-nsm-jni.so inline.
- desktop/pom.xml — dependency management entry.
- build-scripts/native-modules/tuxguitar-nsm-linux/pom.xml — standalone Maven module for the JNI native library (not used by the SWT reactor to avoid duplicate-module conflicts, but available for standalone builds).

---

I tested this on Fedora 43 and the TuxGuitar configuration files were stored in the NSM session directory (here, I used Ray Session):
```
$ ls -lR TuxGuitar.tuxguitar/
TuxGuitar.tuxguitar/:
total 28
drwxr-xr-x. 2 collette collette  4096 13 mai   18:12 plugins
-rw-r--r--. 1 collette collette  3619 21 mai   18:04 tuxguitar.cfg
-rw-r--r--. 1 collette collette 19044 21 mai   18:04 tuxguitar.tg

TuxGuitar.tuxguitar/plugins:
total 16
-rw-r--r--. 1 collette collette 329 13 mai   18:13 tuxguitar-fluidsynth.cfg
-rw-r--r--. 1 collette collette  66 13 mai   18:12 tuxguitar-gtp.cfg
-rw-r--r--. 1 collette collette  47 13 mai   18:12 tuxguitar-jack.cfg
-rw-r--r--. 1 collette collette 123 13 mai   18:12 tuxguitar-jsa.cfg
```

Claude added some JNI code to be able to register a SIGTERM handler. Several times, the SIGTERM handler was not working because Jack seems to intercept the SIGTERM signal and not rethrowing it.
Now, with these last changes, when I close a session in Ray Session, TuxGuitar closes gracefully.