### PR TITLE
always stop sequencer when stopping player

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayer.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayer.java
@@ -115,10 +115,7 @@ public class MidiPlayer{
 	public void stopSequencer() {
 		try {
 			this.lock();
-
-			if( this.getSequencer().isRunning() ){
-				this.getSequencer().stop();
-			}
+			this.getSequencer().stop();
 		} catch (MidiPlayerException e) {
 			e.printStackTrace();
 		} finally {

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/impl/sequencer/MidiSequencerImpl.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/impl/sequencer/MidiSequencerImpl.java
@@ -14,7 +14,6 @@ public class MidiSequencerImpl implements MidiSequencer {
 
 	private boolean reset;
 	private boolean running;
-	private boolean stopped;
 	private Object lock;
 	private TGContext context;
 	private MidiTransmitter transmitter;
@@ -25,7 +24,6 @@ public class MidiSequencerImpl implements MidiSequencer {
 
 	public MidiSequencerImpl(TGContext context) {
 		this.running = false;
-		this.stopped = true;
 		this.context = context;
 		this.lock = new Object();
 		this.midiTickPlayer = new MidiTickPlayer();
@@ -91,14 +89,12 @@ public class MidiSequencerImpl implements MidiSequencer {
 					this.reset = false;
 					this.midiEventPlayer.reset();
 				}
-				this.stopped = false;
 				this.midiTickPlayer.process();
 				this.midiEventPlayer.process();
 				if (this.getTickPosition() > this.getTickLength()) {
 					this.stop();
 				}
-			} else if (!this.stopped) {
-				this.stopped = true;
+			} else {
 				this.midiEventPlayer.clearEvents();
 				this.midiTickPlayer.clearTick();
 				this.reset();


### PR DESCRIPTION
should fix #1092

While playing count-in, sequencer is initialized, but not yet in "running" state.
If player was stopped after count-in started, but before first measure starts, then the sequencer was never reset.

Bug scenario fixed by this commit:
- open several songs, activate count-in
- start playing
- stop while count-in is played (before playing first measure)
- switch song
- start playing

With TuxGuitar Sequencer, the midi sequence from first song is never reset. So, the 2 songs are played simultaneously

Draft pull request: not tested in all configurations.
Tested: TuxGuitar Sequencer, Real Time Sequencer
Not tested: Jack sequencer