### PR TITLE
feat: persist and restore zoom level across sessions

### DIFF
--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetLayoutScaleAction.java
@@ -1,6 +1,8 @@
 package app.tuxguitar.app.action.impl.layout;
 
 import app.tuxguitar.action.TGActionContext;
+import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.app.view.component.tab.Tablature;
 import app.tuxguitar.app.view.component.tab.TablatureEditor;
 import app.tuxguitar.editor.action.TGActionBase;
@@ -21,5 +23,9 @@ public class TGSetLayoutScaleAction extends TGActionBase{
 
 		Tablature tablature = TablatureEditor.getInstance(getContext()).getTablature();
 		tablature.scale(scale);
+
+		// Persist zoom level to config
+		TGConfigManager config = TGConfigManager.getInstance(getContext());
+		config.setValue(TGConfigKeys.LAYOUT_SCALE, tablature.getScale());
 	}
 }

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/system/TGDisposeAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/system/TGDisposeAction.java
@@ -40,6 +40,7 @@ public class TGDisposeAction extends TGActionBase {
 
 		config.setValue(TGConfigKeys.LAYOUT_MODE,TablatureEditor.getInstance(getContext()).getTablature().getViewLayout().getMode());
 		config.setValue(TGConfigKeys.LAYOUT_STYLE,TablatureEditor.getInstance(getContext()).getTablature().getViewLayout().getStyle());
+		config.setValue(TGConfigKeys.LAYOUT_SCALE, TablatureEditor.getInstance(getContext()).getTablature().getScale());
 		config.setValue(TGConfigKeys.SHOW_PIANO,!TuxGuitar.getInstance().getPianoEditor().isDisposed());
 		config.setValue(TGConfigKeys.SHOW_MATRIX,!TuxGuitar.getInstance().getMatrixEditor().isDisposed());
 		config.setValue(TGConfigKeys.SHOW_FRETBOARD,TuxGuitar.getInstance().getFretBoardEditor().isVisible());

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -51,6 +51,7 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.SHOW_TRACKS, true);
 		loadProperty(properties, TGConfigKeys.LAYOUT_MODE, TGLayout.MODE_VERTICAL);
 		loadProperty(properties, TGConfigKeys.LAYOUT_STYLE, (TGLayout.DISPLAY_TABLATURE | TGLayout.DISPLAY_SCORE | TGLayout.DISPLAY_COMPACT | TGLayout.DISPLAY_CHORD_DIAGRAM | TGLayout.HIGHLIGHT_PLAYED_BEAT));
+		loadProperty(properties, TGConfigKeys.LAYOUT_SCALE, "1.0");
 		loadProperty(properties, TGConfigKeys.LANGUAGE, "");
 		loadProperty(properties, TGConfigKeys.EDITOR_MOUSE_MODE, EditorKit.MOUSE_MODE_SELECTION);
 		loadProperty(properties, TGConfigKeys.EDITOR_NATURAL_KEY_MODE, true);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
@@ -22,6 +22,7 @@ public class TGConfigKeys {
 	public static final String SHOW_TRACKS = "show.tracks";
 	public static final String LAYOUT_MODE = "layout.mode";
 	public static final String LAYOUT_STYLE = "layout.style";
+	public static final String LAYOUT_SCALE = "layout.scale";
 	public static final String LANGUAGE = "language";
 	public static final String EDITOR_MOUSE_MODE = "editor.mouse.mode";
 	public static final String EDITOR_NATURAL_KEY_MODE = "editor.natural.key.mode";

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/TablatureEditor.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/tab/TablatureEditor.java
@@ -3,6 +3,8 @@ package app.tuxguitar.app.view.component.tab;
 import java.util.List;
 
 import app.tuxguitar.app.TuxGuitar;
+import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.system.config.TGConfigManager;
 import app.tuxguitar.document.TGDocumentManager;
 import app.tuxguitar.editor.TGEditorManager;
 import app.tuxguitar.editor.event.TGUpdateEvent;
@@ -27,6 +29,13 @@ public class TablatureEditor implements TGEventListener{
 
 	public void initialize() {
 		this.tablature = new Tablature(this.context, TGDocumentManager.getInstance(this.context));
+
+		// Restore saved zoom level from config, clamped to valid range
+		TGConfigManager config = TGConfigManager.getInstance(this.context);
+		float savedScale = config.getFloatValue(TGConfigKeys.LAYOUT_SCALE, Tablature.DEFAULT_SCALE);
+		savedScale = Math.max(0.5f, Math.min(savedScale, 2.0f));
+		this.tablature.scale(savedScale);
+
 		this.tablature.reloadViewLayout();
 		this.tablature.updateTablature();
 		this.tablature.resetCaret();


### PR DESCRIPTION
## Summary
- Adds `layout.scale` config key (default `1.0`) to save the tablature zoom level
- Zoom is persisted to config on every zoom change and on shutdown
- On startup, saved zoom is restored and clamped to the valid 0.5–2.0 range

## Files changed
- `TGConfigKeys.java` — new `LAYOUT_SCALE` constant
- `TGConfigDefaults.java` — default value `"1.0"`
- `TGSetLayoutScaleAction.java` — persist zoom on change
- `TGDisposeAction.java` — persist zoom on shutdown
- `TablatureEditor.java` — restore zoom on startup

## Test plan
- [ ] Set zoom to a non-default level (e.g. 1.5x), close TuxGuitar, reopen — zoom should restore
- [ ] Set zoom to extreme values near 0.5 or 2.0, verify clamp works on restore
- [ ] Fresh install with no config — should default to 1.0x