### PR TITLE
add config to allow elapsed time to continue accumulating during loop

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/ElapsedTimeLoopAccumulator.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/ElapsedTimeLoopAccumulator.java
@@ -1,0 +1,25 @@
+package app.tuxguitar.player.base;
+
+public class ElapsedTimeLoopAccumulator {
+
+	private long baseElapsedTime;
+	private long lastTimestamp;
+
+	public ElapsedTimeLoopAccumulator() {
+		this.reset();
+	}
+
+	public long accumulate(long currentTimestamp) {
+		if (currentTimestamp < this.lastTimestamp) {
+			this.baseElapsedTime += this.lastTimestamp;
+		}
+
+		this.lastTimestamp = currentTimestamp;
+		return (this.baseElapsedTime + currentTimestamp);
+	}
+
+	public void reset() {
+		this.baseElapsedTime = 0;
+		this.lastTimestamp = 0;
+	}
+}

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayer.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayer.java
@@ -427,7 +427,7 @@ public class MidiPlayer{
 		return false;
 	}
 
-	private boolean isPaused() {
+	public boolean isPaused() {
 		try {
 			this.lock();
 

--- a/common/TuxGuitar-lib/src/test/java/app/tuxguitar/player/base/TestElapsedTimeLoopAccumulator.java
+++ b/common/TuxGuitar-lib/src/test/java/app/tuxguitar/player/base/TestElapsedTimeLoopAccumulator.java
@@ -1,0 +1,28 @@
+package app.tuxguitar.player.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TestElapsedTimeLoopAccumulator {
+
+	@Test
+	public void onAccumulateWhenTimestampWrapsExpectContinuousElapsedTime() {
+		ElapsedTimeLoopAccumulator accumulator = new ElapsedTimeLoopAccumulator();
+
+		assertEquals(120L, accumulator.accumulate(120L));
+		assertEquals(380L, accumulator.accumulate(380L));
+		assertEquals(430L, accumulator.accumulate(50L));
+	}
+
+	@Test
+	public void onResetWhenNewPlaybackStartsExpectElapsedTimeStartsFromLoopTimestamp() {
+		ElapsedTimeLoopAccumulator accumulator = new ElapsedTimeLoopAccumulator();
+
+		accumulator.accumulate(900L);
+		accumulator.accumulate(20L);
+		accumulator.reset();
+
+		assertEquals(40L, accumulator.accumulate(40L));
+	}
+}

--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -588,6 +588,7 @@ transport.mode=Play Mode
 transport.mode.simple=Simple Mode
 transport.mode.simple.tempo-percent=Percentage of Tempo
 transport.mode.simple.loop=Play looped
+transport.mode.elapsed-time.dont-stop-during-loop=Don't reset "Elapsed Time" during loops
 transport.mode.trainer=Training Mode
 transport.mode.trainer.increment-description=Increment by
 transport.mode.loop-range=Loop Range

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -445,6 +445,7 @@ transport.mode=Modo Tocador
 transport.mode.simple=Modo Tocador Simples
 transport.mode.simple.tempo-percent=Percentual de tempo
 transport.mode.simple.loop=Tocar um Loop
+transport.mode.elapsed-time.dont-stop-during-loop=Não reiniciar "Tempo Decorrido" durante loops
 transport.mode.trainer=Modo de Treinamento
 transport.mode.trainer.increment-description=Incrementar em
 transport.mode.loop-range=Tamanho do loop

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
@@ -126,6 +126,7 @@ public class TGConfigKeys {
 	public static final String CONFIG_APP_VERSION = "config.app.version";
 
 	public static final String PLAY_WHEN_MOVING = "play.when.moving";
+	public static final String DONT_STOP_ELAPSED_TIME_DURING_LOOP = "elapsed.time.dont-stop-during-loop";
 	public static final String CHORD_INSERT_DIAGRAM_ONLY = "chord.insert-diagram-only";
 
 	public static final String SCROLLING_MAX_FPS = "scrolling.continuous.maxFPS";

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/transport/TGTransportListener.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/transport/TGTransportListener.java
@@ -87,6 +87,8 @@ public class TGTransportListener implements TGEventListener{
 					TGTransport tgTransport = TGTransport.getInstance(TGTransportListener.this.context);
 					tgTransport.gotoPlayerPosition();
 					tgTransport.getCache().reset();
+
+					tgEditorManager.redrawPlayingThread();
 				} catch (Throwable throwable) {
 					TGErrorManager.getInstance(TGTransportListener.this.context).handleError(throwable);
 				}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/transport/TGTransportModeDialog.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/transport/TGTransportModeDialog.java
@@ -50,6 +50,7 @@ public class TGTransportModeDialog {
 	private TGViewContext context;
 	protected UIRadioButton simple;
 	protected UICheckBox simpleLoop;
+	protected UICheckBox dontStopElapsedTimeDuringLoop;
 	protected UISpinner simplePercent;
 
 	protected UIRadioButton custom;
@@ -130,6 +131,14 @@ public class TGTransportModeDialog {
 		this.simpleLoop.setSelected(mode.isLoop());
 		simpleLayout.set(this.simpleLoop, 2, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 2);
 		simpleAdapter.addControl(this.simpleLoop);
+
+		this.dontStopElapsedTimeDuringLoop = uiFactory.createCheckBox(simpleGroup);
+		this.dontStopElapsedTimeDuringLoop.setText(TuxGuitar.getProperty("transport.mode.elapsed-time.dont-stop-during-loop"));
+		this.dontStopElapsedTimeDuringLoop.setSelected(false);
+		simpleLayout.set(this.dontStopElapsedTimeDuringLoop, 3, 1, UITableLayout.ALIGN_FILL, UITableLayout.ALIGN_FILL, true, true, 1, 3);
+
+		ElapsedTimeDontStopController elapsedTimeController = new ElapsedTimeDontStopController(this.simpleLoop, this.dontStopElapsedTimeDuringLoop);
+		elapsedTimeController.update();
 
 		//---Trainer---
 		this.custom = uiFactory.createRadioButton(dialog);
@@ -302,6 +311,9 @@ public class TGTransportModeDialog {
 		mode.setLoopEHeader(loop && loopEHeader != null ? loopEHeader : -1 );
 		tgActionProcessor.setAttribute(TGTransportModeAction.ATTRIBUTE_PLAYER_MODE, mode);
 		tgActionProcessor.process();
+		TGConfigManager manager = TGConfigManager.getInstance(this.context.getContext());
+		manager.setValue(TGConfigKeys.DONT_STOP_ELAPSED_TIME_DURING_LOOP, this.dontStopElapsedTimeDuringLoop.isSelected());
+		manager.save();
 
 		TGDocument document = TGDocumentListManager.getInstance(context.getContext()).findCurrentDocument();
 		if (document != null) {
@@ -487,6 +499,26 @@ public class TGTransportModeDialog {
 					updateLoopEHeader();
 				}
 			});
+		}
+	}
+
+	private class ElapsedTimeDontStopController implements UISelectionListener {
+
+		private UICheckBox simpleLoop;
+		private UICheckBox dontStopElapsedTimeDuringLoop;
+
+		public ElapsedTimeDontStopController(UICheckBox simpleLoop, UICheckBox dontStopElapsedTimeDuringLoop) {
+			this.simpleLoop = simpleLoop;
+			this.dontStopElapsedTimeDuringLoop = dontStopElapsedTimeDuringLoop;
+			this.simpleLoop.addSelectionListener(this);
+		}
+
+		public void update() {
+			this.dontStopElapsedTimeDuringLoop.setEnabled(this.simpleLoop.isSelected());
+		}
+
+		public void onSelect(UISelectionEvent event) {
+			this.update();
 		}
 	}
 }

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarItemTimeCounter.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarItemTimeCounter.java
@@ -19,6 +19,7 @@ import app.tuxguitar.editor.event.TGRedrawEvent;
 import app.tuxguitar.editor.util.TGSyncProcessLocked;
 import app.tuxguitar.event.TGEvent;
 import app.tuxguitar.event.TGEventListener;
+import app.tuxguitar.player.base.ElapsedTimeLoopAccumulator;
 import app.tuxguitar.player.base.MidiPlayer;
 import app.tuxguitar.ui.UIFactory;
 import app.tuxguitar.ui.chooser.UIFontChooser;
@@ -67,6 +68,7 @@ public class TGMainToolBarItemTimeCounter extends TGMainToolBarItem implements T
 	private long timestamp = -1;
 	private float yTimestamp;
 	private boolean fontChanged;
+	private ElapsedTimeLoopAccumulator elapsedTimeLoopAccumulator;
 	private TGContext context;
 
 	public TGMainToolBarItemTimeCounter(TGMainToolBarItemConfig toolBarItemConfig, TGContext context, UIPanel parentPanel, UIWindow parentWindow) {
@@ -117,6 +119,7 @@ public class TGMainToolBarItemTimeCounter extends TGMainToolBarItem implements T
 		tgColorManager.appendSkinnableColors(SKINNABLE_COLORS);
 		this.loadFont();
 		this.loadColors();
+		this.elapsedTimeLoopAccumulator = new ElapsedTimeLoopAccumulator();
 
 		this.createSyncProcesses();
 		this.appendListeners();
@@ -153,11 +156,16 @@ public class TGMainToolBarItemTimeCounter extends TGMainToolBarItem implements T
 				MidiPlayer midiPlayer = MidiPlayer.getInstance(TGMainToolBarItemTimeCounter.this.context);
 				if ((midiPlayer.isRunning()) && (midiPlayer.getCurrentTimestamp() != null)) {
 					long tMs = midiPlayer.getCurrentTimestamp();
+					if (TGConfigManager.getInstance(TGMainToolBarItemTimeCounter.this.context).getBooleanValue(TGConfigKeys.DONT_STOP_ELAPSED_TIME_DURING_LOOP)) {
+						tMs = this.elapsedTimeLoopAccumulator.accumulate(tMs);
+					}
 					if (tMs / 100 != this.timestamp / 100) {
 						this.redrawProcess.process();
 						this.timestamp = tMs;
 					}
-				} else {
+				} else if (!midiPlayer.isPaused()) {
+					this.elapsedTimeLoopAccumulator.reset();
+					this.timestamp = -1;
 					this.redrawProcess.process();
 				}
 			}


### PR DESCRIPTION
Hello everyone, this is my first PR here.

I tried to keep the changes as small as possible.

I added a configuration to allow the elapsed time to increase.

Imagine that a person wants to do the same exercise for 5minutes, but if the elapsed time resets, it makes it harder to keep track of.
<img width="428" height="464" alt="image" src="https://github.com/user-attachments/assets/6793c079-340b-4b4d-9ed8-8bc4e7b87096" />
This is how it looks when a player opens it for the first time.
<img width="390" height="440" alt="image" src="https://github.com/user-attachments/assets/b5b66939-dd80-403f-b7f2-3ec3729c3fde" />
It is still possible to play looping with elapsed time resetting (default behaviour today).
<img width="392" height="205" alt="image" src="https://github.com/user-attachments/assets/639cf9d2-786b-494b-8fae-85115c87cf70" />
<img width="1137" height="424" alt="image" src="https://github.com/user-attachments/assets/76709f4e-923e-4ad0-9feb-39adafd2c484" />
Let me know if this is something desirable and if I need to make any other changes to keep the solution with the desired code structure.