### PR TITLE
fix(ci): repair the FreeBSD workflow's LV2 build

### DIFF
--- a/.github/workflows/freebsd-maven.yml
+++ b/.github/workflows/freebsd-maven.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         usesh: true
         prepare: |
-          pkg install -y curl openjdk11 alsa-plugins maven swt gcc gmake fluidsynth wget git
+          pkg install -y curl openjdk11 alsa-plugins maven swt gcc gmake fluidsynth wget git lv2 lilv suil pkgconf qt5-core qt5-widgets
       # wqy-fonts-20100803_10,1
 
         run: |

--- a/desktop/build-scripts/native-modules/tuxguitar-synth-lv2-freebsd/pom.xml
+++ b/desktop/build-scripts/native-modules/tuxguitar-synth-lv2-freebsd/pom.xml
@@ -42,7 +42,7 @@
 						<configuration>
 							<target name="compile-native-jni">
 								<exec dir="${tuxguitar-synth-lv2.jni.path}" executable="gmake" failonerror="true" >
-									<env key="CXX" value="g++12" />
+									<env key="CXX" value="g++" />
 									<env key="CFLAGS" value="-I${basedir}/../common-include -I/usr/local/include/lilv-0/lilv -fPIC -fpermissive" />
 									<env key="LDFLAGS" value="-fPIC" />
 									<env key="LDLIBS" value="-llilv-0 -lsuil-0" />
@@ -62,7 +62,7 @@
 						<configuration>
 							<target name="compile-native-ui">
 								<exec dir="${tuxguitar-synth-lv2.cxx.path}" executable="gmake" failonerror="true" >
-									<env key="CXX" value="g++12" />
+									<env key="CXX" value="g++" />
 									<env key="CFLAGS" value="-I/usr/local/include/lilv-0/lilv -I/usr/local/include/suil-0/suil `pkg-config Qt5Core --cflags` `pkg-config Qt5Widgets --cflags` -fPIC -fpermissive" />
 									<env key="LDFLAGS" value="-fPIC" />
 									<env key="LDLIBS" value="-llilv-0 -lsuil-0 -lpthread `pkg-config Qt5Core --libs` `pkg-config Qt5Widgets --libs`" />


### PR DESCRIPTION
## Summary

The FreeBSD CI workflow has been failing since the LV2 synth extension was added to the FreeBSD build (b4f6a1058, "Build TG Synth LV2 extension on FreeBSD"). Because Actions are disabled on this repository, the failure only surfaces on forks — every fork currently gets a red FreeBSD run on any push. Two small fixes make it green again.

## Root causes and fixes

**1. Missing LV2 build dependencies in the VM** (`.github/workflows/freebsd-maven.yml`)

`tuxguitar-synth-lv2-freebsd` compiles JNI sources that include `<lilv.h>` and `<lv2/...>` headers, links against `-llilv-0 -lsuil-0`, and its Qt UI host shells out to `pkg-config` for Qt5Core/Qt5Widgets — none of which were installed in the FreeBSD VM. Added `lv2 lilv suil pkgconf qt5-core qt5-widgets` to the `pkg install` line (the FreeBSD counterpart of the Ubuntu workflow's `liblilv-dev libsuil-dev qtbase5-dev`).

**2. Hardcoded `g++12` no longer exists** (`desktop/build-scripts/native-modules/tuxguitar-synth-lv2-freebsd/pom.xml`)

With the packages installed, the build then failed with:

```
gmake: g++12: No such file or directory
gmake: *** [GNUmakefile:11: ../cxx/LV2Logger.o] Error 127
```

The pom hardcoded `CXX=g++12`, written when gcc12 was the ports default. The vmactions FreeBSD 15.1 image's `gcc` meta-package now installs gcc14, so no `g++12` binary exists. Switched both antrun execs to the versionless `g++` symlink the meta-port provides — the same approach the Linux LV2 pom (`g++`) and the FreeBSD fluidsynth pom (`gcc`, which builds fine in the same run) already use, so it keeps working across future compiler default bumps.

## Verification

FreeBSD workflow run on the final commit: completed / success — https://github.com/mattstrayer/tuxguitar/actions/runs/28818605622

No other platforms are touched: the workflow change is FreeBSD-only, and the pom change is inside the `tuxguitar-synth-lv2-freebsd` build script, which only the FreeBSD build uses.
