### PR TITLE
Progressive bend

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGBendPath.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGBendPath.java
@@ -14,6 +14,8 @@ import app.tuxguitar.song.models.effects.TGEffectBend.BendPoint;
 public final class TGBendPath {
 
 	public static final int VALUE_FULL_TONE = 4;
+	/** Horizontal pixels per dialog time unit (0..12), so timing stays readable. */
+	public static final float WIDTH_PER_POSITION = 8.0f;
 
 	private static final String[] AMPLITUDE = {
 		"", "1/4", "1/2", "3/4", "1",
@@ -111,6 +113,10 @@ public final class TGBendPath {
 		}
 	}
 
+	public static float minimumWidth(float scale) {
+		return TGEffectBend.MAX_POSITION_LENGTH * WIDTH_PER_POSITION * scale;
+	}
+
 	public static String amplitudeLabel(int value) {
 		if (value <= 0 || value >= AMPLITUDE.length) {
 			return "";
@@ -133,8 +139,9 @@ public final class TGBendPath {
 		}
 
 		float usableWidth = geometry.xEnd - geometry.xStart;
-		if (usableWidth < 3.0f * geometry.scale) {
-			usableWidth = 3.0f * geometry.scale;
+		float minWidth = minimumWidth(geometry.scale);
+		if (usableWidth < minWidth) {
+			usableWidth = minWidth;
 		}
 
 		List<Vertex> vertices = new ArrayList<Vertex>();
@@ -214,7 +221,7 @@ public final class TGBendPath {
 		if (span <= 0) {
 			return geometry.yOpen;
 		}
-		float t = value / (float) VALUE_FULL_TONE;
+		float t = value / (float) TGEffectBend.MAX_VALUE_LENGTH;
 		if (t < 0f) {
 			t = 0f;
 		}

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGBendPath.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGBendPath.java
@@ -1,0 +1,236 @@
+package app.tuxguitar.graphics.control;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import app.tuxguitar.song.models.effects.TGEffectBend;
+import app.tuxguitar.song.models.effects.TGEffectBend.BendPoint;
+
+/**
+ * Maps a bend's time/pitch points onto the note duration box, for tablature drawing.
+ */
+public final class TGBendPath {
+
+	public static final int VALUE_FULL_TONE = 4;
+
+	private static final String[] AMPLITUDE = {
+		"", "1/4", "1/2", "3/4", "1",
+		"1\u00BC", "1\u00BD", "1\u00BE", "2",
+		"2\u00BC", "2\u00BD", "2\u00BE", "3"
+	};
+
+	private TGBendPath() {
+	}
+
+	public static final class Geometry {
+		public float xStart;
+		public float xEnd;
+		public float yOpen;
+		public float yFull;
+		public float yLabel;
+		public float scale;
+	}
+
+	public enum SegmentKind {
+		HOLD,
+		BEND_UP,
+		RELEASE
+	}
+
+	public static final class Vertex {
+		private final float x;
+		private final float y;
+		private final int position;
+		private final int value;
+
+		private Vertex(float x, float y, int position, int value) {
+			this.x = x;
+			this.y = y;
+			this.position = position;
+			this.value = value;
+		}
+
+		public float getX() {
+			return this.x;
+		}
+
+		public float getY() {
+			return this.y;
+		}
+
+		public int getPosition() {
+			return this.position;
+		}
+
+		public int getValue() {
+			return this.value;
+		}
+	}
+
+	public static final class Segment {
+		private final Vertex from;
+		private final Vertex to;
+		private final SegmentKind kind;
+		private final boolean arrowAtEnd;
+		private final boolean labelAtEnd;
+		private final boolean preBend;
+
+		private Segment(Vertex from, Vertex to, SegmentKind kind, boolean arrowAtEnd, boolean labelAtEnd, boolean preBend) {
+			this.from = from;
+			this.to = to;
+			this.kind = kind;
+			this.arrowAtEnd = arrowAtEnd;
+			this.labelAtEnd = labelAtEnd;
+			this.preBend = preBend;
+		}
+
+		public Vertex getFrom() {
+			return this.from;
+		}
+
+		public Vertex getTo() {
+			return this.to;
+		}
+
+		public SegmentKind getKind() {
+			return this.kind;
+		}
+
+		public boolean isArrowAtEnd() {
+			return this.arrowAtEnd;
+		}
+
+		public boolean isLabelAtEnd() {
+			return this.labelAtEnd;
+		}
+
+		public boolean isPreBend() {
+			return this.preBend;
+		}
+	}
+
+	public static String amplitudeLabel(int value) {
+		if (value <= 0 || value >= AMPLITUDE.length) {
+			return "";
+		}
+		return AMPLITUDE[value];
+	}
+
+	public static List<Segment> build(List<BendPoint> points, Geometry geometry) {
+		if (points == null || points.isEmpty() || geometry == null) {
+			return Collections.emptyList();
+		}
+
+		List<int[]> raw = copyAndCollapse(points);
+		if (raw.get(0)[0] > 0) {
+			raw.add(0, new int[] {0, raw.get(0)[1]});
+		}
+		int lastIndex = raw.size() - 1;
+		if (raw.get(lastIndex)[0] < TGEffectBend.MAX_POSITION_LENGTH) {
+			raw.add(new int[] {TGEffectBend.MAX_POSITION_LENGTH, raw.get(lastIndex)[1]});
+		}
+
+		float usableWidth = geometry.xEnd - geometry.xStart;
+		if (usableWidth < 3.0f * geometry.scale) {
+			usableWidth = 3.0f * geometry.scale;
+		}
+
+		List<Vertex> vertices = new ArrayList<Vertex>();
+		for (int[] point : raw) {
+			vertices.add(new Vertex(
+				mapX(point[0], geometry, usableWidth),
+				mapY(point[1], geometry),
+				point[0],
+				point[1]));
+		}
+
+		boolean preBend = vertices.get(0).getValue() > 0;
+		List<Segment> segments = new ArrayList<Segment>();
+		for (int i = 0; i < vertices.size() - 1; i++) {
+			Vertex from = vertices.get(i);
+			Vertex to = vertices.get(i + 1);
+			if (from.getPosition() == to.getPosition() && from.getValue() == to.getValue()) {
+				continue;
+			}
+			SegmentKind kind = kindOf(from.getValue(), to.getValue());
+			boolean last = (i == vertices.size() - 2);
+			int nextValue = last ? to.getValue() : vertices.get(i + 2).getValue();
+			boolean arrowAtEnd = false;
+			if (kind != SegmentKind.HOLD) {
+				int nextDelta = nextValue - to.getValue();
+				if (last || nextDelta == 0
+						|| (kind == SegmentKind.BEND_UP && nextDelta < 0)
+						|| (kind == SegmentKind.RELEASE && nextDelta > 0)) {
+					arrowAtEnd = true;
+				}
+			}
+			boolean labelAtEnd = (to.getValue() > from.getValue()) && (last || to.getValue() >= nextValue);
+			segments.add(new Segment(from, to, kind, arrowAtEnd, labelAtEnd, i == 0 && preBend));
+		}
+		return segments;
+	}
+
+	private static List<int[]> copyAndCollapse(List<BendPoint> points) {
+		List<int[]> raw = new ArrayList<int[]>();
+		for (BendPoint point : points) {
+			int position = clamp(point.getPosition(), 0, TGEffectBend.MAX_POSITION_LENGTH);
+			int value = clamp(point.getValue(), 0, TGEffectBend.MAX_VALUE_LENGTH);
+			raw.add(new int[] {position, value});
+		}
+		Collections.sort(raw, new Comparator<int[]>() {
+			public int compare(int[] a, int[] b) {
+				return Integer.compare(a[0], b[0]);
+			}
+		});
+		List<int[]> collapsed = new ArrayList<int[]>();
+		for (int[] point : raw) {
+			if (!collapsed.isEmpty() && collapsed.get(collapsed.size() - 1)[0] == point[0]) {
+				collapsed.get(collapsed.size() - 1)[1] = point[1];
+			} else {
+				collapsed.add(point);
+			}
+		}
+		return collapsed;
+	}
+
+	private static SegmentKind kindOf(int fromValue, int toValue) {
+		if (toValue > fromValue) {
+			return SegmentKind.BEND_UP;
+		}
+		if (toValue < fromValue) {
+			return SegmentKind.RELEASE;
+		}
+		return SegmentKind.HOLD;
+	}
+
+	private static float mapX(int position, Geometry geometry, float usableWidth) {
+		return geometry.xStart + (position / (float) TGEffectBend.MAX_POSITION_LENGTH) * usableWidth;
+	}
+
+	private static float mapY(int value, Geometry geometry) {
+		float span = geometry.yOpen - geometry.yFull;
+		if (span <= 0) {
+			return geometry.yOpen;
+		}
+		float t = value / (float) VALUE_FULL_TONE;
+		if (t < 0f) {
+			t = 0f;
+		}
+		if (t > 1f) {
+			t = 1f;
+		}
+		return geometry.yOpen - t * span;
+	}
+
+	private static int clamp(int value, int min, int max) {
+		if (value < min) {
+			return min;
+		}
+		if (value > max) {
+			return max;
+		}
+		return value;
+	}
+}

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
@@ -647,8 +647,13 @@ public class TGNoteImpl extends TGNote {
 	}
 
 	public float getEffectWidth(TGLayout layout) {
-		// Bend curves use the note duration width; they no longer add extra spacing.
-		return 0.0f;
+		if (!getEffect().isBend()) {
+			return 0.0f;
+		}
+		float minWidth = TGBendPath.minimumWidth(layout.getScale());
+		float durationWidth = layout.getDurationWidth(getVoiceImpl().getDuration());
+		float extra = minWidth - durationWidth;
+		return (extra > 0.0f ? extra : 0.0f);
 	}
 
 	private void paintBend(TGLayout layout,UIPainter painter,float fromX,float fromY, UIInset margin, TGEffectBend bend){
@@ -659,11 +664,11 @@ public class TGNoteImpl extends TGNote {
 		}
 
 		float scale = layout.getScale();
-		float width = ( getVoiceImpl().getWidth() - (2.0f * scale) );
+		float voiceWidth = getVoiceImpl().getWidth();
 
 		TGBendPath.Geometry geometry = new TGBendPath.Geometry();
 		geometry.xStart = fromX + getPosX() + margin.getRight() + 1.0f * scale;
-		geometry.xEnd = fromX + getPosX() + width - (8.0f * scale);
+		geometry.xEnd = fromX + getPosX() + voiceWidth - (2.0f * scale);
 		geometry.yLabel = fromY + ts.getPosition(TGTrackSpacing.POSITION_BEND);
 		geometry.yFull = geometry.yLabel + 8.0f * scale;
 		geometry.yOpen = fromY + getPaintPosition(TGTrackSpacing.POSITION_TABLATURE) + getTabPosY() - (2.0f * scale);
@@ -685,15 +690,7 @@ public class TGNoteImpl extends TGNote {
 				paintBendArrow(painter, segment.getFrom().getX(), segment.getFrom().getY(), scale, 1.0f);
 			}
 			painter.moveTo(segment.getFrom().getX(), segment.getFrom().getY());
-			if (segment.getKind() == TGBendPath.SegmentKind.HOLD || segment.getTo().getX() == segment.getFrom().getX()) {
-				painter.lineTo(segment.getTo().getX(), segment.getTo().getY());
-			} else {
-				float dx = segment.getTo().getX() - segment.getFrom().getX();
-				painter.cubicTo(
-					segment.getFrom().getX() + 0.4f * dx, segment.getFrom().getY(),
-					segment.getTo().getX() - 0.4f * dx, segment.getTo().getY(),
-					segment.getTo().getX(), segment.getTo().getY());
-			}
+			painter.lineTo(segment.getTo().getX(), segment.getTo().getY());
 			if (segment.isArrowAtEnd()) {
 				float direction = (segment.getKind() == TGBendPath.SegmentKind.RELEASE) ? -1.0f : 1.0f;
 				paintBendArrow(painter, segment.getTo().getX(), segment.getTo().getY(), scale, direction);

--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/graphics/control/TGNoteImpl.java
@@ -1,6 +1,7 @@
 package app.tuxguitar.graphics.control;
 
 import java.util.Iterator;
+import java.util.List;
 
 import app.tuxguitar.graphics.control.painters.TGKeySignaturePainter;
 import app.tuxguitar.graphics.control.painters.TGNotePainter;
@@ -605,28 +606,15 @@ public class TGNoteImpl extends TGNote {
 		return null;
 	}
 
-	// >=2 bent notes on same beat?
-	// conflict if there is another bend with different value, or with higher string
-	// this way, if all values are identical then one does not raise conflict and is drawn
+	// hide amplitude text when another bent note sits on a higher string
 	private boolean multipleBendConflicts() {
 		TGVoice voice = getVoice();
 		Iterator<TGNote> it = voice.getNotes().iterator();
 		while(it.hasNext()){
 			TGNoteImpl note = (TGNoteImpl)it.next();
-			if (note.getEffect().isBend() && ((note.getString() < getString())
-					|| (note.getEffect().getBend().getMovements().size() !=0 && getEffect().getBend().getMovements().size()!=0
-					    && note.getEffect().getBend().getMovements().get(0) != getEffect().getBend().getMovements().get(0)))) return true;
-		}
-		return false;
-	}
-	// another possible bend conflict: releasing while playing a note on a higher string / releasing from string 1
-	private boolean bendReleaseConflicts()  {
-		if (getString()==1) return true;
-		TGVoice voice = getVoice();
-		Iterator<TGNote> it = voice.getNotes().iterator();
-		while(it.hasNext()){
-			TGNoteImpl note = (TGNoteImpl)it.next();
-			if (note.getString() < getString()) return true;
+			if (note.getEffect().isBend() && note.getString() < getString()) {
+				return true;
+			}
 		}
 		return false;
 	}
@@ -659,138 +647,87 @@ public class TGNoteImpl extends TGNote {
 	}
 
 	public float getEffectWidth(TGLayout layout) {
-		if (getEffect().isBend()) return getBendWidth(layout, getEffect().getBend());
-		return(0.0f);
+		// Bend curves use the note duration width; they no longer add extra spacing.
+		return 0.0f;
 	}
 
-	private float getBendWidth(TGLayout layout, TGEffectBend bend) {
-		return paintBend(layout, null, 0.0f, 0.0f, new UIInset() , bend);
-	}
-
-	private float paintBend(TGLayout layout,UIPainter painter,float fromX,float fromY, UIInset margin, TGEffectBend bend){
+	private void paintBend(TGLayout layout,UIPainter painter,float fromX,float fromY, UIInset margin, TGEffectBend bend){
 		// fromX, fromY: top-left corner of drawing zone in current measure
-		float scale = layout.getScale();
-		float ARROW_WIDTH = 10.0f * scale;
-		String sAmplitude[] = { "", "1/4", "1/2", "3/4", "1", "1\u00BC", "1\u00BD", "1\u00BE", "2", "2\u00BC", "2\u00BD", "2\u00BE", "3" };
-		boolean compactMode = getMeasureImpl().getCompactMode();
-		boolean canPaint = (painter != null);
-
-		// x
-		float bendWidth = 0.0f;
-		float width = ( getVoiceImpl().getWidth() - (2.0f * scale) );
-		float xLeft   = fromX + getPosX() - margin.getLeft() - (4.0f * scale);	// start of hold
-		float xCenter = fromX + getPosX();
-		float xRight  = fromX + getPosX() + margin.getRight() + 1.0f * scale;	// start of bend
-		float xMax    = fromX + getPosX() + width - (8.0f * scale)	;	// end of hold
-		// y
 		TGSpacing ts = getMeasureImpl().getTs();
-		float yAmplitude = 0.0f;
-		float yLow = 0.0f;
-		float yMiddle = 0.0f;
-		float yHigh = 0.0f;
-		if (ts==null || painter==null) {
-			// this case can occur when function is called not to paint, but just to compute spacing
-			canPaint = false;
-		} else {
-			yAmplitude = fromY + ts.getPosition(TGTrackSpacing.POSITION_BEND);
-			yHigh = yAmplitude  + 8.0f * scale;	// high position of arrows (bend/release), or dashed line (hold)
-			yLow = fromY + getPaintPosition(TGTrackSpacing.POSITION_TABLATURE) + getTabPosY();	// start of arrow (bend)
-			yMiddle = yLow - 6.0f*scale;
+		if (ts == null || painter == null) {
+			return;
 		}
 
-		if (bend.getMovements().size() == 0) {
-			// draw hold
-			if (canPaint)  {
-				painter.initPath();
-				float xHold = xLeft;
-				float xStep = 2.5f*scale;
-				while (xHold < xMax)  {
-					painter.moveTo( xHold, yHigh);
-					painter.lineTo( xHold + xStep , yHigh);
-					painter.moveTo( xHold + 2*xStep, yHigh);
-					painter.lineTo( xHold + 3*xStep, yHigh);
-					xHold += 4*xStep;
-				}
-				painter.closePath();
-			}
-			return bendWidth;
+		float scale = layout.getScale();
+		float width = ( getVoiceImpl().getWidth() - (2.0f * scale) );
+
+		TGBendPath.Geometry geometry = new TGBendPath.Geometry();
+		geometry.xStart = fromX + getPosX() + margin.getRight() + 1.0f * scale;
+		geometry.xEnd = fromX + getPosX() + width - (8.0f * scale);
+		geometry.yLabel = fromY + ts.getPosition(TGTrackSpacing.POSITION_BEND);
+		geometry.yFull = geometry.yLabel + 8.0f * scale;
+		geometry.yOpen = fromY + getPaintPosition(TGTrackSpacing.POSITION_TABLATURE) + getTabPosY() - (2.0f * scale);
+		geometry.scale = scale;
+
+		List<TGBendPath.Segment> segments = TGBendPath.build(bend.getPoints(), geometry);
+		if (segments.isEmpty()) {
+			return;
 		}
-		// at least one movement (bend or release)
-		float x0 = xRight;
-		boolean isFirstMovement = true;
-		for (int movement : bend.getMovements()) {
-			float y0 = yLow;
-			float y1 = yHigh;
-			float bendDirection = 1.0f;
-			float x1 = 0.0f;
-			if (movement < 0) {
-				// release (warning, possible conflict with note played on higher string)
-				if (compactMode && !bendReleaseConflicts())  {
-					x0 = xCenter - (3.0f * scale);
-					y1 = yMiddle;
-				} else {
-					y1 = yLow;
-				}
-				y0 = yHigh;
-				bendDirection = -1.0f;
+
+		boolean hideLabels = multipleBendConflicts();
+		for (TGBendPath.Segment segment : segments) {
+			layout.setTabEffectStyle(painter);
+			painter.setLineWidth(layout.getLineWidth(1));
+			painter.initPath();
+			if (segment.isPreBend()) {
+				painter.moveTo(segment.getFrom().getX(), geometry.yOpen);
+				painter.lineTo(segment.getFrom().getX(), segment.getFrom().getY());
+				paintBendArrow(painter, segment.getFrom().getX(), segment.getFrom().getY(), scale, 1.0f);
 			}
-			// draw 1st part of arrow
-			if (canPaint)  {
-				layout.setTabEffectStyle(painter);
-				painter.setLineWidth(layout.getLineWidth(1));
-				painter.initPath();
-				// pre-bend arrow
-				if (!compactMode && isFirstMovement && movement<0)  {
-					painter.moveTo( x0, y0 );
-					painter.lineTo( x0, y1 );
-					painter.moveTo( x0, y0);
-					painter.lineTo( x0 - (2.0f * scale), y0 + 2.0f * scale);
-					painter.moveTo( x0, y0);
-					painter.lineTo( x0 + (2.0f * scale), y0 + 2.0f * scale);
-				}
-				painter.moveTo( x0, y0 );
-				painter.lineTo( x0 + (1.0f * scale), y0 );
-			}
-			// 2nd part of arrow: different width whether compactMode or not -> update bendSpacing
-			if (compactMode) {
-				x1 = x0 + (3.0f * scale);
-				if (canPaint)  {
-					painter.cubicTo(x0 + (1.0f * scale), y0,
-									x0 + (3.0f * scale), y0,
-									x0 + (3.0f * scale), y0 - 2.0f * bendDirection * scale);
-					painter.moveTo( x0 + (3.0f * scale), y0 - 2.0f * bendDirection * scale);
-					painter.lineTo( x0 + (3.0f * scale), y1);
-				}
+			painter.moveTo(segment.getFrom().getX(), segment.getFrom().getY());
+			if (segment.getKind() == TGBendPath.SegmentKind.HOLD || segment.getTo().getX() == segment.getFrom().getX()) {
+				painter.lineTo(segment.getTo().getX(), segment.getTo().getY());
 			} else {
-				x1 = x0 + ARROW_WIDTH;
-				bendWidth += ARROW_WIDTH;
-				if (canPaint)  {
-					painter.cubicTo(x0 + (1.0f * scale), y0,     x1, y0,    x1 , y1);
+				float dx = segment.getTo().getX() - segment.getFrom().getX();
+				painter.cubicTo(
+					segment.getFrom().getX() + 0.4f * dx, segment.getFrom().getY(),
+					segment.getTo().getX() - 0.4f * dx, segment.getTo().getY(),
+					segment.getTo().getX(), segment.getTo().getY());
+			}
+			if (segment.isArrowAtEnd()) {
+				float direction = (segment.getKind() == TGBendPath.SegmentKind.RELEASE) ? -1.0f : 1.0f;
+				paintBendArrow(painter, segment.getTo().getX(), segment.getTo().getY(), scale, direction);
+			}
+			painter.closePath();
+			if (!hideLabels) {
+				if (segment.isPreBend()) {
+					paintBendAmplitude(layout, painter, segment.getFrom().getValue(), segment.getFrom().getX(), geometry);
+				}
+				if (segment.isLabelAtEnd()) {
+					paintBendAmplitude(layout, painter, segment.getTo().getValue(), segment.getTo().getX(), geometry);
 				}
 			}
-			// 3rd part of arrow (head) + amplitude
-			if (canPaint)  {
-				painter.moveTo( x1, y1);
-				painter.lineTo( x1 - (2.0f * scale), y1 + 2.0f * bendDirection * scale);
-				painter.moveTo( x1, y1);
-				painter.lineTo( x1 + (2.0f * scale), y1 + 2.0f * bendDirection * scale);
-				painter.closePath();
-				// amplitude
-				if (!multipleBendConflicts() && (movement>0 || isFirstMovement))  {
-					String amplitude = "";
-					float xAmplitude = (movement > 0 ? x1 : x0);
-					if (movement<0) movement = -movement;
-					if (movement % 4 != 0) xAmplitude -= 4.0f * scale;	// left shift except for short strings (n*full)
-					if (movement < sAmplitude.length) amplitude = sAmplitude[movement];
-					layout.setOfflineEffectStyle(painter);
-					painter.drawString(amplitude, xAmplitude, yAmplitude + painter.getFMTopLine());
-				}
-			}
-			if (compactMode) break;
-			isFirstMovement = false;
-			x0 = x1;
 		}
-		return(bendWidth);
+	}
+
+	private void paintBendArrow(UIPainter painter, float x, float y, float scale, float direction) {
+		painter.moveTo(x, y);
+		painter.lineTo(x - (2.0f * scale), y + 2.0f * scale * direction);
+		painter.moveTo(x, y);
+		painter.lineTo(x + (2.0f * scale), y + 2.0f * scale * direction);
+	}
+
+	private void paintBendAmplitude(TGLayout layout, UIPainter painter, int value, float xAnchor, TGBendPath.Geometry geometry) {
+		String amplitude = TGBendPath.amplitudeLabel(value);
+		if (amplitude.isEmpty()) {
+			return;
+		}
+		float xAmplitude = xAnchor;
+		if (value % 4 != 0) {
+			xAmplitude -= 4.0f * geometry.scale;
+		}
+		layout.setOfflineEffectStyle(painter);
+		painter.drawString(amplitude, xAmplitude, geometry.yLabel + painter.getFMTopLine());
 	}
 
 	private void paintTremoloBar(TGLayout layout,UIPainter painter,float fromX,float fromY){

--- a/common/TuxGuitar-lib/src/test/java/app/tuxguitar/graphics/control/TestTGBendPath.java
+++ b/common/TuxGuitar-lib/src/test/java/app/tuxguitar/graphics/control/TestTGBendPath.java
@@ -1,0 +1,100 @@
+package app.tuxguitar.graphics.control;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import app.tuxguitar.graphics.control.TGBendPath.Segment;
+import app.tuxguitar.graphics.control.TGBendPath.SegmentKind;
+import app.tuxguitar.song.factory.TGFactory;
+import app.tuxguitar.song.models.effects.TGEffectBend;
+
+public class TestTGBendPath {
+
+	private static final float EPS = 0.01f;
+
+	private final TGFactory factory = new TGFactory();
+
+	private TGBendPath.Geometry geometry() {
+		TGBendPath.Geometry geometry = new TGBendPath.Geometry();
+		geometry.xStart = 100f;
+		geometry.xEnd = 220f;
+		geometry.yOpen = 80f;
+		geometry.yFull = 20f;
+		geometry.yLabel = 12f;
+		geometry.scale = 1f;
+		return geometry;
+	}
+
+	private TGEffectBend bend(int... positionValuePairs) {
+		TGEffectBend bend = this.factory.newEffectBend();
+		for (int i = 0; i < positionValuePairs.length; i += 2) {
+			bend.addPoint(positionValuePairs[i], positionValuePairs[i + 1]);
+		}
+		return bend;
+	}
+
+	@Test
+	public void testPresetBendRisesThenHolds() {
+		List<Segment> segments = TGBendPath.build(bend(0, 0, 6, 4, 12, 4).getPoints(), geometry());
+
+		assertEquals(2, segments.size());
+		assertEquals(SegmentKind.BEND_UP, segments.get(0).getKind());
+		assertEquals(SegmentKind.HOLD, segments.get(1).getKind());
+		assertFalse(segments.get(0).isPreBend());
+		assertEquals(160f, segments.get(0).getTo().getX(), EPS);
+		assertEquals(20f, segments.get(1).getFrom().getY(), EPS);
+		assertEquals(20f, segments.get(1).getTo().getY(), EPS);
+		assertTrue(segments.get(0).isArrowAtEnd());
+		assertTrue(segments.get(0).isLabelAtEnd());
+	}
+
+	@Test
+	public void testDelayedBendHoldsThenRises() {
+		List<Segment> segments = TGBendPath.build(bend(0, 0, 9, 0, 12, 4).getPoints(), geometry());
+
+		assertEquals(2, segments.size());
+		assertEquals(SegmentKind.HOLD, segments.get(0).getKind());
+		assertEquals(190f, segments.get(0).getTo().getX(), EPS);
+		assertEquals(SegmentKind.BEND_UP, segments.get(1).getKind());
+		assertTrue(segments.get(1).isArrowAtEnd());
+		assertTrue(segments.get(1).isLabelAtEnd());
+	}
+
+	@Test
+	public void testPreBendHold() {
+		List<Segment> segments = TGBendPath.build(bend(0, 4, 12, 4).getPoints(), geometry());
+
+		assertEquals(1, segments.size());
+		assertEquals(SegmentKind.HOLD, segments.get(0).getKind());
+		assertTrue(segments.get(0).isPreBend());
+		assertEquals(20f, segments.get(0).getFrom().getY(), EPS);
+		assertEquals(20f, segments.get(0).getTo().getY(), EPS);
+		assertFalse(segments.get(0).isLabelAtEnd());
+	}
+
+	@Test
+	public void testSinglePointSpansFullDuration() {
+		List<Segment> segments = TGBendPath.build(bend(6, 4).getPoints(), geometry());
+
+		assertEquals(2, segments.size());
+		assertTrue(segments.get(0).isPreBend());
+		assertEquals(SegmentKind.HOLD, segments.get(0).getKind());
+		assertEquals(SegmentKind.HOLD, segments.get(1).getKind());
+		assertEquals(100f, segments.get(0).getFrom().getX(), EPS);
+		assertEquals(220f, segments.get(1).getTo().getX(), EPS);
+	}
+
+	@Test
+	public void testAmplitudeLabels() {
+		assertEquals("1", TGBendPath.amplitudeLabel(4));
+		assertEquals("1/2", TGBendPath.amplitudeLabel(2));
+		assertEquals("1/4", TGBendPath.amplitudeLabel(1));
+		assertEquals("", TGBendPath.amplitudeLabel(0));
+		assertEquals("", TGBendPath.amplitudeLabel(13));
+	}
+}

--- a/common/TuxGuitar-lib/src/test/java/app/tuxguitar/graphics/control/TestTGBendPath.java
+++ b/common/TuxGuitar-lib/src/test/java/app/tuxguitar/graphics/control/TestTGBendPath.java
@@ -47,8 +47,8 @@ public class TestTGBendPath {
 		assertEquals(SegmentKind.HOLD, segments.get(1).getKind());
 		assertFalse(segments.get(0).isPreBend());
 		assertEquals(160f, segments.get(0).getTo().getX(), EPS);
-		assertEquals(20f, segments.get(1).getFrom().getY(), EPS);
-		assertEquals(20f, segments.get(1).getTo().getY(), EPS);
+		assertEquals(60f, segments.get(1).getFrom().getY(), EPS);
+		assertEquals(60f, segments.get(1).getTo().getY(), EPS);
 		assertTrue(segments.get(0).isArrowAtEnd());
 		assertTrue(segments.get(0).isLabelAtEnd());
 	}
@@ -72,8 +72,8 @@ public class TestTGBendPath {
 		assertEquals(1, segments.size());
 		assertEquals(SegmentKind.HOLD, segments.get(0).getKind());
 		assertTrue(segments.get(0).isPreBend());
-		assertEquals(20f, segments.get(0).getFrom().getY(), EPS);
-		assertEquals(20f, segments.get(0).getTo().getY(), EPS);
+		assertEquals(60f, segments.get(0).getFrom().getY(), EPS);
+		assertEquals(60f, segments.get(0).getTo().getY(), EPS);
 		assertFalse(segments.get(0).isLabelAtEnd());
 	}
 
@@ -87,6 +87,23 @@ public class TestTGBendPath {
 		assertEquals(SegmentKind.HOLD, segments.get(1).getKind());
 		assertEquals(100f, segments.get(0).getFrom().getX(), EPS);
 		assertEquals(220f, segments.get(1).getTo().getX(), EPS);
+	}
+
+	@Test
+	public void testCoordinatesFollowDialogGrid() {
+		List<Segment> segments = TGBendPath.build(bend(0, 0, 3, 6, 12, 6).getPoints(), geometry());
+
+		assertEquals(2, segments.size());
+		assertEquals(130f, segments.get(0).getTo().getX(), EPS);
+		assertEquals(50f, segments.get(0).getTo().getY(), EPS);
+		assertEquals(220f, segments.get(1).getTo().getX(), EPS);
+		assertEquals(50f, segments.get(1).getTo().getY(), EPS);
+	}
+
+	@Test
+	public void testMinimumWidthCoversDialogPositions() {
+		assertEquals(12 * 8.0f, TGBendPath.minimumWidth(1f), EPS);
+		assertEquals(12 * 16.0f, TGBendPath.minimumWidth(2f), EPS);
 	}
 
 	@Test


### PR DESCRIPTION
# Progressive bend display

Bend curves on tablature follow the bend editor grid in both **pitch** and **timing** (discussion [#1182](https://github.com/helge17/tuxguitar/discussions/1182)).

Commits: `add progressive bend`, `follow timming`.

## Scope

| File | Action |
|---|---|
| `common/TuxGuitar-lib/.../graphics/control/TGBendPath.java` | **New** — pure geometry, no painter |
| `common/TuxGuitar-lib/.../graphics/control/TGNoteImpl.java` | Rewrite of `paintBend`; extra width padded to a readable timeline |
| `common/TuxGuitar-lib/src/test/.../graphics/control/TestTGBendPath.java` | **New** — mapping unit tests |

**Unchanged:** `TGEffectBend`, bend dialog, MIDI, GP/PTB imports, ASCII, MusicXML, `TGMeasureImpl` / `TGVoiceImpl` (they already call `getEffectWidth()`).

A single drawing path: no compact / non-compact branch.

---

## 1. `TGBendPath` — the core

A calculation class. Input: bend points + screen rectangle. Output: segments to draw.

The polyline is a scaled copy of the editor grid:

- X axis of the dialog = time (`position` 0..12)
- Y axis of the dialog = pitch (`value` 0..12 quarter-tones)

```java
public final class TGBendPath {
    public static final int VALUE_FULL_TONE = 4;           // label table: 4 → "1"
    public static final float WIDTH_PER_POSITION = 8.0f;   // px per time unit, × scale

    public static final class Geometry {
        float xStart;  // to the right of the fret number
        float xEnd;    // end of the allocated voice width
        float yOpen;   // just above the string (value = 0)
        float yFull;   // ceiling (POSITION_BEND zone, value = 12)
        float yLabel;  // line for 1/4, 1, … text
        float scale;
    }

    public enum SegmentKind { HOLD, BEND_UP, RELEASE }

    public static List<Segment> build(List<BendPoint> points, Geometry g);
    public static float minimumWidth(float scale);  // 12 × 8 × scale
    public static String amplitudeLabel(int value);
}
```

`build` rules:

1. Sort by `position`. Ignore fewer than 1 point.
2. If the first point is not at `0`: virtual point `(0, first.value)` — the line starts at the note.
3. If the last point is not at `12`: virtual point `(12, last.value)` — the line covers the whole duration.
4. Mapping (same proportions as the dialog):
   - `x = xStart + (position / 12) * usableWidth`
   - `y = yOpen - (value / 12) * (yOpen - yFull)`, clamped to `[yFull, yOpen]`
5. `usableWidth = max(xEnd - xStart, minimumWidth(scale))`.
6. Segment `i → i+1`: `HOLD` if same value, otherwise `BEND_UP` / `RELEASE`.
7. **Pre-bend**: first value `> 0` → `preBend` on the first segment (vertical stroke `yOpen → y(value)`).
8. Arrow at the end of a rise/fall if the next segment is a hold, a reverse, or the end.
9. Label: pre-bend, and each **local maximum** (not every point).

Drawing uses **straight `lineTo`** between vertices, like the editor. Bézier easing was dropped: it kept pitch flat then jumped at the end of each segment, so a late bend in the dialog looked like an immediate bend on the tab.

A whole tone (`value = 4`) is **one third** of the vertical range, not the full height. A 3-tone bend reaches `yFull`.

---

## 2. `TGNoteImpl` — what changed

**`paintBend`** no longer reads `getMovements()` or `compactMode`. It:

1. builds `Geometry`: `xStart` just after the fret number, `xEnd` at the end of the voice (`posX + voiceWidth - 2×scale`);
2. calls `TGBendPath.build(...)`;
3. draws: vertical pre-bend, **`lineTo` for every segment**, 2×scale arrowhead, text via `amplitudeLabel`.

Signature: `void`.

**Extra width** — pad short notes so the 12 time units stay readable:

```java
public float getEffectWidth(TGLayout layout) {
    if (!getEffect().isBend()) {
        return 0.0f;
    }
    float minWidth = TGBendPath.minimumWidth(layout.getScale());
    float durationWidth = layout.getDurationWidth(getVoiceImpl().getDuration());
    float extra = minWidth - durationWidth;
    return (extra > 0.0f ? extra : 0.0f);
}
```

`minimumWidth` = `12 × 8 × scale` (~96 px at scale 1). Notes whose duration width is already larger get no extra.

`getBendWidth` and the `paintBend(painter=null)` trick are gone.

**Conflicts**

- `multipleBendConflicts`: hides **text only** if another bend sits on a higher string. The curve is always drawn (Y differs per string).
- `bendReleaseConflicts`: unused, **removed**.

---

## 3. Layout

`getEffectWidth()` used to return `n × 10×scale` per movement (non-compact arrows), then briefly `0` (envelope squeezed into a few pixels).

Now it only **pads up to the 12-step minimum**. Consequences:

- short notes / compact (Android, PDF, SVG): the beat grows so timing can be read;
- long notes: no extra if duration width already ≥ the minimum;
- multi-track: `maxEffectWidth` still aligns measures, but only when a track actually needs the padding.

X mapping uses the **full voice width**, not `voiceWidth - 8×scale`.

---

## 4. Expected visuals

| Data | Drawing |
|---|---|
| Preset bend `(0,0)(6,4)(12,4)` | Straight rise over the first half (to 1/3 of height), plateau, `1` at the peak |
| **#1182** delayed rise `(0,0)(9,0)(12,4)` | Flat 75% of the note, then a straight slope — same as the editor |
| Point at 25% time, value 6 `(0,0)(3,6)(12,6)` | Vertex at 25% of width and 50% of height |
| Pre-bend hold `(0,4)(12,4)` | Vertical + plateau at 1/3 height + `1` (**#640**) |
| Bend-release-bend | Polyline at the real X/Y of each editor point |
| Compact = non-compact | Same glyph; short notes are padded to the minimum width |

---

## 5. Tests (`TestTGBendPath`)

Fixed geometry `xStart=100, xEnd=220, yOpen=80, yFull=20` (span 60):

- preset bend: 2 segments, boundary at `x=160`, hold at `y=60` (4/12 of the span)
- delayed rise: hold until `x=190`, then `BEND_UP`
- pre-bend hold: 1 `HOLD` at `y=60`, `preBend=true`
- single point `[6,4]`: virtual 0 and 12, line across the full width
- dialog grid: `(3,6)` → `x=130`, `y=50`
- `minimumWidth(1)==96`, `minimumWidth(2)==192`
- `amplitudeLabel(4)=="1"`, `(2)=="1/2"`, `(1)=="1/4"`

No painter test (no headless `UIPainter` in lib).

---

## 6. Out of this change

- standard notation staff
- tremolo bar
- curve across tied notes
- increasing vertical `bendSpacing`
- removing the `effectWidth` machinery in `TGMeasureImpl`

---

## Decisions

1. **Straight lines** — copy the editor polyline; no Bézier that distorts timing.
2. **`y` uses `value / 12`** — same vertical proportions as the dialog (1 whole tone = 1/3 of the range).
3. **Pad short notes** to `12 × 8 × scale` so the time axis is readable; do not pad notes that are already wider.
4. **Virtual points at 0 and 12** — the line always covers the note, even if the editor only has a point in the middle.
5. **Hold as a solid stroke** (no dashes) — GP dashes are mainly for ties, out of v1.
