### PR TITLE
Fix JFX number-key note entry on startup (fixes #1005)

### DIFF
--- a/desktop/TuxGuitar-ui-toolkit-jfx/src/app/tuxguitar/ui/jfx/widget/JFXImageView.java
+++ b/desktop/TuxGuitar-ui-toolkit-jfx/src/app/tuxguitar/ui/jfx/widget/JFXImageView.java
@@ -56,7 +56,6 @@ public class JFXImageView extends JFXNode<ImageView> implements UIImageView {
 	}
 
 	public void redraw() {
-		this.getControl().requestFocus();
 	}
 
 	public void addResizeListener(UIResizeListener listener) {


### PR DESCRIPTION
JFXImageView.redraw() incorrectly called requestFocus(), which pulled keyboard focus away from the tab editor on toolbar layout.

Summary
- Remove error-causing requestFocus() from JFXImageView.redraw().
- Toolbar ImageView layout no longer steals keyboard focus from the tab editor.

Fixes #1005

