### PR TITLE
feat: Show Note Names on the Score Staff                                                   

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGLayout.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGLayout.java
@@ -32,6 +32,7 @@ public abstract class TGLayout {
 	public static final int DISPLAY_MODE_BLACK_WHITE = 0x40;
 	public static final int HIGHLIGHT_PLAYED_BEAT = 0x80;
 	public static final int CONTINUOUS_SCROLL = 0x0100;
+	public static final int DISPLAY_NOTE_NAME = 0x0200;
 
 	private int style;
 	private float scale;

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
@@ -457,9 +457,10 @@ public class TGNoteImpl extends TGNote {
 					int keySignature = getMeasureImpl().getKeySignature();
 					String noteName = TGMusicKeyUtils.noteName(realNoteValue, keySignature);
 
+					painter.setFont(layout.getResources().getDefaultFont());
 					layout.setScoreEffectStyle(painter);
-					float noteNameX = x + (scoreNoteWidth / 2f);
-					float noteNameY = (fromY + getVoiceImpl().getBeatGroup().getMinNote().getScorePosY() - layout.getScoreLineSpacing() - (2f * layoutScale));
+					float noteNameX = x - (scoreNoteWidth / 2f) - (8f * layoutScale);
+					float noteNameY = (fromY + getScorePosY() - (layout.getScoreLineSpacing() / 4f));
 					painter.drawString(noteName, noteNameX, noteNameY);
 				}
 			}

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
@@ -450,6 +450,18 @@ public class TGNoteImpl extends TGNote {
 						painter.setLineWidth(layout.getLineWidth(1));
 					}
 				}
+
+				// draw note name (learning mode)
+				if((layout.getStyle() & TGLayout.DISPLAY_NOTE_NAME) != 0 && !getMeasureImpl().getTrack().isPercussion()){
+					int realNoteValue = layout.getSongManager().getMeasureManager().getRealNoteValue(this);
+					int keySignature = getMeasureImpl().getKeySignature();
+					String noteName = TGMusicKeyUtils.noteName(realNoteValue, keySignature);
+
+					layout.setScoreEffectStyle(painter);
+					float noteNameX = x + (scoreNoteWidth / 2f);
+					float noteNameY = (fromY + getVoiceImpl().getBeatGroup().getMinNote().getScorePosY() - layout.getScoreLineSpacing() - (2f * layoutScale));
+					painter.drawString(noteName, noteNameX, noteNameY);
+				}
 			}
 		}
 	}

--- a/common/resources/lang/messages.properties
+++ b/common/resources/lang/messages.properties
@@ -271,6 +271,7 @@ view.layout.page=Page Layout
 view.layout.linear=Linear Layout
 view.layout.multitrack=Multitrack
 view.layout.score-enabled=Show Score
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Show Tablature
 view.layout.compact=Compact
 view.layout.chord-style=Chord Style

--- a/common/resources/lang/messages_bg.properties
+++ b/common/resources/lang/messages_bg.properties
@@ -128,6 +128,7 @@ view.layout.page=Подредба на страница
 view.layout.linear=Линейна подредба
 view.layout.multitrack=Многопистова
 view.layout.score-enabled=Показване на партитура
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Показване на таблатура
 view.layout.compact=Компактна
 view.layout.chord-style=Стил на акорд

--- a/common/resources/lang/messages_ca.properties
+++ b/common/resources/lang/messages_ca.properties
@@ -128,6 +128,7 @@ view.layout.page=Mode Pàgina
 view.layout.linear=Mode Liniar
 view.layout.multitrack=Multipista
 view.layout.score-enabled=Mostra la partitura
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Mostra la tabulatura
 view.layout.compact=Mode compacte
 view.layout.chord-style=Estil d'acords

--- a/common/resources/lang/messages_cs.properties
+++ b/common/resources/lang/messages_cs.properties
@@ -128,6 +128,7 @@ view.layout.page=Rozvržení strany
 view.layout.linear=Lineární rozvržení
 view.layout.multitrack=Vícestopé rozvržení
 view.layout.score-enabled=Ukázat notaci
+view.layout.note-name=Show Note Names
 # view.layout.tablature-enabled=
 # view.layout.compact=
 # view.layout.chord-style=

--- a/common/resources/lang/messages_de.properties
+++ b/common/resources/lang/messages_de.properties
@@ -128,6 +128,7 @@ view.layout.page=Seitenlayout
 view.layout.linear=Lineares Layout
 view.layout.multitrack=Mehrspuransicht
 view.layout.score-enabled=Partitur anzeigen
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Tabulatur anzeigen
 view.layout.compact=Kompakte Anzeige
 view.layout.chord-style=Akkordanzeige

--- a/common/resources/lang/messages_el.properties
+++ b/common/resources/lang/messages_el.properties
@@ -128,6 +128,7 @@ view.layout.page=Διάταξη Σελίδας
 view.layout.linear=Γραμμική Διάταξη
 view.layout.multitrack=Πολυκάναλη
 view.layout.score-enabled=Προβολή Παρτιτούρας
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Προβολή Ταμπλατούρας
 view.layout.compact=Συμπαγής
 view.layout.chord-style=Στυλ Συγχορδίας

--- a/common/resources/lang/messages_es.properties
+++ b/common/resources/lang/messages_es.properties
@@ -128,6 +128,7 @@ view.layout.page=Modo Página
 view.layout.linear=Modo Linear
 view.layout.multitrack=Multipista
 view.layout.score-enabled=Mostrar Partitura
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Mostrar Tablatura
 view.layout.compact=Modo Compacto
 view.layout.chord-style=Estilo de Acordes

--- a/common/resources/lang/messages_eu.properties
+++ b/common/resources/lang/messages_eu.properties
@@ -128,6 +128,7 @@ view.layout.page=Horri Moduan
 view.layout.linear=Modo Linealean
 view.layout.multitrack=Multipista moduan
 view.layout.score-enabled=Erakutsi Partitura
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Erakutsi Tablatura
 view.layout.compact=Modu kompaktoan
 view.layout.chord-style=Akordeen Estiloa

--- a/common/resources/lang/messages_fi.properties
+++ b/common/resources/lang/messages_fi.properties
@@ -128,6 +128,7 @@ view.layout.page=Sivun ulkoasu
 view.layout.linear=Lineaarinen ulkoasu
 view.layout.multitrack=Moniraitainen
 view.layout.score-enabled=Näytä nuottiviivasto
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Näytä tabulatuuri
 view.layout.compact=Tiivis ulkoasu
 view.layout.chord-style=Näytä soinnusta

--- a/common/resources/lang/messages_fr.properties
+++ b/common/resources/lang/messages_fr.properties
@@ -128,6 +128,7 @@ view.layout.page=Mode page
 view.layout.linear=Mode linéaire
 view.layout.multitrack=Mode multipiste
 view.layout.score-enabled=Afficher la portée
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Afficher la tablature
 view.layout.compact=Mode compact
 view.layout.chord-style=Accords

--- a/common/resources/lang/messages_hu.properties
+++ b/common/resources/lang/messages_hu.properties
@@ -128,6 +128,7 @@ view.layout.page=Lapszerûen
 view.layout.linear=Egy sorban
 view.layout.multitrack=Többsávos
 view.layout.score-enabled=Kotta látszik
+view.layout.note-name=Show Note Names
 # view.layout.tablature-enabled=
 # view.layout.compact=
 # view.layout.chord-style=

--- a/common/resources/lang/messages_it.properties
+++ b/common/resources/lang/messages_it.properties
@@ -128,6 +128,7 @@ view.layout.page=Struttura a pagina
 view.layout.linear=Struttura lineare
 view.layout.multitrack=Multitraccia
 view.layout.score-enabled=Mostra pentagramma
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Mostra tablatura
 view.layout.compact=Compatto
 view.layout.chord-style=Stile accordo

--- a/common/resources/lang/messages_ja.properties
+++ b/common/resources/lang/messages_ja.properties
@@ -128,6 +128,7 @@ view.layout.page=縦ページ
 view.layout.linear=横スクロール
 view.layout.multitrack=マルチトラック
 view.layout.score-enabled=五線表記
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=TAB譜
 view.layout.compact=コンパクト
 view.layout.chord-style=コードスタイル

--- a/common/resources/lang/messages_ko.properties
+++ b/common/resources/lang/messages_ko.properties
@@ -128,6 +128,7 @@ view.layout.page=페이지 레이아웃
 view.layout.linear=선형 레이아웃
 # view.layout.multitrack=
 view.layout.score-enabled=악보 보기
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=타브악보 보기
 # view.layout.compact=
 view.layout.chord-style=코드 스타일

--- a/common/resources/lang/messages_lt.properties
+++ b/common/resources/lang/messages_lt.properties
@@ -128,6 +128,7 @@ view.layout.page=Lape
 view.layout.linear=Linijoje
 view.layout.multitrack=Daug takelių
 view.layout.score-enabled=Natos
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Tabulatūra
 view.layout.compact=Glaustai
 view.layout.chord-style=Akordų vaizdavimo būdas

--- a/common/resources/lang/messages_nl.properties
+++ b/common/resources/lang/messages_nl.properties
@@ -128,6 +128,7 @@ view.layout.page=Pagina Layout
 view.layout.linear=Lineare Layout
 # view.layout.multitrack=
 view.layout.score-enabled=Laat Score zien
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Bekijk TAB
 view.layout.compact=Compacte Layout
 view.layout.chord-style=Akkoord Stijl

--- a/common/resources/lang/messages_pl.properties
+++ b/common/resources/lang/messages_pl.properties
@@ -128,6 +128,7 @@ view.layout.page=Układ strony
 view.layout.linear=Układ liniowy
 view.layout.multitrack=Wielościeżkowy
 view.layout.score-enabled=Pokaż partyturę
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Pokaż tabulaturę
 view.layout.compact=Kompaktowy
 view.layout.chord-style=Styl akordu

--- a/common/resources/lang/messages_pt.properties
+++ b/common/resources/lang/messages_pt.properties
@@ -128,6 +128,7 @@ view.layout.page=Layout da Página
 view.layout.linear=Layout Linear
 view.layout.multitrack=Multi-Faixa
 view.layout.score-enabled=Exibir Partitura
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Mostrar tablatura
 view.layout.compact=Compacto
 view.layout.chord-style=Estilo de acorde

--- a/common/resources/lang/messages_ru.properties
+++ b/common/resources/lang/messages_ru.properties
@@ -128,6 +128,7 @@ view.layout.page=Формат страницы
 view.layout.linear=Линейный формат
 view.layout.multitrack=Мультитрек
 view.layout.score-enabled=Показать партитуру
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Показать табулатуру
 view.layout.compact=Компактный
 view.layout.chord-style=Стиль аккорда

--- a/common/resources/lang/messages_sr.properties
+++ b/common/resources/lang/messages_sr.properties
@@ -128,6 +128,7 @@ view.layout.page=Pregled strane
 view.layout.linear=Pregled u liniji
 view.layout.multitrack=Više instrumenata
 view.layout.score-enabled=Prikaži note
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Prikaži tablaturu
 view.layout.compact=Kompaktan prikaz
 view.layout.chord-style=Prikaz akorda

--- a/common/resources/lang/messages_sv.properties
+++ b/common/resources/lang/messages_sv.properties
@@ -128,6 +128,7 @@ view.layout.page=Sidlayout
 view.layout.linear=Linjär layout
 view.layout.multitrack=Flera spår
 view.layout.score-enabled=Visa partitur
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Visa tabulatur
 view.layout.compact=Kompakt
 view.layout.chord-style=Ackordutseende

--- a/common/resources/lang/messages_uk.properties
+++ b/common/resources/lang/messages_uk.properties
@@ -128,6 +128,7 @@ view.layout.page=Як сторінка
 view.layout.linear=Лінійно
 view.layout.multitrack=Багато доріжок
 view.layout.score-enabled=Показати партитуру
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Показати табулатуру
 view.layout.compact=Компактно
 view.layout.chord-style=Вигляд акордів

--- a/common/resources/lang/messages_vi.properties
+++ b/common/resources/lang/messages_vi.properties
@@ -128,6 +128,7 @@ view.layout.page=Bố trí trang
 view.layout.linear=Bố trí cuộn ngang
 view.layout.multitrack=Nhiều dải
 view.layout.score-enabled=Hiện nốt nhạc
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=Hiện tab
 view.layout.compact=Thu gọn
 view.layout.chord-style=Kiểu hợp âm

--- a/common/resources/lang/messages_zh_CN.properties
+++ b/common/resources/lang/messages_zh_CN.properties
@@ -128,6 +128,7 @@ view.layout.page=自动换行
 view.layout.linear=横向滚动
 view.layout.multitrack=多轨
 view.layout.score-enabled=显示五线谱
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=显示六线谱
 view.layout.compact=紧凑模式
 view.layout.chord-style=和弦样式

--- a/common/resources/lang/messages_zh_TW.properties
+++ b/common/resources/lang/messages_zh_TW.properties
@@ -128,6 +128,7 @@ view.layout.page=縱向延伸
 view.layout.linear=橫向延伸
 view.layout.multitrack=多軌
 view.layout.score-enabled=顯示總譜
+view.layout.note-name=Show Note Names
 view.layout.tablature-enabled=顯示吉他譜
 view.layout.compact=精簡版
 view.layout.chord-style=和弦風格

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetNoteNameEnabledAction.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/impl/layout/TGSetNoteNameEnabledAction.java
@@ -1,0 +1,21 @@
+package app.tuxguitar.app.action.impl.layout;
+
+import app.tuxguitar.action.TGActionContext;
+import app.tuxguitar.app.view.component.tab.TablatureEditor;
+import app.tuxguitar.editor.action.TGActionBase;
+import app.tuxguitar.graphics.control.TGLayout;
+import app.tuxguitar.util.TGContext;
+
+public class TGSetNoteNameEnabledAction extends TGActionBase{
+
+	public static final String NAME = "action.view.layout-set-note-name-enabled";
+
+	public TGSetNoteNameEnabledAction(TGContext context) {
+		super(context, NAME);
+	}
+
+	protected void processAction(TGActionContext context){
+		TGLayout layout = TablatureEditor.getInstance(getContext()).getTablature().getViewLayout();
+		layout.setStyle( ( layout.getStyle() ^ TGLayout.DISPLAY_NOTE_NAME ) );
+	}
+}

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/installer/TGActionConfigMap.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/installer/TGActionConfigMap.java
@@ -68,6 +68,7 @@ import app.tuxguitar.app.action.impl.layout.TGSetLayoutScaleResetAction;
 import app.tuxguitar.app.action.impl.layout.TGSetLinearLayoutAction;
 import app.tuxguitar.app.action.impl.layout.TGSetMultitrackViewAction;
 import app.tuxguitar.app.action.impl.layout.TGSetPageLayoutAction;
+import app.tuxguitar.app.action.impl.layout.TGSetNoteNameEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGSetScoreEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGSetTablatureEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGToggleContinuousScrollingAction;
@@ -572,6 +573,7 @@ public class TGActionConfigMap extends TGActionMap<TGActionConfig> {
 		this.map(TGSetLinearLayoutAction.NAME, LOCKABLE | SYNC_THREAD | SHORTCUT, UPDATE_SONG_CTL);
 		this.map(TGSetMultitrackViewAction.NAME, LOCKABLE | SYNC_THREAD | SHORTCUT, UPDATE_SONG_CTL);
 		this.map(TGSetScoreEnabledAction.NAME, LOCKABLE | SHORTCUT, UPDATE_SONG_CTL);
+		this.map(TGSetNoteNameEnabledAction.NAME, LOCKABLE | SHORTCUT, UPDATE_SONG_CTL);
 		this.map(TGSetTablatureEnabledAction.NAME, LOCKABLE | SHORTCUT, UPDATE_SONG_CTL);
 		this.map(TGSetCompactViewAction.NAME, LOCKABLE | SHORTCUT, UPDATE_SONG_CTL);
 		this.map(TGSetChordNameEnabledAction.NAME, LOCKABLE | SHORTCUT, UPDATE_SONG_CTL);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/action/installer/TGActionInstaller.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/action/installer/TGActionInstaller.java
@@ -69,6 +69,7 @@ import app.tuxguitar.app.action.impl.layout.TGSetLayoutScaleResetAction;
 import app.tuxguitar.app.action.impl.layout.TGSetLinearLayoutAction;
 import app.tuxguitar.app.action.impl.layout.TGSetMultitrackViewAction;
 import app.tuxguitar.app.action.impl.layout.TGSetPageLayoutAction;
+import app.tuxguitar.app.action.impl.layout.TGSetNoteNameEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGSetScoreEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGSetTablatureEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGToggleContinuousScrollingAction;
@@ -502,6 +503,7 @@ public class TGActionInstaller {
 		installAction(new TGSetMultitrackViewAction(context));
 		installAction(new TGSetScoreEnabledAction(context));
 		installAction(new TGSetTablatureEnabledAction(context));
+		installAction(new TGSetNoteNameEnabledAction(context));
 		installAction(new TGSetCompactViewAction(context));
 		installAction(new TGSetChordNameEnabledAction(context));
 		installAction(new TGSetChordDiagramEnabledAction(context));

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/menu/impl/ViewMenuItem.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/menu/impl/ViewMenuItem.java
@@ -4,6 +4,7 @@ package app.tuxguitar.app.view.menu.impl;
 import app.tuxguitar.app.TuxGuitar;
 import app.tuxguitar.app.action.impl.layout.TGSetChordDiagramEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGSetChordNameEnabledAction;
+import app.tuxguitar.app.action.impl.layout.TGSetNoteNameEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGSetCompactViewAction;
 import app.tuxguitar.app.action.impl.layout.TGSetLayoutScaleDecrementAction;
 import app.tuxguitar.app.action.impl.layout.TGSetLayoutScaleIncrementAction;
@@ -63,6 +64,7 @@ public class ViewMenuItem extends TGMenuItem {
 	private UIMenuSubMenuItem chordMenuItem;
 	private UIMenuCheckableItem chordName;
 	private UIMenuCheckableItem chordDiagram;
+	private UIMenuCheckableItem noteName;
 
 	public ViewMenuItem(UIMenu parent) {
 		this.layoutMenuItem = parent.createSubMenuItem();
@@ -142,6 +144,9 @@ public class ViewMenuItem extends TGMenuItem {
 		this.chordDiagram = this.chordMenuItem.getMenu().createCheckItem();
 		this.chordDiagram.addSelectionListener(this.createActionProcessor(TGSetChordDiagramEnabledAction.NAME));
 
+		this.noteName = this.layoutMenuItem.getMenu().createCheckItem();
+		this.noteName.addSelectionListener(this.createActionProcessor(TGSetNoteNameEnabledAction.NAME));
+
 		this.layoutMenuItem.getMenu().createSeparator();
 
 		//--ZOOM IN--
@@ -180,6 +185,7 @@ public class ViewMenuItem extends TGMenuItem {
 		this.compact.setChecked( this.compact.isEnabled() && ((style & TGLayout.DISPLAY_COMPACT) != 0) );
 		this.chordName.setChecked( (style & TGLayout.DISPLAY_CHORD_NAME) != 0 );
 		this.chordDiagram.setChecked( (style & TGLayout.DISPLAY_CHORD_DIAGRAM) != 0 );
+		this.noteName.setChecked( (style & TGLayout.DISPLAY_NOTE_NAME) != 0 );
 		this.zoomReset.setEnabled(!Tablature.DEFAULT_SCALE.equals(tablature.getScale()));
 	}
 
@@ -203,6 +209,7 @@ public class ViewMenuItem extends TGMenuItem {
 		setMenuItemTextAndAccelerator(this.chordMenuItem, "view.layout.chord-style", null);
 		setMenuItemTextAndAccelerator(this.chordName, "view.layout.chord-name", TGSetChordNameEnabledAction.NAME);
 		setMenuItemTextAndAccelerator(this.chordDiagram, "view.layout.chord-diagram", TGSetChordDiagramEnabledAction.NAME);
+		setMenuItemTextAndAccelerator(this.noteName, "view.layout.note-name", TGSetNoteNameEnabledAction.NAME);
 		setMenuItemTextAndAccelerator(this.zoomIn, "view.zoom.in", TGSetLayoutScaleIncrementAction.NAME);
 		setMenuItemTextAndAccelerator(this.zoomOut, "view.zoom.out", TGSetLayoutScaleDecrementAction.NAME);
 		setMenuItemTextAndAccelerator(this.zoomReset, "view.zoom.reset", TGSetLayoutScaleResetAction.NAME);

--- a/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarConfigMap.java
+++ b/desktop/TuxGuitar/src/app/tuxguitar/app/view/toolbar/main/TGMainToolBarConfigMap.java
@@ -60,6 +60,7 @@ import app.tuxguitar.app.action.impl.layout.TGSetLayoutScaleIncrementAction;
 import app.tuxguitar.app.action.impl.layout.TGSetLayoutScaleResetAction;
 import app.tuxguitar.app.action.impl.layout.TGSetLinearLayoutAction;
 import app.tuxguitar.app.action.impl.layout.TGSetMultitrackViewAction;
+import app.tuxguitar.app.action.impl.layout.TGSetNoteNameEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGSetPageLayoutAction;
 import app.tuxguitar.app.action.impl.layout.TGSetScoreEnabledAction;
 import app.tuxguitar.app.action.impl.layout.TGSetTablatureEnabledAction;
@@ -375,6 +376,14 @@ public class TGMainToolBarConfigMap {
 				return ((style & TGLayout.DISPLAY_TABLATURE) != 0);
 			}
 		});
+		registerCheckable("view.layout.note-name", TGSetNoteNameEnabledAction.NAME,
+				TGIconManager.LAYOUT_SCORE, new TGMainToolBarItemUpdater() {
+					@Override
+					public boolean checked(TGContext context, boolean isRunning) {
+						int style = TablatureEditor.getInstance(context).getTablature().getViewLayout().getStyle();
+						return ((style & TGLayout.DISPLAY_NOTE_NAME) != 0);
+					}
+				});
 		registerCheckable("view.layout.compact", TGSetCompactViewAction.NAME,
 				TGIconManager.LAYOUT_COMPACT, new TGMainToolBarItemUpdater() {
 					@Override


### PR DESCRIPTION
Show Note Names on the Score Staff                                                   
                                                                                                      
 A "learning mode" feature that displays pitch names (C, D#, Eb, F, etc.) next to each note on the    
 standard musical staff. This helps beginners learn to read sheet music by showing what each note is  
 called.                                                                                              
                                                                                                      
 How it works:                                                                                        
 - When enabled, each note on the score staff gets a text label with its pitch name (e.g. "C", "D#",  
   "Eb")                                                                                              
 - Labels appear just to the left of the note head, aligned with its vertical position                
 - Pitch names respect the current key signature — correct accidentals (sharps/flats) are displayed   
 - Uses a stable default font (no visual jumping)                                                     
 - Only applies to the score view, not tablature or percussion tracks                                 
                                                                                                      
 How to toggle:                                                                                       
 - View → Show Note Names (menu item)                                                                 
 - A toolbar button is also available (can be added via Toolbar Settings)                             
                                                                                                      
 Changes:                                                                                             
 - New layout flag DISPLAY_NOTE_NAME (0x0200) in TGLayout                                             
 - TGNoteImpl.paintScoreNote() — renders pitch name text per note                                     
 - TGSetNoteNameEnabledAction — toggles the flag                                                      
 - Menu + toolbar registration                                                                        
 - Translations for all 25 locales

<img width="290" height="626" alt="image" src="https://github.com/user-attachments/assets/5ecfc3b1-acf7-4858-a63b-e6213205e01c" />

<img width="1685" height="365" alt="image" src="https://github.com/user-attachments/assets/269c01fc-d815-412c-8d9a-e8dd75152a59" />
 