### PR TITLE
add session time using event listener approach

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -242,3 +242,8 @@ Alejandro6626
 Klaus Rettinghaus
     * MusicXML export
     * Contact: https://github.com/rettinghaus
+
+Hebert Coelho de Oliveira
+    * Brazilian Portuguese translation
+    * Session Time counter
+    * Contact: https://github.com/uaihebert

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayer.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayer.java
@@ -133,6 +133,7 @@ public class MidiPlayer{
 			this.setPaused(paused);
 			this.stopSequencer();
 			this.setRunning(false);
+			this.notifyStopped(paused);
 		} finally {
 			this.unlock();
 		}
@@ -164,6 +165,7 @@ public class MidiPlayer{
 
 			final boolean notifyStarted = (!this.isRunning());
 			this.setRunning(true);
+			this.setPaused(false);
 			this.stopSequencer();
 			this.checkDevices();
 			this.updateLoop(true);
@@ -307,7 +309,7 @@ public class MidiPlayer{
 				}
 
 				if(!this.isRunning() ){
-					this.notifyStopped();
+					this.notifyStopped(this.isPaused());
 				}
 			} finally {
 				this.unlock();
@@ -1261,8 +1263,8 @@ public class MidiPlayer{
 		TGEventManager.getInstance(this.context).fireEvent(new MidiPlayerEvent(MidiPlayerEvent.NOTIFY_STARTED));
 	}
 
-	public void notifyStopped(){
-		TGEventManager.getInstance(this.context).fireEvent(new MidiPlayerEvent(MidiPlayerEvent.NOTIFY_STOPPED));
+	public void notifyStopped(boolean paused){
+		TGEventManager.getInstance(this.context).fireEvent(new MidiPlayerEvent(MidiPlayerEvent.NOTIFY_STOPPED, paused));
 	}
 
 	public void notifyCountDownStarted(){

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayerEvent.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/player/base/MidiPlayerEvent.java
@@ -7,6 +7,7 @@ public class MidiPlayerEvent extends TGEvent {
 	public static final String EVENT_TYPE = "midi-player-notification";
 
 	public static final String PROPERTY_NOTIFICATION_TYPE = "notificationType";
+	public static final String PROPERTY_PAUSED = "paused";
 
 	public static final int NOTIFY_STARTED = 1;
 	public static final int NOTIFY_STOPPED = 2;
@@ -15,8 +16,13 @@ public class MidiPlayerEvent extends TGEvent {
 	public static final int NOTIFY_LOOP = 5;
 
 	public MidiPlayerEvent(int notificationType) {
+		this(notificationType, false);
+	}
+
+	public MidiPlayerEvent(int notificationType, boolean paused) {
 		super(EVENT_TYPE);
 
 		this.setAttribute(PROPERTY_NOTIFICATION_TYPE, Integer.valueOf(notificationType));
+		this.setAttribute(PROPERTY_PAUSED, paused);
 	}
 }

--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -290,6 +290,7 @@ toolbar.settings.save-as=Save current toolbar as
 toolbar.settings.delete=Delete current toolbar
 toolbar.separator=-------- Separator --------
 toolbar.timeCounter=Elapsed time
+toolbar.playingSessionTime=Playing session time
 toolbar.tempoIndicator=Tempo indicator
 toolbar.main.left=Left area
 toolbar.main.center=Center area

--- a/common/resources/lang/messages_bg.properties
+++ b/common/resources/lang/messages_bg.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Запазване като
 toolbar.settings.delete=Изтриване
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_ca.properties
+++ b/common/resources/lang/messages_ca.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Desa com a
 toolbar.settings.delete=Esborra
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_cs.properties
+++ b/common/resources/lang/messages_cs.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Uložit jako...
 toolbar.settings.delete=Odstranit
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_de.properties
+++ b/common/resources/lang/messages_de.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Aktuelle Symbolleiste speichern unter
 toolbar.settings.delete=Gespeicherte Symbolleiste löschen
 toolbar.separator=-------- Trennzeichen --------
 toolbar.timeCounter=Zeitanzeige
+#toolbar.playingSessionTime=
 toolbar.tempoIndicator=Tempo-Anzeige
 toolbar.main.left=Linker Bereich
 toolbar.main.center=Mittlerer Bereich

--- a/common/resources/lang/messages_el.properties
+++ b/common/resources/lang/messages_el.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Αποθήκευση Ως
 toolbar.settings.delete=Επανάληψη Διαγραφή
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Guardar Como
 toolbar.settings.delete=Borrar
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_eu.properties
+++ b/common/resources/lang/messages_eu.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Gorde beste izenarekin
 toolbar.settings.delete=Ezabatu
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_fi.properties
+++ b/common/resources/lang/messages_fi.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Tallenna nimellä
 toolbar.settings.delete=Poista
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_fr.properties
+++ b/common/resources/lang/messages_fr.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Enregistrer sous...
 toolbar.settings.delete=Supprimer
 toolbar.separator=-------- Séparateur --------
 toolbar.timeCounter=Temps écoulé
+#toolbar.playingSessionTime=
 toolbar.tempoIndicator=Tempo
 toolbar.main.left=Zone de gauche
 toolbar.main.center=Zone centrale

--- a/common/resources/lang/messages_hu.properties
+++ b/common/resources/lang/messages_hu.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Mentés másként...
 toolbar.settings.delete=Törlés
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_it.properties
+++ b/common/resources/lang/messages_it.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Salva barra corrente come
 toolbar.settings.delete=Elimina barra salvata
 toolbar.separator=-------- Separatore --------
 toolbar.timeCounter=Contatore di tempo
+#toolbar.playingSessionTime=
 toolbar.tempoIndicator=Indicatore Tempo
 toolbar.main.left=Area sinistra
 toolbar.main.center=Area centrale

--- a/common/resources/lang/messages_ja.properties
+++ b/common/resources/lang/messages_ja.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=別名保存
 toolbar.settings.delete=削除
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_ko.properties
+++ b/common/resources/lang/messages_ko.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=다른 이름으로 저장
 toolbar.settings.delete=삭제
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_lt.properties
+++ b/common/resources/lang/messages_lt.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Įrašyti taip
 toolbar.settings.delete=Pašalinti
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_nl.properties
+++ b/common/resources/lang/messages_nl.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Opslaan Als
 toolbar.settings.delete=Verwijder
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_pl.properties
+++ b/common/resources/lang/messages_pl.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Zapisz jako
 toolbar.settings.delete=Usuń
 # toolbar.separator=
 toolbar.timeCounter=Miniony czas
+#toolbar.playingSessionTime=
 toolbar.tempoIndicator=Tempo
 toolbar.main.left=Lewy obszar
 toolbar.main.center=Środkowy obszar

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Salvar Como
 toolbar.settings.delete=Excluir
 # toolbar.separator=
 toolbar.timeCounter=Tempo Decorrido
+toolbar.playingSessionTime=Tempo de prática
 toolbar.tempoIndicator=Indicador de Tempo
 toolbar.main.left=Área Esquerda
 toolbar.main.center=Área Central

--- a/common/resources/lang/messages_ru.properties
+++ b/common/resources/lang/messages_ru.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Сохранить как
 toolbar.settings.delete=Удалить
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_sr.properties
+++ b/common/resources/lang/messages_sr.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Snimi kao
 toolbar.settings.delete=Obriši
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_sv.properties
+++ b/common/resources/lang/messages_sv.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Spara som
 toolbar.settings.delete=Ta bort
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_uk.properties
+++ b/common/resources/lang/messages_uk.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Зберегти як
 toolbar.settings.delete=Видалити
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_vi.properties
+++ b/common/resources/lang/messages_vi.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=Lưu dạng
 toolbar.settings.delete=Xoá
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_zh_CN.properties
+++ b/common/resources/lang/messages_zh_CN.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=另存为
 toolbar.settings.delete=清除
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/common/resources/lang/messages_zh_TW.properties
+++ b/common/resources/lang/messages_zh_TW.properties
@@ -147,6 +147,7 @@ toolbar.settings.save-as=另存新檔
 toolbar.settings.delete=刪除
 # toolbar.separator=
 # toolbar.timeCounter=
+#toolbar.playingSessionTime=
 # toolbar.tempoIndicator=
 # toolbar.main.left=
 # toolbar.main.center=

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBar.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBar.java
@@ -114,7 +114,15 @@ public class TGMainToolBar extends TGToolBarModel {
 				this.layoutControls(mainToolBarLayout, area, col, controls);
 				col += controls.size();
 			}
+			if (area == RIGHT_AREA) {
+				TGMainToolBarSection sessionTimeSection = new TGMainToolBarSectionSessionTime(getContext(), this.panel);
+				this.addSection(sessionTimeSection);
+				for (UIControl control : sessionTimeSection.getControls()) {
+					mainToolBarLayout.set(control, 1, col, UITableLayout.ALIGN_RIGHT, UITableLayout.ALIGN_CENTER, false, true);
+				}
+			}
 		}
+
 		this.panel.layout();
 	}
 

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarSectionSessionTime.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarSectionSessionTime.java
@@ -1,0 +1,154 @@
+package app.tuxguitar.app.view.toolbar.main;
+
+import app.tuxguitar.app.TuxGuitar;
+import app.tuxguitar.app.system.config.TGConfigKeys;
+import app.tuxguitar.app.system.config.TGConfigManager;
+import app.tuxguitar.app.ui.TGApplication;
+import app.tuxguitar.editor.event.TGRedrawEvent;
+import app.tuxguitar.editor.util.TGSyncProcessLocked;
+import app.tuxguitar.event.TGEvent;
+import app.tuxguitar.event.TGEventListener;
+import app.tuxguitar.player.base.MidiPlayer;
+import app.tuxguitar.player.base.MidiPlayerEvent;
+import app.tuxguitar.ui.UIFactory;
+import app.tuxguitar.ui.event.UIDisposeEvent;
+import app.tuxguitar.ui.event.UIDisposeListener;
+import app.tuxguitar.ui.resource.UIFont;
+import app.tuxguitar.ui.resource.UIFontModel;
+import app.tuxguitar.ui.widget.UILabel;
+import app.tuxguitar.ui.widget.UIPanel;
+import app.tuxguitar.util.TGContext;
+
+public class TGMainToolBarSectionSessionTime extends TGMainToolBarSection implements TGEventListener {
+
+	private static final int STATE_STOPPED = 0;
+	private static final int STATE_RUNNING = 1;
+	private static final int STATE_PAUSED = 2;
+
+	private UILabel sessionTimeLabel;
+	private TGSyncProcessLocked redrawProcess;
+	private UIPanel parentPanel;
+	private UIFontModel fontModel;
+	private UIFont font;
+
+	private int state = STATE_STOPPED;
+	private long sessionStartTime = 0;
+	private long accumulatedTime = 0;
+
+	public TGMainToolBarSectionSessionTime(TGContext context, UIPanel parentPanel) {
+		super(context);
+		UIFactory uiFactory = TGApplication.getInstance(this.getContext()).getFactory();
+
+		this.parentPanel = parentPanel;
+		this.sessionTimeLabel = uiFactory.createLabel(parentPanel);
+		this.sessionTimeLabel.setToolTipText(TuxGuitar.getProperty("toolbar.playingSessionTime"));
+		this.controls.add(this.sessionTimeLabel);
+
+		this.loadFont();
+
+		this.sessionTimeLabel.addDisposeListener(new UIDisposeListener() {
+			@Override
+			public void onDispose(UIDisposeEvent event) {
+				if (TGMainToolBarSectionSessionTime.this.font != null) {
+					TGMainToolBarSectionSessionTime.this.font.dispose();
+				}
+				TuxGuitar.getInstance().getEditorManager().removeRedrawListener(TGMainToolBarSectionSessionTime.this);
+				MidiPlayer.getInstance(TGMainToolBarSectionSessionTime.this.getContext()).removeListener(TGMainToolBarSectionSessionTime.this);
+			}
+		});
+
+		this.createSyncProcesses();
+		this.appendListeners();
+		loadProperties();
+	}
+
+	private void loadFont() {
+		if (this.font != null) {
+			this.font.dispose();
+		}
+		UIFactory uiFactory = TGApplication.getInstance(this.getContext()).getFactory();
+		this.fontModel = TGConfigManager.getInstance(this.getContext())
+				.getFontModelConfigValue(TGConfigKeys.FONT_MAINTOOLBAR_TIMESTAMP);
+		this.font = uiFactory.createFont(this.fontModel);
+		this.sessionTimeLabel.setFont(this.font);
+	}
+
+	private void createSyncProcesses() {
+		this.redrawProcess = new TGSyncProcessLocked(getContext(), new Runnable() {
+			public void run() {
+				TGMainToolBarSectionSessionTime.this.updateItems();
+			}
+		});
+	}
+
+	private void appendListeners() {
+		TuxGuitar.getInstance().getEditorManager().addRedrawListener(this);
+		MidiPlayer.getInstance(getContext()).addListener(this);
+	}
+
+	@Override
+	public void processEvent(final TGEvent event) {
+		if (MidiPlayerEvent.EVENT_TYPE.equals(event.getEventType())) {
+			int type = ((Integer) event.getAttribute(MidiPlayerEvent.PROPERTY_NOTIFICATION_TYPE)).intValue();
+			if (type == MidiPlayerEvent.NOTIFY_STARTED) {
+				if (state == STATE_STOPPED) {
+					this.sessionStartTime = System.currentTimeMillis();
+					this.accumulatedTime = 0;
+					this.state = STATE_RUNNING;
+				} else if (state == STATE_PAUSED) {
+					this.sessionStartTime = System.currentTimeMillis();
+					this.state = STATE_RUNNING;
+				}
+			} else if (type == MidiPlayerEvent.NOTIFY_STOPPED) {
+				boolean paused = ((Boolean) event.getAttribute(MidiPlayerEvent.PROPERTY_PAUSED)).booleanValue();
+				if (paused) {
+					this.accumulatedTime = this.getCurrentElapsedTime();
+					this.state = STATE_PAUSED;
+				} else {
+					this.state = STATE_STOPPED;
+					this.accumulatedTime = 0;
+				}
+			}
+		} else if (TGRedrawEvent.EVENT_TYPE.equals(event.getEventType())) {
+			int type = ((Integer) event.getAttribute(TGRedrawEvent.PROPERTY_REDRAW_MODE)).intValue();
+			if (type == TGRedrawEvent.PLAYING_THREAD || type == TGRedrawEvent.PLAYING_NEW_BEAT) {
+				if (state == STATE_RUNNING) {
+					this.redrawProcess.process();
+				}
+			}
+		}
+	}
+
+	private long getCurrentElapsedTime() {
+		if (state == STATE_RUNNING) {
+			return this.accumulatedTime + (System.currentTimeMillis() - this.sessionStartTime);
+		}
+		return this.accumulatedTime;
+	}
+
+	@Override
+	public void loadProperties() {
+		this.updateLabel("0:00:00");
+	}
+
+	@Override
+	public void updateItems() {
+		String time;
+		if (this.state == STATE_STOPPED) {
+			time = "0:00:00";
+		} else {
+			long tMs = this.getCurrentElapsedTime();
+			time = String.format("%d:%02d:%02d", tMs / 3600000, (tMs / 60000) % 60, (tMs / 1000) % 60);
+		}
+		this.updateLabel(time);
+	}
+
+	private void updateLabel(String text) {
+		this.sessionTimeLabel.setText(text);
+	}
+
+	@Override
+	public void addToolBarItem(TGMainToolBarItemConfig toolBarItemConfig) {
+		// nothing to do, content of this section is not configurable
+	}
+}


### PR DESCRIPTION
Add session count timer.
To use it:
<img width="675" height="391" alt="image" src="https://github.com/user-attachments/assets/892bc42d-9af3-4ba1-9bf1-c8ae299445aa" />
When the player press play with looped option, we will see the total time:
<img width="736" height="112" alt="image" src="https://github.com/user-attachments/assets/78f8f17f-19cf-4b55-91c7-27663290bad7" />

Icon is free to use, got it from here: https://fontawesome.com/icons/classic/solid/stopwatch
