### PR TITLE
tuxguitar.sh: guard FreeBSD pkg check for necessary files with uname -s

### DIFF
--- a/desktop/build-scripts/common-resources/common-freebsd/tuxguitar.sh
+++ b/desktop/build-scripts/common-resources/common-freebsd/tuxguitar.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+
+if [ "$(uname -s)" = "FreeBSD" ]; then
+    pkgs="swt fluidsynth lilv suil"
+    missing=""
+
+    for p in $pkgs; do
+        pkg info -q "$p" || missing="$missing $p"
+    done
+
+    if [ -n "$missing" ]; then
+        missing=$(echo "$missing" | xargs)
+
+        echo "missing packages: $missing"
+        echo "Please install them by:"
+        echo "  doas pkg install $missing"
+        exit 1
+    fi
+fi
 ##SCRIPT DIR
 TG_DIR=`dirname "$(realpath "$0")"`
 ##JAVA


### PR DESCRIPTION
Only run the pkg(8) dependency check on FreeBSD; on other platforms pkg either does not exist or has different semantics. Also redirect pkg info stderr to suppress per-package error output.

Pre-existing shellcheck warnings (SC2006, SC2125) are out of scope for this PR and left for a separate fix.

Fixes #1062