### PR TITLE
fix bug in free edition mode

### DIFF
--- a/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGMeasureManager.java
+++ b/common/TuxGuitar-lib/src/main/java/app/tuxguitar/song/managers/TGMeasureManager.java
@@ -2069,7 +2069,8 @@ public class TGMeasureManager {
 		}
 
 		// Si el primer o ultimo componente, quedan fuera del compas, entonces el movimiento no es satisfactorio
-		if(first != null && last != null && lastDuration != null){
+		boolean isFreeEditionMode = getSongManager().isFreeEditionMode(measure);
+		if(!isFreeEditionMode && first != null && last != null && lastDuration != null){
 			if((first.getBeat().getPreciseStart() + thePreciseMove) < measurePreciseStart || (last.getBeat().getPreciseStart() + lastDuration.getPreciseTime() + thePreciseMove) > measurePreciseEnd){
 				success = false;
 			}


### PR DESCRIPTION
when deleting a rest, if free edition mode is active then moving all following beats shall be performed even if it leads to something invalid
fix #1188 