### PR TITLE
fix: resolve dark mode color issues in track table

### DIFF
--- a/desktop/TuxGuitar-ui-toolkit-swt/src/app/tuxguitar/ui/swt/appearance/SWTAppearance.java
+++ b/desktop/TuxGuitar-ui-toolkit-swt/src/app/tuxguitar/ui/swt/appearance/SWTAppearance.java
@@ -26,7 +26,7 @@ public class SWTAppearance implements UIAppearance {
 		this.colorMap.put(UIColorAppearance.WidgetForeground, this.createColorModel(SWT.COLOR_WIDGET_FOREGROUND));
 		this.colorMap.put(UIColorAppearance.WidgetLightBackground, this.createColorModel(SWT.COLOR_WIDGET_BACKGROUND, SWT.COLOR_WIDGET_HIGHLIGHT_SHADOW));
 		this.colorMap.put(UIColorAppearance.WidgetLightForeground, this.createColorModel(SWT.COLOR_WIDGET_FOREGROUND));
-		this.colorMap.put(UIColorAppearance.WidgetHighlightBackground, this.createColorModel(SWT.COLOR_WIDGET_HIGHLIGHT_SHADOW));
+		this.colorMap.put(UIColorAppearance.WidgetHighlightBackground, this.createColorModel(SWT.COLOR_WIDGET_BACKGROUND, SWT.COLOR_WIDGET_NORMAL_SHADOW));
 		this.colorMap.put(UIColorAppearance.WidgetHighlightForeground, this.createColorModel(SWT.COLOR_WIDGET_FOREGROUND));
 		this.colorMap.put(UIColorAppearance.WidgetSelectedBackground, this.createColorModel(SWT.COLOR_WIDGET_BACKGROUND, SWT.COLOR_WIDGET_NORMAL_SHADOW));
 		this.colorMap.put(UIColorAppearance.WidgetSelectedForeground, this.createColorModel(SWT.COLOR_LIST_SELECTION_TEXT));

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/table/TGTableColorModel.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/component/table/TGTableColorModel.java
@@ -58,8 +58,8 @@ public class TGTableColorModel {
 		colorModels[EVEN_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetHighlightForeground);
 		colorModels[ODD_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightBackground);
 		colorModels[ODD_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightForeground);
-		colorModels[SELECTED_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetSelectedBackground);
-		colorModels[SELECTED_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.WidgetSelectedForeground);
+		colorModels[SELECTED_LINE_BACKGROUND] = appearance.getColorModel(UIColorAppearance.InputSelectedBackground);
+		colorModels[SELECTED_LINE_FOREGROUND] = appearance.getColorModel(UIColorAppearance.InputSelectedForeground);
 		colorModels[CELL_BACKGROUND] = appearance.getColorModel(UIColorAppearance.WidgetLightBackground);
 		colorModels[CELL_REST_MEASURE] = appearance.getColorModel(UIColorAppearance.WidgetSelectedBackground);
 


### PR DESCRIPTION
## Summary
- `SWTAppearance.java`: `WidgetHighlightBackground` was mapped to `COLOR_WIDGET_HIGHLIGHT_SHADOW` alone, which resolves to white in dark mode — making even rows in the track table white-on-white. Changed to blend `WIDGET_BACKGROUND + WIDGET_NORMAL_SHADOW` for a visible midtone (same pattern already used by `WidgetSelectedBackground` on the adjacent line).
- `TGTableColorModel.java`: Selected row used `WidgetSelectedBackground` (a muted gray blend), swapped to `InputSelectedBackground` which picks up the system accent color for a clearer selection highlight in both light and dark themes.

## Files changed
- `SWTAppearance.java` — fix even-row highlight color
- `TGTableColorModel.java` — use system accent for selected row

## Test plan
- [ ] Open a multi-track song in dark mode — even/odd row striping should be visible
- [ ] Selected track row should use system accent color (e.g. blue on macOS)
- [ ] Verify no regression in light mode — rows and selection still distinguishable