### PR TITLE
feat: tonic note highlighting on fretboard

### DIFF
--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -304,6 +304,7 @@ fretboard.string-color=String Color
 fretboard.fretpoint-color=Fret Color
 fretboard.note-color=Note Color
 fretboard.scale-note-color=Scale Note Color
+fretboard.tonic-color=Tonic Note Color
 fretboard.direction=Direction
 fretboard.right-mode=Right Mode
 fretboard.left-mode=Left Mode

--- a/common/resources/lang/messages_bg.properties
+++ b/common/resources/lang/messages_bg.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Цвят на струна
 fretboard.fretpoint-color=Цвят на прагче
 fretboard.note-color=Цвят на нота
 # fretboard.scale-note-color=
+# fretboard.tonic-color=
 fretboard.direction=Посока
 fretboard.right-mode=Десен режим
 fretboard.left-mode=Ляв режим

--- a/common/resources/lang/messages_ca.properties
+++ b/common/resources/lang/messages_ca.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Color de cordes
 fretboard.fretpoint-color=Color dels marcadors de posició
 fretboard.note-color=Color de les notes
 fretboard.scale-note-color=Color de les notes d'escala
+# fretboard.tonic-color=
 fretboard.direction=Direcció
 fretboard.right-mode=Cap a la dreta
 fretboard.left-mode=Cap a l'esquerra

--- a/common/resources/lang/messages_cs.properties
+++ b/common/resources/lang/messages_cs.properties
@@ -161,6 +161,7 @@ toolbar.settings.delete=Odstranit
 # fretboard.fretpoint-color=
 # fretboard.note-color=
 # fretboard.scale-note-color=
+# fretboard.tonic-color=
 # fretboard.direction=
 fretboard.right-mode=Pravý mód
 fretboard.left-mode=Levý mód

--- a/common/resources/lang/messages_de.properties
+++ b/common/resources/lang/messages_de.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Saitenfarbe
 fretboard.fretpoint-color=Bundfarbe
 fretboard.note-color=Notenfarbe
 fretboard.scale-note-color=Skalenfarbe
+# fretboard.tonic-color=
 fretboard.direction=Händigkeit
 fretboard.right-mode=Rechtshänder
 fretboard.left-mode=Linkshänder

--- a/common/resources/lang/messages_el.properties
+++ b/common/resources/lang/messages_el.properties
@@ -161,6 +161,7 @@ fretboard.string-color=String Χρώμα
 fretboard.fretpoint-color=Fret Χρώμα
 fretboard.note-color=Χρώμα Νότας
 fretboard.scale-note-color=Χρώμα Κλίμακας Νότας
+# fretboard.tonic-color=
 fretboard.direction=Κατεύθυνση
 fretboard.right-mode=Χρήση από δεξιά
 fretboard.left-mode=Χρήση από αριστερά

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Color de cuerdas
 fretboard.fretpoint-color=Color de marcadores de posición
 fretboard.note-color=Color de notas
 fretboard.scale-note-color=Color de notas de escala
+# fretboard.tonic-color=
 fretboard.direction=Dirección
 fretboard.right-mode=Hacia la derecha
 fretboard.left-mode=Hacia la izquierda

--- a/common/resources/lang/messages_eu.properties
+++ b/common/resources/lang/messages_eu.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Harien Koloreak
 fretboard.fretpoint-color=Posizio markaren kolorea
 fretboard.note-color=Noten kolorea
 fretboard.scale-note-color=Eskalako Noten Koloreak
+# fretboard.tonic-color=
 fretboard.direction=Norabidea
 fretboard.right-mode=Eskubira
 fretboard.left-mode=Ezkerrera

--- a/common/resources/lang/messages_fi.properties
+++ b/common/resources/lang/messages_fi.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Nauhan väri
 fretboard.fretpoint-color=Otelaudan väri
 fretboard.note-color=Nuotin väri
 fretboard.scale-note-color=Soitettavan/valitun nuotin väri
+# fretboard.tonic-color=
 fretboard.direction=Suunta
 fretboard.right-mode=Oikeakätinen
 fretboard.left-mode=Vasenkätinen

--- a/common/resources/lang/messages_fr.properties
+++ b/common/resources/lang/messages_fr.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Couleur des cordes
 fretboard.fretpoint-color=Couleur des repères
 fretboard.note-color=Couleur des notes
 fretboard.scale-note-color=Couleur des notes de la gamme
+# fretboard.tonic-color=
 fretboard.direction=Sens
 fretboard.right-mode=Mode droitier
 fretboard.left-mode=Mode gaucher

--- a/common/resources/lang/messages_hu.properties
+++ b/common/resources/lang/messages_hu.properties
@@ -161,6 +161,7 @@ toolbar.settings.delete=Törlés
 # fretboard.fretpoint-color=
 # fretboard.note-color=
 # fretboard.scale-note-color=
+# fretboard.tonic-color=
 # fretboard.direction=
 fretboard.right-mode=Jobbkezes
 fretboard.left-mode=Balkezes

--- a/common/resources/lang/messages_it.properties
+++ b/common/resources/lang/messages_it.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Colore stringa
 fretboard.fretpoint-color=Colore manico
 fretboard.note-color=Colore nota
 fretboard.scale-note-color=Colore nota scala
+# fretboard.tonic-color=
 fretboard.direction=Lateralità
 fretboard.right-mode=Modo destro
 fretboard.left-mode=Modo sinistro

--- a/common/resources/lang/messages_ja.properties
+++ b/common/resources/lang/messages_ja.properties
@@ -161,6 +161,7 @@ fretboard.string-color=弦
 fretboard.fretpoint-color=ポジション・マーク
 fretboard.note-color=音名
 fretboard.scale-note-color=スケール
+# fretboard.tonic-color=
 fretboard.direction=方向
 fretboard.right-mode=ライト
 fretboard.left-mode=レフト

--- a/common/resources/lang/messages_ko.properties
+++ b/common/resources/lang/messages_ko.properties
@@ -161,6 +161,7 @@ fretboard.settings=지판 설정
 # fretboard.fretpoint-color=
 # fretboard.note-color=
 # fretboard.scale-note-color=
+# fretboard.tonic-color=
 fretboard.direction=방향
 # fretboard.right-mode=
 # fretboard.left-mode=

--- a/common/resources/lang/messages_lt.properties
+++ b/common/resources/lang/messages_lt.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Stygų spalva
 fretboard.fretpoint-color=Grifo spalva
 fretboard.note-color=Natos spalva
 fretboard.scale-note-color=Penklinės lapo spalva
+# fretboard.tonic-color=
 fretboard.direction=Kryptis
 fretboard.right-mode=Dešniarankiams
 fretboard.left-mode=Kairiarankiams

--- a/common/resources/lang/messages_nl.properties
+++ b/common/resources/lang/messages_nl.properties
@@ -161,6 +161,7 @@ fretboard.string-color=String Kleur
 fretboard.fretpoint-color=Fret Kleur
 fretboard.note-color=Noot Kleur
 fretboard.scale-note-color=Noten Scale Kleur
+# fretboard.tonic-color=
 # fretboard.direction=
 fretboard.right-mode=Rechter modus
 fretboard.left-mode=Linker modus

--- a/common/resources/lang/messages_pl.properties
+++ b/common/resources/lang/messages_pl.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Kolor struny
 fretboard.fretpoint-color=Kolor progu
 fretboard.note-color=Kolor nuty
 fretboard.scale-note-color=Kolor nuty skali
+# fretboard.tonic-color=
 fretboard.direction=Kierunek
 fretboard.right-mode=Praworęczna
 fretboard.left-mode=Leworęczna

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Cor das cordas
 fretboard.fretpoint-color=Cor dos Frets
 fretboard.note-color=Cor das notas
 fretboard.scale-note-color=Cor das notas de escala
+# fretboard.tonic-color=
 fretboard.direction=Direção
 fretboard.right-mode=Modo Destro
 fretboard.left-mode=Modo Canhoto

--- a/common/resources/lang/messages_ru.properties
+++ b/common/resources/lang/messages_ru.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Цвет струн
 fretboard.fretpoint-color=Цвет ладов
 fretboard.note-color=Цвет нот
 fretboard.scale-note-color=Цвет нот гаммы
+# fretboard.tonic-color=
 fretboard.direction=Направление
 fretboard.right-mode=Слева направо
 fretboard.left-mode=Справа налево

--- a/common/resources/lang/messages_sr.properties
+++ b/common/resources/lang/messages_sr.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Boja žice
 fretboard.fretpoint-color=Boja praga
 fretboard.note-color=Boja note
 fretboard.scale-note-color=Boja skale
+# fretboard.tonic-color=
 # fretboard.direction=
 fretboard.right-mode=Desnoruka
 fretboard.left-mode=Levoruka

--- a/common/resources/lang/messages_sv.properties
+++ b/common/resources/lang/messages_sv.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Strängfärg
 fretboard.fretpoint-color=Färg på greppband
 fretboard.note-color=Notfärg
 fretboard.scale-note-color=Färg på not i skala
+# fretboard.tonic-color=
 fretboard.direction=Riktning
 fretboard.right-mode=Högerhänt läge
 fretboard.left-mode=Vänsterhänt läge

--- a/common/resources/lang/messages_uk.properties
+++ b/common/resources/lang/messages_uk.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Колір струн
 fretboard.fretpoint-color=Колір ладів
 fretboard.note-color=Колір нот
 fretboard.scale-note-color=Колір нот ладів
+# fretboard.tonic-color=
 # fretboard.direction=
 fretboard.right-mode=Правша
 fretboard.left-mode=Лівша

--- a/common/resources/lang/messages_vi.properties
+++ b/common/resources/lang/messages_vi.properties
@@ -161,6 +161,7 @@ fretboard.string-color=Màu dây
 fretboard.fretpoint-color=Màu phím đàn
 fretboard.note-color=Màu nốt
 fretboard.scale-note-color=Màu nốt thuộc âm giai
+# fretboard.tonic-color=
 # fretboard.direction=
 fretboard.right-mode=Tay phải
 fretboard.left-mode=Tay trái

--- a/common/resources/lang/messages_zh_CN.properties
+++ b/common/resources/lang/messages_zh_CN.properties
@@ -161,6 +161,7 @@ fretboard.string-color=琴弦颜色
 fretboard.fretpoint-color=字体颜色
 fretboard.note-color=音符颜色
 fretboard.scale-note-color=音阶音符颜色
+# fretboard.tonic-color=
 fretboard.direction=方向
 fretboard.right-mode=右手
 fretboard.left-mode=左手

--- a/common/resources/lang/messages_zh_TW.properties
+++ b/common/resources/lang/messages_zh_TW.properties
@@ -161,6 +161,7 @@ fretboard.string-color=琴絃的顏色
 fretboard.fretpoint-color=琴格顏色
 fretboard.note-color=音符顏色
 fretboard.scale-note-color=音階的音符顏色
+# fretboard.tonic-color=
 fretboard.direction=方式
 fretboard.right-mode=右手琴
 fretboard.left-mode=左手琴

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigDefaults.java
@@ -98,6 +98,7 @@ public class TGConfigDefaults{
 		loadProperty(properties, TGConfigKeys.FRETBOARD_COLOR_FRET_POINT, "192,192,192");
 		loadProperty(properties, TGConfigKeys.FRETBOARD_COLOR_NOTE, "42,85,128");
 		loadProperty(properties, TGConfigKeys.FRETBOARD_COLOR_SCALE, "128,32,32");
+		loadProperty(properties, TGConfigKeys.FRETBOARD_COLOR_TONIC, "0,0,0");
 		loadProperty(properties, TGConfigKeys.FRETBOARD_DIRECTION, TGFretBoardConfig.DIRECTION_RIGHT);
 		loadProperty(properties, TGConfigKeys.PIANO_COLOR_KEY_NATURAL, "255,255,255");
 		loadProperty(properties, TGConfigKeys.PIANO_COLOR_KEY_NOT_NATURAL, "0,0,0");

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/system/config/TGConfigKeys.java
@@ -70,6 +70,7 @@ public class TGConfigKeys {
 	public static final String FRETBOARD_COLOR_FRET_POINT = "fretboard.color.fret-point";
 	public static final String FRETBOARD_COLOR_NOTE = "fretboard.color.note";
 	public static final String FRETBOARD_COLOR_SCALE = "fretboard.color.scale";
+	public static final String FRETBOARD_COLOR_TONIC = "fretboard.color.tonic";
 	public static final String FRETBOARD_DIRECTION = "fretboard.direction";
 	public static final String PIANO_COLOR_KEY_NATURAL = "piano.color.natural-key";
 	public static final String PIANO_COLOR_KEY_NOT_NATURAL = "piano.color.not-natural-key";

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/fretboard/TGFretBoard.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/fretboard/TGFretBoard.java
@@ -442,6 +442,7 @@ public class TGFretBoard {
 		TGTrack track = getTrack();
 		TGScale scale = TuxGuitar.getInstance().getScaleManager().getScale();
 		int keySignature = TGMusicKeyUtils.getKeySignature(scale);
+		int tonicKey = scale.getKey();
 
 		for (int i = 0; i < this.strings.length; i++) {
 			TGString string = track.getString(i + 1);
@@ -455,12 +456,16 @@ public class TGFretBoard {
 					}
 					int y = this.strings[i];
 
+					boolean isTonic = ((noteValue % 12) == tonicKey);
+					UIColor ovalColor = isTonic ? this.config.getColorTonic() : this.config.getColorScale();
+
 					if( (this.config.getStyle() & TGFretBoardConfig.DISPLAY_TEXT_SCALE) != 0 ){
 						String noteName = TGMusicKeyUtils.noteName(noteValue, keySignature);
-						paintKeyText(painter,this.config.getColorScaleText(), this.config.getColorScale(),x,y,noteName);
+						UIColor textColor = isTonic ? this.config.getColorTonicText() : this.config.getColorScaleText();
+						paintKeyText(painter, textColor, ovalColor, x, y, noteName);
 					}
 					else{
-						paintKeyOval(painter,this.config.getColorScale(),x,y);
+						paintKeyOval(painter, ovalColor, x, y);
 					}
 				}
 			}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/fretboard/TGFretBoardConfig.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/dialog/fretboard/TGFretBoardConfig.java
@@ -54,8 +54,10 @@ public class TGFretBoardConfig {
 	private UIColor colorFretPoint;
 	private UIColor colorNote;
 	private UIColor colorScale;
+	private UIColor colorTonic;
 	private UIColor colorNoteText;
 	private UIColor colorScaleText;
+	private UIColor colorTonicText;
 
 	public TGFretBoardConfig(TGContext context){
 		this.context = context;
@@ -89,12 +91,20 @@ public class TGFretBoardConfig {
 		return this.colorScale;
 	}
 
+	public UIColor getColorTonic() {
+		return this.colorTonic;
+	}
+
 	public UIColor getColorNoteText() {
 		return colorNoteText;
 	}
 
 	public UIColor getColorScaleText() {
 		return colorScaleText;
+	}
+
+	public UIColor getColorTonicText() {
+		return colorTonicText;
 	}
 
 	public int getDirection(){
@@ -120,8 +130,10 @@ public class TGFretBoardConfig {
 		this.colorFretPoint = createColor(factory,config.getColorModelConfigValue(TGConfigKeys.FRETBOARD_COLOR_FRET_POINT));
 		this.colorNote = createColor(factory,config.getColorModelConfigValue(TGConfigKeys.FRETBOARD_COLOR_NOTE));
 		this.colorScale = createColor(factory,config.getColorModelConfigValue(TGConfigKeys.FRETBOARD_COLOR_SCALE));
+		this.colorTonic = createColor(factory,config.getColorModelConfigValue(TGConfigKeys.FRETBOARD_COLOR_TONIC));
 		this.colorNoteText = createColor(factory, this.colorForeground(this.colorNote));
 		this.colorScaleText = createColor(factory, this.colorForeground(this.colorScale));
+		this.colorTonicText = createColor(factory, this.colorForeground(this.colorTonic));
 	}
 
 	private UIColorModel colorForeground(UIColor colorBackground) {
@@ -143,9 +155,10 @@ public class TGFretBoardConfig {
 		config.setValue(TGConfigKeys.FRETBOARD_COLOR_FRET_POINT,defaults.getValue(TGConfigKeys.FRETBOARD_COLOR_FRET_POINT));
 		config.setValue(TGConfigKeys.FRETBOARD_COLOR_NOTE,defaults.getValue(TGConfigKeys.FRETBOARD_COLOR_NOTE));
 		config.setValue(TGConfigKeys.FRETBOARD_COLOR_SCALE,defaults.getValue(TGConfigKeys.FRETBOARD_COLOR_SCALE));
+		config.setValue(TGConfigKeys.FRETBOARD_COLOR_TONIC,defaults.getValue(TGConfigKeys.FRETBOARD_COLOR_TONIC));
 	}
 
-	public void save(int style, int direction, UIFontModel fm, UIColorModel rgbBackground, UIColorModel rgbString, UIColorModel rgbFretPoint, UIColorModel rgbNote, UIColorModel rgbScale){
+	public void save(int style, int direction, UIFontModel fm, UIColorModel rgbBackground, UIColorModel rgbString, UIColorModel rgbFretPoint, UIColorModel rgbNote, UIColorModel rgbScale, UIColorModel rgbTonic){
 		TGConfigManager config = TuxGuitar.getInstance().getConfig();
 		config.setValue(TGConfigKeys.FRETBOARD_STYLE,style);
 		config.setValue(TGConfigKeys.FRETBOARD_DIRECTION,direction);
@@ -155,6 +168,7 @@ public class TGFretBoardConfig {
 		config.setValue(TGConfigKeys.FRETBOARD_COLOR_FRET_POINT,rgbFretPoint);
 		config.setValue(TGConfigKeys.FRETBOARD_COLOR_NOTE,rgbNote);
 		config.setValue(TGConfigKeys.FRETBOARD_COLOR_SCALE,rgbScale);
+		config.setValue(TGConfigKeys.FRETBOARD_COLOR_TONIC,rgbTonic);
 	}
 
 	public void saveDirection( int direction ){
@@ -171,8 +185,10 @@ public class TGFretBoardConfig {
 		this.colorFretPoint.dispose();
 		this.colorNote.dispose();
 		this.colorScale.dispose();
+		this.colorTonic.dispose();
 		this.colorNoteText.dispose();
 		this.colorScaleText.dispose();
+		this.colorTonicText.dispose();
 	}
 
 	public void configure(UIWindow parent, boolean isPercussion) {
@@ -199,6 +215,7 @@ public class TGFretBoardConfig {
 		final UIColorModel rgbFretPoint = getColorChooser(window, group, TuxGuitar.getProperty("fretboard.fretpoint-color") + ":", this.colorFretPoint, ++groupRow);
 		final UIColorModel rgbNote = getColorChooser(window, group, TuxGuitar.getProperty("fretboard.note-color") + ":", this.colorNote, ++groupRow);
 		final UIColorModel rgbScale = getColorChooser(window, group, TuxGuitar.getProperty("fretboard.scale-note-color") + ":", this.colorScale, ++groupRow);
+		final UIColorModel rgbTonic = getColorChooser(window, group, TuxGuitar.getProperty("fretboard.tonic-color") + ":", this.colorTonic, ++groupRow);
 
 
 		UILabel directionLabel = factory.createLabel(group);
@@ -263,7 +280,7 @@ public class TGFretBoardConfig {
 
 				window.dispose();
 
-				save(style, direction, fontData, rgbBackground, rgbString, rgbFretPoint, rgbNote, rgbScale);
+				save(style, direction, fontData, rgbBackground, rgbString, rgbFretPoint, rgbNote, rgbScale, rgbTonic);
 				applyChanges();
 			}
 		});


### PR DESCRIPTION
- New config key: fretboard.color.tonic (default 0,0,0 — same as fretboard)
- Tonic note in selected scale rendered with distinct color
- 'Tonic Note Color' picker in Fretboard Settings dialog
- Applied to both oval and text rendering modes
- Translations for all 25 locales

<img width="1226" height="348" alt="image" src="https://github.com/user-attachments/assets/c1ebc4bd-7be7-469e-afbf-0ff6bf0f04b9" />
<img width="393" height="507" alt="image" src="https://github.com/user-attachments/assets/52316fe7-0048-4efa-bef0-0d0cb05dbbb0" />
