### PR TITLE
fix GP chord diagram import (.gp and .gpx)

### DIFF
--- a/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentParser.java
+++ b/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentParser.java
@@ -333,7 +333,7 @@ public class GPXDocumentParser {
 									for (int s = 0; s < gpChord.getStringCount(); s++) {
 										Integer value = gpChord.getFrets()[s];
 										if (value != null) {
-											chord.addFretValue(s, value);
+											chord.addFretValue(gpChord.getStringCount() - s - 1, value + gpChord.getBaseFret());
 										}
 									}
 									tgBeat.setChord(chord);

--- a/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentReader.java
+++ b/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/GPXDocumentReader.java
@@ -223,21 +223,18 @@ public class GPXDocumentReader {
 										chord.setId(getAttributeIntegerValue(itemNode, "id"));
 										chord.setName(getAttributeValue(itemNode, "name"));
 										chord.setStringCount(getAttributeIntegerValue(diagramNode, "stringCount"));
-										chord.setFretCount(getAttributeIntegerValue(diagramNode, "fretCount"));
 										chord.setBaseFret(getAttributeIntegerValue(diagramNode, "baseFret"));
-										if( chord.getFretCount() != null ) {
-											chord.setFrets(new Integer[chord.getStringCount()]);
-											for( int f = 0 ; f < fretsNode.getLength() ; f ++ ){
-												Node fretNode = fretsNode.item( f );
-												if (fretNode.getNodeName().equals("Fret")) {
-													Integer string = getAttributeIntegerValue(fretNode, "string");
-													if( string != null && string > 0 && string <= chord.getStringCount() ) {
-														chord.getFrets()[string - 1] = getAttributeIntegerValue(fretNode, "fret");
-													}
+										chord.setFrets(new Integer[chord.getStringCount()]);
+										for( int f = 0 ; f < fretsNode.getLength() ; f ++ ){
+											Node fretNode = fretsNode.item( f );
+											if (fretNode.getNodeName().equals("Fret")) {
+												Integer string = getAttributeIntegerValue(fretNode, "string");
+												if( string != null && string < chord.getStringCount() ) {
+													chord.getFrets()[string] = getAttributeIntegerValue(fretNode, "fret");
 												}
 											}
-											this.gpxDocument.getChords().add(chord);
 										}
+										this.gpxDocument.getChords().add(chord);
 									}
 								}
 							}

--- a/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/score/GPXChord.java
+++ b/common/TuxGuitar-gpx/src/app/tuxguitar/io/gpx/score/GPXChord.java
@@ -5,7 +5,6 @@ public class GPXChord {
 	private int id;
 	private String name;
 	private Integer stringCount;
-	private Integer fretCount;
 	private Integer baseFret;
 	private Integer[] frets;
 
@@ -35,14 +34,6 @@ public class GPXChord {
 
 	public void setStringCount(Integer stringCount) {
 		this.stringCount = stringCount;
-	}
-
-	public Integer getFretCount() {
-		return fretCount;
-	}
-
-	public void setFretCount(Integer fretCount) {
-		this.fretCount = fretCount;
 	}
 
 	public Integer getBaseFret() {


### PR DESCRIPTION
- assuming "fretCount" attribute is the number of frets *drawn on the diagram* No more interpreted: this parameter is not configurable in TG
- order of strings in the diagram is reversed between GP and TG
- in GP file, value of fret is relative to baseFret, in TG it is an absolute value

GP file structure reverse-engineered from a few samples (it's not 100% reliable)

fix #1139