### PR TITLE
adaptation to a future evolution of apache commons-compress

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/io/tg/TGSongWriterImpl.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/io/tg/TGSongWriterImpl.java
@@ -77,7 +77,10 @@ public class TGSongWriterImpl extends TGStream implements TGSongWriter {
 			this.saveDocument(outputStream);
 			outputStream.closeArchiveEntry();
 			outputStream.close();
-		} catch (ArchiveException | IOException e) {
+		} catch (ArchiveException e) {
+			e.printStackTrace();
+			throw new TGFileFormatException(e);
+		} catch (IOException e) {
 			e.printStackTrace();
 			throw new TGFileFormatException(e);
 		}


### PR DESCRIPTION
Already patched in openSUSE packaging, see
https://build.opensuse.org/projects/openSUSE:Factory/packages/tuxguitar/files/tuxguitar-new-commons-compress.patch?expand=1

Rationale:
in newer apache-commons-compress, the
org.apache.commons.compress.archivers.ArchiveException is a subclass of java.io.IOException and thus they cannot be alternatives in a multi-catch statement.