### PR TITLE
Fix bug when importing chord in .gp or .gpx file

### DIFF
--- a/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentParser.java
+++ b/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentParser.java
@@ -323,17 +323,17 @@ public class GPXDocumentParser {
 							if (beat.getChordId() != null) {
 								GPXChord gpChord = this.document.getChord(beat.getChordId());
 								if (gpChord != null) {
-									TGChord chord = this.factory.newChord(gpChord.getFrets().length);
+									TGChord chord = this.factory.newChord(gpChord.getStringCount());
 									if (gpChord.getName() != null) {
 										chord.setName(gpChord.getName());
 									}
 									if (gpChord.getBaseFret() != null) {
 										chord.setFirstFret(gpChord.getBaseFret());
 									}
-									for (int f = 0; f < gpChord.getFrets().length; f++) {
-										Integer value = gpChord.getFrets()[f];
+									for (int s = 0; s < gpChord.getStringCount(); s++) {
+										Integer value = gpChord.getFrets()[s];
 										if (value != null) {
-											chord.addFretValue(f, value);
+											chord.addFretValue(s, value);
 										}
 									}
 									tgBeat.setChord(chord);

--- a/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentReader.java
+++ b/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentReader.java
@@ -226,12 +226,12 @@ public class GPXDocumentReader {
 										chord.setFretCount(getAttributeIntegerValue(diagramNode, "fretCount"));
 										chord.setBaseFret(getAttributeIntegerValue(diagramNode, "baseFret"));
 										if( chord.getFretCount() != null ) {
-											chord.setFrets(new Integer[chord.getFretCount()]);
+											chord.setFrets(new Integer[chord.getStringCount()]);
 											for( int f = 0 ; f < fretsNode.getLength() ; f ++ ){
 												Node fretNode = fretsNode.item( f );
 												if (fretNode.getNodeName().equals("Fret")) {
 													Integer string = getAttributeIntegerValue(fretNode, "string");
-													if( string != null && string > 0 && string <= chord.getFretCount() ) {
+													if( string != null && string > 0 && string <= chord.getStringCount() ) {
 														chord.getFrets()[string - 1] = getAttributeIntegerValue(fretNode, "fret");
 													}
 												}


### PR DESCRIPTION
fix #1139

mismatch between fret number and string number
To reproduce bug, open a .gp or .gpx file with a chord where lowest string is not played.
This lowest string was not shown in the tab by TuxGuitar