### PR TITLE
fix another issue with free edition mode

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGSongManager.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGSongManager.java
@@ -101,6 +101,19 @@ public class TGSongManager {
 		return false;
 	}
 
+	
+	// duration of one measure for all tracks OK?
+	public boolean areAllMeasuresValid(TGSong song, TGMeasureHeader header) {
+		boolean OK = true;
+		Iterator<TGTrack> tracks = song.getTracks();
+		while (tracks.hasNext()) {
+			TGTrack track = tracks.next();
+			OK &= getMeasureManager().isMeasureDurationValid(track.getMeasure(header.getNumber()-1));
+		}
+		return OK;
+	}
+	
+
 	public void setProperties(TGSong song, String name,String artist,String album,String author,String date,String copyright,String writer,String transcriber,String comments){
 		song.setName(name);
 		song.setArtist(artist);
@@ -470,8 +483,10 @@ public class TGSongManager {
 	}
 
 	public void changeTimeSignature(TGSong song, TGMeasureHeader header,TGTimeSignature timeSignature,boolean toEnd){
+		boolean movedNextHeader = false;
 		//asigno el nuevo ritmo
 		header.getTimeSignature().copyFrom(timeSignature);
+		autoCompleteSilences(song, header);
 
 		long nextStart = header.getStart() + header.getLength();
 		List<TGMeasureHeader> measures = getMeasureHeadersBeforeEnd(song, header.getStart() + 1);
@@ -479,15 +494,20 @@ public class TGSongManager {
 		while(it.hasNext()){
 			TGMeasureHeader nextHeader = it.next();
 			long theMove = nextStart - nextHeader.getStart();
-			if (!this.freeEditionMode) {
+			if (!this.freeEditionMode || areAllMeasuresValid(song, header)) {
 				moveMeasureHeader(nextHeader,theMove,0);
+				movedNextHeader = true;
 			}
 			if(toEnd){
 				nextHeader.getTimeSignature().copyFrom(timeSignature);
 			}
 			nextStart = nextHeader.getStart() + nextHeader.getLength();
 		}
-		if (!this.freeEditionMode) {
+		if (this.freeEditionMode) {
+			if (movedNextHeader) {
+				updatePreciseStart(song, header.getPreciseStart());
+			}
+		} else {
 			moveOutOfBoundsBeatsToNewMeasure(song, header.getStart());
 		}
 	}
@@ -900,6 +920,14 @@ public class TGSongManager {
 		while(it.hasNext()){
 			TGTrack track = it.next();
 			getTrackManager().autoCompleteSilences(track);
+		}
+	}
+
+	public void autoCompleteSilences(TGSong song, TGMeasureHeader header){
+		Iterator<TGTrack> it = song.getTracks();
+		while(it.hasNext()){
+			TGTrack track = it.next();
+			getMeasureManager().autoCompleteSilences(track.getMeasure(header.getNumber()-1));
 		}
 	}
 


### PR DESCRIPTION
bug scenario:
- song with 5 measures at 4/4
- put cursor in measure 2 and activate free edition mode
- set time signature *of measure 2 only* to 5/4

Everything looks OK on the screen, but `preciseStart` attribute of measures 3 to 5 are incorrect

Examples of visible consequences:
- impossible to select whole track by click&drag
- copy measure 2
- move cursor to measure 3, paste with paste count=2
  measure is only pasted once