### PR TITLE
fix create note issue

### DIFF
--- a/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/effect/TGChangeDeadNoteAction.java
+++ b/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/effect/TGChangeDeadNoteAction.java
@@ -5,8 +5,6 @@ import app.tuxguitar.document.TGDocumentContextAttributes;
 import app.tuxguitar.editor.action.TGActionBase;
 import app.tuxguitar.song.managers.TGSongManager;
 import app.tuxguitar.song.models.TGBeat;
-import app.tuxguitar.song.models.TGDuration;
-import app.tuxguitar.song.models.TGMeasure;
 import app.tuxguitar.song.models.TGNote;
 import app.tuxguitar.song.models.TGString;
 import app.tuxguitar.song.models.TGTrack;
@@ -38,10 +36,8 @@ public class TGChangeDeadNoteAction extends TGActionBase {
 			}
 		}
 		else if( note == null && !track.isPercussion()){
-			TGMeasure measure = ((TGMeasure) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_MEASURE));
 			TGBeat beat = ((TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT));
 			TGVoice voice = ((TGVoice) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VOICE));
-			TGDuration duration = ((TGDuration) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_DURATION));
 			TGString string = ((TGString) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING));
 			int velocity = ((Integer) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VELOCITY)).intValue();
 
@@ -50,9 +46,7 @@ public class TGChangeDeadNoteAction extends TGActionBase {
 			note.setVelocity(velocity);
 			note.setString(string.getNumber());
 
-			TGDuration noteDuration = duration.clone(songManager.getFactory());
-
-			songManager.getMeasureManager().addNote(measure, beat.getStart(), note, noteDuration, voice.getIndex());
+			songManager.getMeasureManager().addNote(beat, note, voice.getIndex());
 			songManager.getMeasureManager().changeDeadNote(note);
 		}
 	}

--- a/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/note/TGInsertChordAction.java
+++ b/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/note/TGInsertChordAction.java
@@ -8,7 +8,6 @@ import app.tuxguitar.editor.action.TGActionBase;
 import app.tuxguitar.song.managers.TGSongManager;
 import app.tuxguitar.song.models.TGBeat;
 import app.tuxguitar.song.models.TGChord;
-import app.tuxguitar.song.models.TGDuration;
 import app.tuxguitar.song.models.TGNote;
 import app.tuxguitar.song.models.TGString;
 import app.tuxguitar.song.models.TGTrack;
@@ -51,10 +50,7 @@ public class TGInsertChordAction extends TGActionBase {
 					note.setVelocity(velocity);
 					note.setString(string.getNumber());
 
-					TGDuration duration = songManager.getFactory().newDuration();
-					duration.copyFrom(voice.getDuration());
-
-					songManager.getMeasureManager().addNote(beat, note, duration, voice.getIndex());
+					songManager.getMeasureManager().addNote(beat, note, voice.getIndex());
 				}
 			}
 			songManager.getMeasureManager().addChord(beat, chord);

--- a/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/note/TGSetNoteFretNumberAction.java
+++ b/common/TuxGuitar-editor-utils/src/main/java/app/tuxguitar/editor/action/note/TGSetNoteFretNumberAction.java
@@ -1,11 +1,14 @@
 package app.tuxguitar.editor.action.note;
 
 import app.tuxguitar.action.TGActionContext;
-import app.tuxguitar.action.TGActionManager;
 import app.tuxguitar.document.TGDocumentContextAttributes;
 import app.tuxguitar.editor.action.TGActionBase;
+import app.tuxguitar.song.managers.TGSongManager;
+import app.tuxguitar.song.models.TGBeat;
+import app.tuxguitar.song.models.TGNote;
 import app.tuxguitar.song.models.TGString;
 import app.tuxguitar.song.models.TGTrack;
+import app.tuxguitar.song.models.TGVoice;
 import app.tuxguitar.util.TGContext;
 
 public class TGSetNoteFretNumberAction extends TGActionBase  {
@@ -27,15 +30,18 @@ public class TGSetNoteFretNumberAction extends TGActionBase  {
 	}
 
 	protected void processAction(TGActionContext context){
+		TGSongManager songManager = getSongManager(context);
 		TGTrack track = (TGTrack) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_TRACK);
 		TGString string = (TGString) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_STRING);
-		Long start = (Long) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_POSITION);
-
+		TGBeat beat = (TGBeat) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_BEAT);
+		TGVoice voice = ((TGVoice) context.getAttribute(TGDocumentContextAttributes.ATTRIBUTE_VOICE));
+		long preciseStart = beat.getPreciseStart();
+		
 		int fret = this.number;
 		long time = System.currentTimeMillis();
 
 		if( this.number < 10 ){
-			if( lastAddedStart == start.longValue() && lastAddedString == string.getNumber() ){
+			if( lastAddedStart == preciseStart && lastAddedString == string.getNumber() ){
 				if( lastAddedFret > 0 && lastAddedFret < 10 && time <  ( lastAddedTime + DELAY ) ){
 					int newFret = ( ( lastAddedFret * 10 ) + fret );
 					if( newFret <= track.getMaxFret() || track.isPercussion() ){
@@ -45,14 +51,14 @@ public class TGSetNoteFretNumberAction extends TGActionBase  {
 			}
 			lastAddedTime = time;
 			lastAddedFret = fret;
-			lastAddedStart = start.longValue();
+			lastAddedStart = preciseStart;
 			lastAddedString = string.getNumber();
 		}
 
-		context.setAttribute(TGDocumentContextAttributes.ATTRIBUTE_FRET, Integer.valueOf(fret));
-
-		TGActionManager tgActionManager = TGActionManager.getInstance(getContext());
-		tgActionManager.execute(TGChangeNoteAction.NAME, context);
+		TGNote note = songManager.getFactory().newNote();
+		note.setString(lastAddedString);
+		note.setValue(fret);
+		songManager.getMeasureManager().addNote(beat, note, voice.getIndex());
 	}
 
 	public static final String getActionName(int number){

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGMeasureManager.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGMeasureManager.java
@@ -132,7 +132,24 @@ public class TGMeasureManager {
 	}
 
 	public void addNote(TGBeat beat, TGNote note, TGDuration duration, int voice){
+		// TODO don't rely on imprecise start, since target beat and voice are correctly identified
 		addNote(beat, note, duration, beat.getStart(),voice);
+		
+	}
+
+	public void addNote(TGBeat beat, TGNote note, int voiceIndex){
+		// delete other note on the same string (theoretically maximum one)
+		TGNote toDelete = null;
+		for(TGNote voiceNote : beat.getVoice(voiceIndex).getNotes()) {
+			if (voiceNote.getString() == note.getString()) {
+				toDelete = voiceNote;
+				break;
+			}
+		}
+		if (toDelete != null) {
+			removeNote(toDelete, false);
+		}
+		beat.getVoice(voiceIndex).addNote(note);
 	}
 
 	public void addNote(TGBeat beat, TGNote note, TGDuration duration, long start, int voice){
@@ -140,7 +157,6 @@ public class TGMeasureManager {
 		if( emptyVoice ){
 			beat.getVoice( voice ).setEmpty( false );
 		}
-
 		//Verifico si entra en el compas
 		if(validateDuration(beat.getMeasure(),beat, voice, duration,true,true)){
 			//Borro lo que haya en la misma posicion

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/installer/TGActionConfigMap.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/installer/TGActionConfigMap.java
@@ -332,6 +332,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 	private static final TGUpdateController UPDATE_CHANNELS_CTL = new TGUpdateChannelsController();
 	private static final TGUpdateController UPDATE_NOTE_RANGE_CTL = new TGUpdateNoteRangeController();
 	private static final TGUpdateController UPDATE_BEAT_RANGE_CTL = new TGUpdateBeatRangeController();
+	private static final TGUpdateController UPDATE_MODIFIED_NOTE_CTL = new TGUpdateModifiedNoteController();
 
 	private static final TGUndoableActionController UNDOABLE_SONG_GENERIC = new TGUndoableSongGenericController();
 	private static final TGUndoableActionController UNDOABLE_MEASURE_GENERIC = new TGUndoableMeasureGenericController();
@@ -460,7 +461,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		this.map(TGCopyBeatAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT);
 
 		//beat actions
-		this.map(TGChangeNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY, new TGUpdateModifiedNoteController(), UNDOABLE_MEASURE_GENERIC);
+		this.map(TGChangeNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY, UPDATE_MODIFIED_NOTE_CTL, UNDOABLE_MEASURE_GENERIC);
 		this.map(TGChangePickStrokeUpAction.NAME, LOCKABLE | DISABLE_ON_PLAY, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 		this.map(TGChangePickStrokeDownAction.NAME, LOCKABLE | DISABLE_ON_PLAY, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 		this.map(TGChangeTiedNoteAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
@@ -486,7 +487,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		this.map(TGInsertChordAction.NAME, LOCKABLE | DISABLE_ON_PLAY, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 		this.map(TGRemoveChordAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 		for( int i = 0 ; i < 10 ; i ++ ){
-			this.map(TGSetNoteFretNumberAction.getActionName(i), LOCKABLE | DISABLE_ON_PLAY | SHORTCUT);
+			this.map(TGSetNoteFretNumberAction.getActionName(i), LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_MODIFIED_NOTE_CTL, UNDOABLE_MEASURE_GENERIC);
 		}
 		this.map(TGToggleNoteEnharmonicAction.NAME, LOCKABLE | DISABLE_ON_PLAY | SHORTCUT, UPDATE_MEASURE_CTL, UNDOABLE_MEASURE_GENERIC);
 


### PR DESCRIPTION
see #1115

In some cases, notes need to be created in an already identified beat/voice. Then, it is NOT reliable to use legacy TGBeat.start attribute to identify the beat, as it's imprecise.

Before the fix, it was not always possible to create a note by typing its number on the keyboard, by adding a chord, or by adding a dead note. Example: fill a 4/4 measure with triplets of 64th. At some locations (not all), typing digits on the fretboard failed to create a note.

It's probable there are still some other bugs like this in methods of TGMeasureManager that rely on imprecise TGBeat.start attribute.
