### PR TITLE
feat(macos): add Apple Silicon (aarch64) native builds

### DIFF
--- a/.github/workflows/macos-maven.yml
+++ b/.github/workflows/macos-maven.yml
@@ -38,13 +38,18 @@ jobs:
     - name : install SWT
       run: mkdir swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }} && cd swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }} && unzip ../swt-${{ env.SWT_VERSION }}-cocoa-macosx-${{ env.TUX_ARCH }}.zip && mvn install:install-file -Dfile=swt.jar -DgroupId=org.eclipse.swt -DartifactId=org.eclipse.swt.cocoa.macosx -Dpackaging=jar -Dversion=${{ env.SWT_VERSION }}
     - name: Build with Maven
-      run: cd desktop/build-scripts/tuxguitar-macosx-swt-cocoa && mvn -e clean verify
+      run: cd desktop/build-scripts/tuxguitar-macosx-swt-cocoa && mvn -e clean verify -P native-modules
+    - name: Bundle JRE into app
+      run: $JAVA_HOME/bin/jlink --add-modules java.desktop,jdk.unsupported --output desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target/tuxguitar-9.99-SNAPSHOT-macosx-swt-cocoa.app/Contents/MacOS/jre
     - name: Rename app depending of arch
       run: mv desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target/tuxguitar-9.99-SNAPSHOT-macosx-swt-cocoa.app desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target/tuxguitar-9.99-SNAPSHOT-macosx-${{ env.TUX_ARCH }}-swt-cocoa.app
+    # tar to preserve executable permissions, upload-artifact does not keep them
+    - name: Pack app
+      run: tar --directory=desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target -czf tuxguitar-9.99-SNAPSHOT-macosx-${{ env.TUX_ARCH }}-swt-cocoa.app.tar.gz tuxguitar-9.99-SNAPSHOT-macosx-${{ env.TUX_ARCH }}-swt-cocoa.app
     - uses: actions/upload-artifact@v4
       with:
         name: Package-MacOS-${{ matrix.os }}
-        path: desktop/build-scripts/tuxguitar-macosx-swt-cocoa/target/tuxguitar-9.99-SNAPSHOT-macosx-${{ env.TUX_ARCH }}-swt-cocoa.app
+        path: tuxguitar-9.99-SNAPSHOT-macosx-${{ env.TUX_ARCH }}-swt-cocoa.app.tar.gz
 
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -425,6 +425,21 @@
 			</properties>
 		</profile>
 		<profile>
+			<!-- Activated on top of platform-macos-cocoa on Apple Silicon: OpenJFX publishes
+			     separate artifacts with the "mac-aarch64" classifier for this architecture -->
+			<id>platform-macos-cocoa-aarch64</id>
+			<activation>
+				<os>
+					<family>unix</family>
+					<name>mac os x</name>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<properties>
+				<javafx.platform>mac-aarch64</javafx.platform>
+			</properties>
+		</profile>
+		<profile>
 			<id>platform-freebsd</id>
 			<activation>
 				<os>

--- a/misc/build_tuxguitar_from_source.sh
+++ b/misc/build_tuxguitar_from_source.sh
@@ -308,7 +308,8 @@ else
 
     # I could not find any repo for current SWT versions, so SWT must be installed manually.
     # See https://github.com/pcarmona79/tuxguitar/issues/1
-    SWT_NAME=swt-$SWT_VERSION-$SWT_PLATFORM-`uname -m`
+    # Eclipse names Apple Silicon downloads "aarch64" while `uname -m` reports "arm64" on macOS
+    SWT_NAME=swt-$SWT_VERSION-$SWT_PLATFORM-`uname -m | sed 's/^arm64$/aarch64/'`
     SWT_LINK=https://archive.eclipse.org/eclipse/downloads/drops4/R-$SWT_VERSION-$SWT_DATE/$SWT_NAME.zip
     SWT_JARF=$SW_DIR/$SWT_NAME/swt.jar
 
@@ -538,7 +539,8 @@ scp -p -X nrequests=1 -X buffer=2048 $BUILD_HOST:$SRC_PATH/00-Binary_Packages/tu
 
 function build_tg_for_macos {
 
-BUILD_ARCH=`uname -m`
+# Use "aarch64" instead of "arm64" in package names, consistent with the GitHub CI builds
+BUILD_ARCH=`uname -m | sed 's/^arm64$/aarch64/'`
 
 install_eclipse_swt
 
@@ -551,7 +553,9 @@ for GUI_TK in swt jfx; do
   TARGET=tuxguitar-$TGVERSION-macosx-$GUI_TK-cocoa
 
   # Extract JRE from locally installed openjdk (from Homebrew) to get it integrated in the APP.TAR.GZ packages
-  /usr/local/opt/openjdk/bin/jlink --add-modules java.desktop --output target/$TARGET.app/Contents/MacOS/jre
+  # Homebrew lives in /usr/local on Intel and /opt/homebrew on Apple Silicon, so ask brew for the path
+  # jdk.unsupported provides sun.misc.Unsafe, required by the JavaFX Marlin renderer
+  `brew --prefix openjdk`/bin/jlink --add-modules java.desktop,jdk.unsupported --output target/$TARGET.app/Contents/MacOS/jre
 
   rm -rf target/$TARGET-$BUILD_ARCH.app && mv -i target/$TARGET.app target/$TARGET-$BUILD_ARCH.app
   tar --uname=root --gname=root --directory=target -czf $DIST_DIR/$TARGET-$BUILD_ARCH.app.tar.gz $TARGET-$BUILD_ARCH.app

--- a/misc/build_tuxguitar_from_source.sh
+++ b/misc/build_tuxguitar_from_source.sh
@@ -553,9 +553,11 @@ for GUI_TK in swt jfx; do
   TARGET=tuxguitar-$TGVERSION-macosx-$GUI_TK-cocoa
 
   # Extract JRE from locally installed openjdk (from Homebrew) to get it integrated in the APP.TAR.GZ packages
-  # Homebrew lives in /usr/local on Intel and /opt/homebrew on Apple Silicon, so ask brew for the path
+  # Homebrew lives in /usr/local on Intel and /opt/homebrew on Apple Silicon, so ask brew for the path.
+  # If brew is not on the PATH (e.g. non-interactive shells), fall back to the Intel path used before.
+  OPENJDK_PREFIX=`brew --prefix openjdk 2>/dev/null || echo /usr/local/opt/openjdk`
   # jdk.unsupported provides sun.misc.Unsafe, required by the JavaFX Marlin renderer
-  `brew --prefix openjdk`/bin/jlink --add-modules java.desktop,jdk.unsupported --output target/$TARGET.app/Contents/MacOS/jre
+  $OPENJDK_PREFIX/bin/jlink --add-modules java.desktop,jdk.unsupported --output target/$TARGET.app/Contents/MacOS/jre
 
   rm -rf target/$TARGET-$BUILD_ARCH.app && mv -i target/$TARGET.app target/$TARGET-$BUILD_ARCH.app
   tar --uname=root --gname=root --directory=target -czf $DIST_DIR/$TARGET-$BUILD_ARCH.app.tar.gz $TARGET-$BUILD_ARCH.app


### PR DESCRIPTION
## Summary

The macOS packages are currently x86_64-only, so on Apple Silicon Macs TuxGuitar requires Rosetta — which macOS 26/27 no longer installs by default and Apple has deprecated. This PR makes the build pipeline architecture-aware so that native `aarch64` macOS apps can be produced, without changing anything for the existing Intel builds.

The application itself needed **zero code changes** — it is architecture-independent Java, and the TuxGuitar-AudioUnit JNI Makefile already builds a universal binary. The x86_64 requirement was baked in purely at packaging time by three things, each fixed here.

## Changes

**`.github/workflows/macos-maven.yml`** — make the CI artifact a complete, runnable app
- The workflow already runs on `macos-14`/`macos-15` (Apple Silicon runners) and installs aarch64 SWT, but the `.app` it produced bundled **no `jre/` at all** (the launcher hardcodes `./jre/bin/java`), so the artifact was not runnable. A new step jlinks the runner's Temurin 21 (arm64) into `Contents/MacOS/jre`, same as the release script does.
- Build with `-P native-modules` for parity with release builds (bundles the AudioUnit plugin; the runners have the Xcode CLT).
- Tar the app before upload: `actions/upload-artifact` does not preserve executable permissions, so the raw `.app` arrived with `tuxguitar.sh` and `jre/bin/java` non-executable. The artifact is now `tuxguitar-…-macosx-aarch64-swt-cocoa.app.tar.gz`, matching the release naming.

**`misc/build_tuxguitar_from_source.sh`** — survive an Apple Silicon build host
- SWT download: Eclipse names Apple Silicon zips `…-aarch64.zip` but `uname -m` reports `arm64` on macOS (the `arm64` URL 404s). Map it with an anchored `sed` that is a no-op on all other platforms.
- Package naming: use `aarch64` (consistent with the CI builds and the Eclipse/Temurin convention); Intel builds keep producing `x86_64` exactly as before.
- jlink path: Homebrew lives in `/usr/local` on Intel but `/opt/homebrew` on Apple Silicon, so ask `brew --prefix openjdk` — with a fallback to the previous hardcoded `/usr/local/opt/openjdk` in case `brew` is not on the PATH of the build shell, so the existing Intel VM flow cannot regress.

**`desktop/pom.xml`** — correct JavaFX natives on Apple Silicon
- OpenJFX publishes Apple Silicon artifacts under the `mac-aarch64` classifier; the parent pom hardcoded `mac` (Intel) for every Mac. A new profile, activated only when the JVM reports `os.arch=aarch64`, overrides just `javafx.platform`. It layers on top of the existing `platform-macos-cocoa` profile, which is otherwise unchanged.

## Pre-existing bug fixed on the way

The jlink module list (`java.desktop` only) is missing `jdk.unsupported`, which provides `sun.misc.Unsafe` — required by the JavaFX Marlin rasterizer. The JFX variant built by the release script throws `NoClassDefFoundError: sun/misc/Unsafe` on every rendered frame; this affects the **Intel** JFX package too and is architecture-independent (the SWT variant never touches Marlin, which is why it went unnoticed). Both jlink invocations now include `jdk.unsupported`; the JFX app launches cleanly with it.

## Verification

- Both variants (`tuxguitar-macosx-swt-cocoa`, `tuxguitar-macosx-jfx-cocoa`) built with `-P native-modules` on an Apple Silicon Mac (macOS 27, Temurin 21, SWT 4.37 cocoa-macosx-aarch64) and launch-tested: clean logs, running natively. The jlink'd JRE is arm64-only, so the apps cannot be running under Rosetta.
- `mvn help:evaluate -Dexpression=javafx.platform` resolves to `mac-aarch64` on arm64 and `mac` remains the result on Intel (activation is keyed to `os.arch`).
- CI: both matrix jobs green; the produced artifact was downloaded, exec bits verified intact after untar, and the exact CI-built app launch-tested natively.

## Notes for review

- The CI artifact changed shape (directory → `.app.tar.gz`). Intentional, since the old artifact was not runnable anyway, but anything that consumed the raw layout needs to untar now.
- `macos-13` (the last Intel runner) is retired on GitHub, so both matrix jobs currently produce identical aarch64 artifacts; Intel packages remain the domain of your local build flow. Happy to dedupe the matrix or wire the artifact into releases if you want that in this PR.
